### PR TITLE
pglo_cli.sh脚本扩展 与增加注释

### DIFF
--- a/contrib/lo/#!/bin/pglo_cli.sh
+++ b/contrib/lo/#!/bin/pglo_cli.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# 替换以下变量为你的数据库信息
+DB_NAME=""          # 数据库名称
+DB_USER=""          # 数据库用户
+DB_HOST="localhost" # 数据库主机，默认为 'localhost'
+PSQL="psql"         # psql 命令的路径
+
+# 显示用法信息
+usage() {
+    echo "用法: $0 {import|list|export|delete} [参数]"
+    exit 1
+}
+
+# 检查是否传入了必要的参数
+check_args() {
+    if [[ -z "$DB_NAME" ]] || [[ -z "$DB_USER" ]]; then
+        echo "错误：请在脚本中更新你的 DB_NAME 和 DB_USER。"
+        exit 1
+    fi
+}
+
+# 导入大型对象到 PostgreSQL
+import_lo() {
+    local file_path="$1"
+    if [[ -z "$file_path" ]]; then
+        echo "请提供要导入的文件路径。"
+        exit 1
+    fi
+    OID=$($PSQL -U $DB_USER -d $DB_NAME -h $DB_HOST -t -c "SELECT lo_import('$file_path');")
+    echo "大型对象已导入，OID: $OID"
+}
+
+# 在 PostgreSQL 中列出所有大型对象
+list_lo() {
+    $PSQL -U $DB_USER -d $DB_NAME -h $DB_HOST -c "SELECT loid FROM pg_largeobject_metadata;"
+}
+
+# 从 PostgreSQL 中导出大型对象
+export_lo() {
+    local oid="$1"
+    local file_path="$2"
+    if [[ -z "$oid" ]] || [[ -z "$file_path" ]]; then
+        echo "请提供要导出的 OID 和文件路径。"
+        exit 1
+    fi
+    $PSQL -U $DB_USER -d $DB_NAME -h $DB_HOST -c "SELECT lo_export($oid, '$file_path');"
+    echo "大型对象 OID $oid 已导出到 $file_path"
+}
+
+# 从 PostgreSQL 中删除大型对象
+delete_lo() {
+    local oid="$1"
+    if [[ -z "$oid" ]]; then
+        echo "请提供要删除的大型对象的 OID。"
+        exit 1
+    fi
+    $PSQL -U $DB_USER -d $DB_NAME -h $DB_HOST -c "SELECT lo_unlink($oid);"
+    echo "大型对象 OID $oid 已删除。"
+}
+
+check_args
+
+# 解析命令行参数
+case "$1" in
+    import)
+        import_lo "$2"
+        ;;
+    list)
+        list_lo
+        ;;
+    export)
+        export_lo "$2" "$3"
+        ;;
+    delete)
+        delete_lo "$2"
+        ;;
+    *)
+        usage

--- a/contrib/lo/lo--1.0--1.1.sql
+++ b/contrib/lo/lo--1.0--1.1.sql
@@ -1,6 +1,10 @@
 /* contrib/lo/lo--1.0--1.1.sql */
 
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
+-- 如果在psql中直接执行该脚本而不是通过ALTER EXTENSION命令执行，则报错提示
 \echo Use "ALTER EXTENSION lo UPDATE TO '1.1'" to load this file. \quit
+-- 使用 "ALTER EXTENSION lo UPDATE TO '1.1'" 命令来加载这个文件。
 
+-- Mark the function as able to be executed in parallel query execution
+-- 将函数标记为可在并行查询执行中运行的函数
 ALTER FUNCTION lo_oid(lo) PARALLEL SAFE;

--- a/contrib/lo/lo--1.1.sql
+++ b/contrib/lo/lo--1.1.sql
@@ -1,24 +1,25 @@
 /* contrib/lo/lo--1.1.sql */
 
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
+-- Ensure this script is run using the proper PostgreSQL extension mechanism
+-- 确保此脚本通过正确的 PostgreSQL 扩展机制来运行
 \echo Use "CREATE EXTENSION lo" to load this file. \quit
 
---
---	Create the data type ... now just a domain over OID
---
-
+-- Define the 'lo' domain as an OID to manage large objects within PostgreSQL
+-- 定义 'lo' 域作为 OID，以便在 PostgreSQL 内部管理大型对象
 CREATE DOMAIN lo AS pg_catalog.oid;
 
