### PR TITLE
慢SQL排查

### DIFF
--- a/contrib/pg_stat_timing/README.md
+++ b/contrib/pg_stat_timing/README.md
@@ -1,0 +1,60 @@
+#### 编译插件
+
+使用 gcc 编译器的编译工具链编译插件代码
+
+```
+gcc -Wall -Werror -shared -o pg_stat_timing.so pg_stat_timing.c -I/path/to/opentenbase/include -L/path/to/opentenbase/lib -lopenbase
+```
+
+
+
+#### 配置插件
+
+编辑 OpenTenBase 的配置文件，确保 `shared_preload_libraries` 配置项包含插件的名称。
+
+```
+shared_preload_libraries = 'pg_stat_timing'
+```
+
+
+
+#### 重启 OpenTenBase
+
+重新启动 OpenTenBase 以使插件加载。
+
+
+
+#### **加载插件**
+
+需要在 OpenTenBase 数据库中加载该插件。使用以下 SQL 命令在数据库中加载插件：
+
+```
+CREATE EXTENSION pg_stat_timing;
+```
+
+
+
+#### **设置预期时间**
+
+使用提供的自定义函数 `set_expected_time()` 来设置预期的查询执行时间。在 SQL 控制台中执行以下命令：
+
+```
+SELECT set_expected_time(100000); -- 设置预期时间为100毫秒
+```
+
+
+
+#### 执行查询
+
+当用户执行查询时，插件会跟踪查询的执行时间，并根据预期时间进行检查。如果查询执行时间超出了预期时间，将会生成相应的日志信息。例如：
+
+```
+LOG:  Query (ID: 123) exceeded expected time: 100000 microseconds (actual: 150000 microseconds)
+```
+
+
+
+#### **定位慢SQL**
+
+ 查询的执行时间信息将记录在日志中。可以查看日志以获取有关查询执行时间的详细信息。
+

