### PR TITLE
fix：session_memory_size应该是以M为单位的整数显示，而不是字符串

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -13752,7 +13752,10 @@ show_total_memorysize(void)
     int32   size;
     static char buf[64];
     size = get_total_memory_size();
-	snprintf(buf, sizeof(buf), "%dM", size);
+	/*
+     * session_memory_size再pg_setting中的值是int类型，单位为M，所以不要有单位显示，防止报错
+     */
+    snprintf(buf, sizeof(buf), "%d", size);
     return buf;
 }
 


### PR DESCRIPTION
session_memory_size再pg_setting中的值是int类型，单位为M，所以不要有单位显示，防止报错
这里只是显示的有问题，导致安装postgres_exporter报错。修复格式化即可
panic: Error converting setting "session_memory_size" value "3M" to float: strconv.ParseFloat: parsing "3M": invalid syntax