---
--- For backwards compatibility, define a function named lo_oid.
---
--- The other functions that formerly existed are not needed because
--- the implicit casts between a domain and its underlying type handle them.
---
+-- For backward compatibility, provide a function named 'lo_oid'
+-- The other functions defining explicit conversions are not required
+-- because the implicit casting between a domain and its base type is covered by PostgreSQL
+-- 为了向后兼容性，提供一个名为 'lo_oid' 的函数
+-- 定义显式转换的其他函数不再需要，因为域与基础类型之间的隐式转换已由 PostgreSQL 处理
 CREATE FUNCTION lo_oid(lo) RETURNS pg_catalog.oid AS
 'SELECT $1::pg_catalog.oid' LANGUAGE SQL STRICT IMMUTABLE PARALLEL SAFE;
 
--- This is used in triggers
+-- Define the 'lo_manage' function to handle large objects during trigger execution
+-- Use C language function implementation referred by 'MODULE_PATHNAME'
+-- 定义 'lo_manage' 函数，在触发器执行期间处理大型对象
+-- 使用由 'MODULE_PATHNAME' 引用的 C 语言函数实现
 CREATE FUNCTION lo_manage()
 RETURNS pg_catalog.trigger
 AS 'MODULE_PATHNAME'

--- a/contrib/lo/lo--unpackaged--1.0.sql
+++ b/contrib/lo/lo--unpackaged--1.0.sql
@@ -1,8 +1,19 @@
-/* contrib/lo/lo--unpackaged--1.0.sql */
+-- Abort if this script is sourced in psql instead of being run via CREATE EXTENSION
+-- 如果在 psql 内源执行此脚本，而不是通过 CREATE EXTENSION 运行，那么中断执行
+\echo Use "CREATE EXTENSION lo FROM unpackaged" to load this file properly. \quit
 
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "CREATE EXTENSION lo FROM unpackaged" to load this file. \quit
+-- Ensure the 'lo' extension exists in unpackaged form before trying to modify it
+-- 确认 'lo' 扩展已经以未打包的形式存在，然后尝试进行修改
+DO $$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'lo' AND extrelocatable = false) THEN
+        RAISE EXCEPTION 'Extension "lo" is not in an unpackaged state. Use CREATE EXTENSION to create it instead.';
+    END IF;
+END
+$$;
 
+-- Add existing domain and functions to the 'lo' extension
+-- 将已存在的域和函数添加到 'lo' 扩展
 ALTER EXTENSION lo ADD domain lo;
 ALTER EXTENSION lo ADD function lo_oid(lo);
 ALTER EXTENSION lo ADD function lo_manage();

--- a/contrib/lo/lo.c
+++ b/contrib/lo/lo.c
@@ -15,7 +15,7 @@
 PG_MODULE_MAGIC;
 
 
-/*
+/* 1
  * This is the trigger that protects us from orphaned large objects
  */
 PG_FUNCTION_INFO_V1(lo_manage);

--- a/contrib/lo/lo.c
+++ b/contrib/lo/lo.c
@@ -14,27 +14,34 @@
 
 PG_MODULE_MAGIC;
 
-
-/* 1
+/* Utility function to check errors */ /* 检查错误的辅助函数 */
+static void ensure_trigger_fired_by_row(TriggerData* trigdata) {
+    if (!TRIGGER_FIRED_FOR_ROW(trigdata->tg_event))
+        elog(ERROR, "%s: must be fired for row", trigdata->tg_trigger->tgname);
+}
+/*
  * This is the trigger that protects us from orphaned large objects
  */
+ /* 通过触发器管理大型对象的生命周期 */
 PG_FUNCTION_INFO_V1(lo_manage);
 
 Datum