--- a/contrib/pg_stat_timing/pg_stat_timing.c
+++ b/contrib/pg_stat_timing/pg_stat_timing.c
@@ -1,0 +1,140 @@
+#include "tenbase/pg.h"
+#include "tenbase/fmgr.h"
+#include "tenbase/executor.h"
+#include "tenbase/utils/timestamp.h"
+#include "tenbase/utils/guc.h"
+#include "tenbase/catalog/pg_type.h"
+#include "tenbase/pgstat.h"
+
+PG_MODULE_MAGIC;
+
+void _PG_init(void);
+void _PG_fini(void);
+static ExecutorStart_hook_type prev_ExecutorStart_hook = NULL;
+static ExecutorEnd_hook_type prev_ExecutorEnd_hook = NULL;
+
+typedef struct {
+    TimestampTz start_time;
+    TimestampTz end_time;
+    int expected_time; // 预期时间（微秒）
+    bool exceeded;     // 是否超出预期时间
+} QueryTiming;
+
+HTAB *query_timings = NULL;
+
+// 初始化哈希表
+static void init_query_timings(void) {
+    HASHCTL ctl;
+    MemSet(&ctl, 0, sizeof(ctl));
+    ctl.keysize = sizeof(uint32);
+    ctl.entrysize = sizeof(QueryTiming);
+    query_timings = hash_create("QueryTimings", 256, &ctl, HASH_ELEM | HASH_BLOBS);
+}
+
+// ExecutorStart钩子函数
+static void pg_stat_statements_ExecutorStart(QueryDesc *queryDesc, int eflags) {
+    uint32 query_id = queryDesc->plannedstmt->queryId;
+
+    // 创建查询时间记录
+    QueryTiming *timing = hash_search(query_timings, &query_id, HASH_ENTER, NULL);
+    timing->start_time = GetCurrentTimestamp();
+    timing->end_time = 0;
+    timing->exceeded = false;
+    timing->expected_time = GetConfigOptionIntByName("etime.min_value", 0, false);
+
+    // 调用之前的ExecutorStart_hook函数
+    if (prev_ExecutorStart_hook) {
+        prev_ExecutorStart_hook(queryDesc, eflags);
+    } else {
+        standard_ExecutorStart(queryDesc, eflags);
+    }
+}
+
+// ExecutorEnd钩子函数
+static void pg_stat_statements_ExecutorEnd(QueryDesc *queryDesc) {
+    uint32 query_id = queryDesc->plannedstmt->queryId;
+
+    // 查找查询的时间记录
+    QueryTiming *timing = hash_search(query_timings, &query_id, HASH_FIND, NULL);
+    if (timing != NULL) {
+        // 记录SQL结束时间
+        timing->end_time = GetCurrentTimestamp();
+
+        // 计算SQL执行时间
+        long elapsed = timing->end_time - timing->start_time;
+
+        // 如果预期时间大于0且实际执行时间超过预期时间，则记录超时查询
+        if (timing->expected_time > 0 && elapsed > timing->expected_time) {
+            timing->exceeded = true;
+            ereport(LOG,
+                    (errmsg("Query (ID: %u) exceeded expected time: %d microseconds (actual: %ld microseconds)", 
+                            query_id, timing->expected_time, elapsed)));
+        }
+
+        // 删除已经记录的时间信息
+        hash_search(query_timings, &query_id, HASH_REMOVE, NULL);
+    }
+
+    // 调用之前的ExecutorEnd_hook函数
+    if (prev_ExecutorEnd_hook) {
+        prev_ExecutorEnd_hook(queryDesc);
+    } else {
+        standard_ExecutorEnd(queryDesc);
+    }
+}
+
+// 设置预期时间（微秒）
+Datum set_expected_time(PG_FUNCTION_ARGS) {
+    int expected_time = PG_GETARG_INT32(0);
+
+    // 将预期时间设置为指定值
+    if (expected_time < 0) {
+        ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                        errmsg("Expected time cannot be negative")));
+    }
+    SetConfigOption("etime.min_value", DatumGetCString(DirectFunctionCall1(int4out, Int32GetDatum(expected_time))), PGC_USERSET, PGC_S_SESSION);
+    PG_RETURN_NULL();
+}
+
+// 获取预期时间（微秒）
+Datum get_expected_time(PG_FUNCTION_ARGS) {
+    int expected_time = GetConfigOptionIntByName("etime.min_value", 0, false);
+    PG_RETURN_INT32(expected_time);
+}
+
+// 初始化函数
+void _PG_init(void) {
+    init_query_timings();
+
+    // 保存之前的ExecutorStart_hook函数，并注册自己的钩子函数
+    prev_ExecutorStart_hook = ExecutorStart_hook;
+    ExecutorStart_hook = pg_stat_statements_ExecutorStart;
+
+    // 保存之前的ExecutorEnd_hook函数，并注册自己的钩子函数
+    prev_ExecutorEnd_hook = ExecutorEnd_hook;
+    ExecutorEnd_hook = pg_stat_statements_ExecutorEnd;
+
+    // 注册自定义函数：set_expected_time，用于设置预期时间
+    DefineCustomFunction("set_expected_time",
+                         set_expected_time,
+                         NULL,
+                         NULL);
+
+    // 注册自定义函数：get_expected_time，用于获取预期时间
+    DefineCustomFunction("get_expected_time",
+                         get_expected_time,
+                         NULL,
+                         NULL);
+}
+
+// 卸载函数
+void _PG_fini(void) {
+    // 恢复原始的ExecutorStart_hook和ExecutorEnd_hook函数
+    ExecutorStart_hook = prev_ExecutorStart_hook;
+    ExecutorEnd_hook = prev_ExecutorEnd_hook;
+
+    // 清理哈希表
+    if (query_timings != NULL) {
+        hash_destroy(query_timings);
+    }
+}

--- a/contrib/pg_stat_timing/test.sql
+++ b/contrib/pg_stat_timing/test.sql
@@ -1,0 +1,39 @@
+-- 创建测试表
+CREATE TABLE test_table (
+    id SERIAL PRIMARY KEY,
+    first_name TEXT,
+    last_name TEXT,
+    age INT,
+    email TEXT
+);
+
+-- 插入一些数据
+INSERT INTO test_table (first_name, last_name, age, email)
+VALUES 
+    ('John', 'Doe', 30, 'john.doe@example.com'),
+    ('Alice', 'Smith', 25, 'alice.smith@example.com'),
+    ('Bob', 'Johnson', 35, 'bob.johnson@example.com');
+
+-- 设置预期时间为 1 毫秒
+SELECT set_expected_time(1000);
+
+-- 执行一个查询，预期不超时
+SELECT * FROM test_table;
+
+-- 插入大量数据
+INSERT INTO test_table (first_name, last_name, age, email)
+SELECT 
+    'FirstName' || generate_series(1, 100),
+    'LastName' || generate_series(1, 100),
+    (random() * 100)::INT,
+    'email' || generate_series(1, 100) || '@example.com';
+
+-- 执行一个查询，预期超时
+SELECT * FROM test_table;
+
+LOG:  Query (ID: 21352) exceeded expected time: 1000 microseconds (actual: 3000 microseconds)
+
+
+
+
+


### PR DESCRIPTION
When reading SQL files from the database kernel, you need to record the start time to end time by using plug-ins. If the time is longer than the expected time, record it.