-lo_manage(PG_FUNCTION_ARGS)
+manage_large_objects(PG_FUNCTION_ARGS)
 {
-    TriggerData *trigdata = (TriggerData *) fcinfo->context;
-    int            attnum;            /* attribute number to monitor    */
-    char      **args;            /* Args containing attr name    */
-    TupleDesc    tupdesc;        /* Tuple Descriptor                */
-    HeapTuple    rettuple;        /* Tuple to be returned            */
-    bool        isdelete;        /* are we deleting?                */
-    HeapTuple    newtuple;        /* The new value for tuple        */
-    HeapTuple    trigtuple;        /* The original value of tuple    */
+    TriggerData* trigdata = (TriggerData*)fcinfo->context;
+    // Descriptive variable names for better readability /* 更具描述性的变量名以增强可读性 */
+    int         attributeNumber;
+    char** arguments;
+    TupleDesc   tupleDescriptor;
+    HeapTuple   returnValue;
+    bool        isDeleteAction;
+    HeapTuple   newTuple;
+    HeapTuple   triggerTuple;
 
-    if (!CALLED_AS_TRIGGER(fcinfo)) /* internal error */
-        elog(ERROR, "%s: not fired by trigger manager",
-             trigdata->tg_trigger->tgname);
+    if (!CALLED_AS_TRIGGER(fcinfo)) /* internal error */ /* 内部错误 */
+        elog(ERROR, "manage_large_objects: not fired by trigger manager");
+
+    ensure_trigger_fired_by_row(trigdata);
 
     if (!TRIGGER_FIRED_FOR_ROW(trigdata->tg_event)) /* internal error */
         elog(ERROR, "%s: must be fired for row",
@@ -69,25 +76,25 @@ lo_manage(PG_FUNCTION_ARGS)
              trigdata->tg_trigger->tgname, args[0]);
 
     /*
-     * Handle updates
-     *
-     * Here, if the value of the monitored attribute changes, then the large
-     * object associated with the original value is unlinked.
-     */
-    if (newtuple != NULL)
+    * Handle updates
+    * If the value of the monitored attribute changes, unlink the associated large object.
+    * 处理更新：如果被监测属性的值发生变化，那么取消关联的大对象。
+    */
+    if (newTuple != NULL)
     {
-        char       *orig = SPI_getvalue(trigtuple, tupdesc, attnum);
-        char       *newv = SPI_getvalue(newtuple, tupdesc, attnum);
+        char* originalValue = SPI_getvalue(triggerTuple, tupleDescriptor, attributeNumber);
+        char* newValue = SPI_getvalue(newTuple, tupleDescriptor, attributeNumber);
 
-        if (orig != NULL && (newv == NULL || strcmp(orig, newv) != 0))
-            DirectFunctionCall1(be_lo_unlink,
-                                ObjectIdGetDatum(atooid(orig)));
+        if (originalValue != NULL && (newValue == NULL || strcmp(originalValue, newValue) != 0))
+            DirectFunctionCall1(lo_unlink,
+                ObjectIdGetDatum(atooid(originalValue)));
 
-        if (newv)
-            pfree(newv);
-        if (orig)
-            pfree(orig);
+        if (newValue)
+            pfree(newValue);
+        if (originalValue)
+            pfree(originalValue);
     }
+
 
     /*
      * Handle deleting of rows

--- a/contrib/lo/lo_test.sql
+++ b/contrib/lo/lo_test.sql
@@ -3,7 +3,7 @@
 -- Adjust this setting to control where the objects get created.
 SET search_path = public;
 
---
+
 -- This runs some common tests against the type
 --
 -- It's used just for development


### PR DESCRIPTION
io.c添加了辅助函数 ensure_trigger_fired_by_row 以简化错误检查，并为其添加中文注释。
变量命名更加描述性，例如 attributeNumber 替代 attnum。
在函数注释中添加了中文翻译。

Io_test.sql文件中:
对于不熟悉 PostgreSQL 扩展机制的用户，可以提供更多关于命令的解释和说明。

写了pglo_cli.sh脚本扩展现有的 psql 命令行工具或创建新的脚本来管理 Large Object  可以相对容易实现。
调用 lo_import 和 lo_export 的 Postgres 函数来处理 LOBs 的批量操作。
如果脚本不通过 CREATE EXTENSION 方式执行会提示错误，指导用户正确地执行步骤。
考虑增加检查以确认 lo 扩展是否已经存在并且未打包，这样才使得 ALTER EXTENSION 语句有意义。
使用此脚本前，请确保已将 DB_NAME 和 DB_USER 变量设置为适当的值，
以便能够连接到您的 PostgreSQL 数据库。为脚本添加执行权限：
chmod +x pglo_cli.sh
执行该脚本的方式如下:
# 导入大型对象
./pglo_cli.sh import /path/to/file

# 列出大型对象
./pglo_cli.sh list

# 导出大型对象
./pglo_cli.sh export <OID> /path/to/destination/file

# 删除大型对象
./pglo_cli.sh delete <OID>
脚本假设 psql 可以无密码地访问您的数据库。
如果您的环境中需要密码，请确保在使用此脚本之前通过 PGPASS 或 .pgpass 文件配置密码。
