### PR TITLE
add oracle compatibility extension for opentenbase

### DIFF
--- a/contrib/pg_dbms_metadata/ChangeLog
+++ b/contrib/pg_dbms_metadata/ChangeLog
@@ -1,0 +1,6 @@
+Version 1.0.0 (Based on HexaCluster Corp. Version 1.0.0) - 2024-04-06
+
+-- Add Oracle compatible view 'dual' for better usage of the dbms_metadata package.
+-- Remove stored procedure support, as the current core of PGXC is based on PostgreSQL 10, which does not support stored procedures.
+-- Add PGXC distributed syntax to the create table statement.
+-- Adjust test cases to better test PGXC

--- a/contrib/pg_dbms_metadata/LICENSE
+++ b/contrib/pg_dbms_metadata/LICENSE
@@ -1,0 +1,23 @@
+PostgreSQL License
+
+Copyright (c) 2023, HexaCluster Corp.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement is
+hereby granted, provided that the above copyright notice and this paragraph
+and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL HexaCluster Corp BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF HexaCluster Corp.
+HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+HexaCluster Corp. SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+AND HexaCluster Corp HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+
+---
+
+As a derivative work based on the software provided by HexaCluster Corp., Joyann.lin inherits and extends the permissions and requirements of the original PostgreSQL License. This derivative work is also subject to the terms and conditions outlined above.

--- a/contrib/pg_dbms_metadata/META.json
+++ b/contrib/pg_dbms_metadata/META.json
@@ -1,0 +1,42 @@
+{
+    "name": "pg_dbms_metadata",
+    "abstract": "Extension to extract DDL of database objects in a way compatible to Oracle DBMS_METADATA package.",
+    "version": "1.0.0",
+    "maintainer": "joyannlin",
+    "license": "postgresql",
+    "release_status": "stable",
+    "provides": {
+       "pg_dbms_metadata": {
+          "abstract": "Extension to extract DDL of database objects in a way compatible to Oracle DBMS_METADATA package",
+          "file": "sql/pg_dbms_metadata--1.0.0.sql",
+          "docfile": "README.md",
+          "version": "1.0.0"
+       }
+    },
+    "resources": {
+       "bugtracker": {
+          "web": "https://github.com/joyannlin/pg_dbms_metadata/issues"
+       },
+       "repository": {
+         "url":  "git://github.com/joyannlin/pg_dbms_metadata.git",
+         "web":  "https://github.com/joyannlin/pg_dbms_metadata.git",
+         "type": "git"
+       }
+    },
+    "prereqs": {
+        "runtime": {
+            "requires": {
+                "PostgreSQL": "9.1"
+            }
+        }
+    },
+    "generated_by": "Akhil Reddy Banappagari",
+    "meta-spec": {
+       "version": "1.0.0",
+       "url": "http://pgxn.org/meta/spec.txt"
+    },
+    "tags": [
+       "dbms_metadata",
+       "get_ddl"
+    ]
+ }

--- a/contrib/pg_dbms_metadata/Makefile
+++ b/contrib/pg_dbms_metadata/Makefile
@@ -1,0 +1,27 @@
+EXTENSION  = pg_dbms_metadata
+EXTVERSION = $(shell grep default_version $(EXTENSION).control | \
+		sed -e "s/default_version[[:space:]]*=[[:space:]]*'\([^']*\)'/\1/")
+
+PGFILEDESC = "pg_dbms_metadata - Propose Oracle DBMS_METADATA compatibility for PostgreSQL"
+
+PG_CONFIG = pg_config
+PG91 = $(shell $(PG_CONFIG) --version | egrep " 8\.| 9\.0" > /dev/null && echo no || echo yes)
+
+ifeq ($(PG91),yes)
+DOCS = $(wildcard README*)
+
+DATA = $(wildcard updates/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+else
+$(error Minimum version of PostgreSQL required is 9.1.0)
+endif
+
+TESTS        = 00_init  01_get_ddl 02_get_dependent_ddl \
+	       03_get_granted_ddl 04_set_transform_param \
+		   05_clean_up
+
+REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
+REGRESS_OPTS = --inputdir=test
+
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+

--- a/contrib/pg_dbms_metadata/README.md
+++ b/contrib/pg_dbms_metadata/README.md
@@ -1,0 +1,202 @@
+# pg_dbms_metadata
+
+Propose Oracle DBMS_METADATA compatibility for PostgreSQL PGXC,Based on HexaCluster Corp. Version 1.0
+
+PostgreSQL extension to extract DDL of database objects in a way compatible to Oracle DBMS_METADATA package. This extension serves a dual purpose—not only does it provide compatibility with the Oracle DBMS_METADATA package, but it also establishes a systematic approach to programmatically retrieve DDL for objects. You now have the flexibility to generate DDL for an object either from a plain SQL query or from PL/pgSQL code. This also enables the extraction of DDL using any client that can execute plain SQL queries. These features distinguishes it from standard methods like pg_dump. 
+
+Information about the Oracle DBMS_metadata package can be found [here](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_METADATA.html)
+
+* [Description](#description)
+* [Installation](#installation)
+* [Manage the extension](#manage-the-extension)
+* [Functions](#functions)
+  - [GET_DDL](#get_ddl)
+  - [GET_DEPENDENT_DDL](#get_dependent_ddl)
+  - [GET_GRANTED_DDL](#get_granted_ddl)
+  - [SET_TRANSFORM_PARAM](#set_transform_param)
+* [Authors](#authors)
+* [License](#license)
+
+## [Description](#description)
+
+This PostgreSQL extension provide compatibility with the DBMS_METADATA Oracle package's API to extract DDL. This extension only supports DDL extraction through GET_xxx functions. Support to FETCH_xxx functions and XML support is not added. As of now, any user can get the ddl of any object in the database. Like Oracle, we have flexibility of omitting schema name while trying to get ddl of an object. This will use search_path to find the object and gets required ddl. However when schema name is omitted, the current user should atleast have USAGE access on schema in which target object is present. 
+
+Also see [ROADMAP](ROADMAP.md) for a precise understanding of what has been implemented and what is part of the future plans.
+
+The following functions are implemented:
+
+* `GET_DDL()` This function extracts DDL of specified object.  
+* `GET_DEPENDENT_DDL()` This function extracts DDL of all dependent objects of specified type for a specified base object.
+* `GET_GRANTED_DDL()` This function extracts the SQL statements to recreate granted privileges and roles for a specified grantee.
+* `SET_TRANSFORM_PARAM()` This function is used to customize DDL through configuring session-level transform params. 
+
+## [Installation](#installation)
+
+To be able to run this extension, your PostgreSQL version must support extensions (>= 9.1).
+
+1. Copy the source code from repository.
+2. set pg_config binary location in PATH environment variable
+3. Execute following command to install this extension
+
+```
+    make
+    sudo make install
+```
+
+Test of the extension can be done using:
+```
+    make installcheck
+```
+
+If you don't want to create an extension for this, you can simply import the SQL file and use the complete functionality:
+```
+psql -d mydb -c "CREATE SCHEMA dbms_metadata;"
+
+psql -d mydb -f sql/pg_dbms_metadata--1.0.0.sql
+```
+This is especially useful for database in DBaas cloud services. To upgrade just import the extension upgrade files using psql.
+
+## [Manage the extension](#manage-the-extension)
+
+Each database that needs to use `pg_dbms_metadata` must creates the extension:
+```
+    psql -d mydb -c "CREATE EXTENSION pg_dbms_metadata"
+```
+
+To upgrade to a new version execute:
+```
+    psql -d mydb -c 'ALTER EXTENSION pg_dbms_metadata UPDATE TO "1.1.0"'
+```
+
+## [Functions](#functions)
+
+### [GET_DDL](#get_ddl)
+
+This function extracts DDL of database objects. 
+
+Below is list of currently supported object types. To get a ddl of a check constraint, unlike Oracle you need to use CHECK_CONSTRAINT object type. In Oracle, we will use the CONSTRAINT object type to get ddl of a check constraint.
+* TABLE 
+* VIEW 
+* SEQUENCE 
+* FUNCTION 
+* TRIGGER
+* INDEX 
+* CONSTRAINT 
+* CHECK_CONSTRAINT
+* REF_CONSTRAINT
+* TYPE
+
+Syntax:
+```
+dbms_metadata.get_ddl (
+   object_type      IN text,
+   name             IN text,
+   schema           IN text DEFAULT NULL)
+   RETURNS text;
+```
+Parameters:
+
+- object_type: Object type for which DDL is needed.
+- name: Name of object 
+- schema: Schema in which object is present. When schema is not provided search_path is used to find the object and get ddl. However schema cannot be NULL for object types TRIGGER, REF_CONSTRAINT.
+
+Example:
+```
+SELECT dbms_metadata.get_ddl('TABLE','employees','gdmmm');
+```
+
+### [GET_DEPENDENT_DDL](#get_dependent_ddl)
+
+This function extracts DDL of all dependent objects of specified object type for a specified base object. 
+
+Below is the list of currently supported dependent object types
+* SEQUENCE
+* TRIGGER
+* CONSTRAINT
+* REF_CONSTRAINT
+* INDEX.
+
+Syntax:
+```
+dbms_metadata.get_dependent_ddl (
+   object_type          IN text,
+   base_object_name     IN text,
+   base_object_schema   IN text DEFAULT NULL)
+   RETURNS text;
+```
+Parameters:
+
+- object_type: Object type of dependent objects for which DDL is needed.
+- base_object_name: Name of base object 
+- base_object_schema: Schema in which base object is present. When base object schema is not provided search_path is used to find the base object.
+
+Example:
+```
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','employees','gdmmm');
+```
+
+### [GET_GRANTED_DDL](#get_granted_ddl)
+
+This function extracts the SQL statements to recreate granted privileges and roles for a specified grantee.
+
+Below is the list of currently supported object types
+* ROLE_GRANT
+
+Syntax:
+```
+dbms_metadata.get_granted_ddl (
+    object_type  IN text, 
+    grantee      IN text)
+    RETURNS text;
+```
+Parameters:
+
+- object_type: Type of grants to retrieve 
+- grantee: User/role for whom we need to retrieve grants
+
+Example:
+```
+SELECT dbms_metadata.get_granted_ddl('ROLE_GRANT','user_test');
+```
+
+### [SET_TRANSFORM_PARAM](#set_transform_param)
+
+This function is used to configure session-level transform params, with which we can customize the DDL of objects. This only supports session-level transform params, not setting transform params through any other transform handles like Oracle. GET_DDL, GET_DEPENDENT_DDL inherit these params when they invoke the DDL transform. There is a small change in the function signature when compared to the one of Oracle.
+
+Syntax:
+```
+dbms_metadata.set_transform_param (
+   name          IN text,
+   value         IN text);
+
+dbms_metadata.set_transform_param (
+   name          IN text,
+   value         IN boolean);
+```
+Parameters:
+
+- name: The name of the transform parameter.
+- value: The value of the transform.
+
+List of currently supported transform params
+
+| Object types          | Name                                  | Datatype      | Meaning & Notes      
+| --------------------- | ------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------
+| All objects           | SQLTERMINATOR                         | boolean       | If TRUE, append the SQL terminator( ; ) to each DDL statement. Defaults to FALSE.  
+| TABLE                 | CONSTRAINTS                           | boolean       | If TRUE, include all non-referential table constraints. If FALSE, omit them. Defaults to TRUE.  
+| TABLE                 | REF_CONSTRAINTS                       | boolean       | If TRUE, include all referential constraints (foreign keys). If FALSE, omit them. Defaults to TRUE.  
+| TABLE                 | CONSTRAINTS_AS_ALTER (UNSUPPORTED)    | boolean       | If TRUE, include table constraints as separate ALTER TABLE. This is not yet implemented in this extension. Currently all constraints are being given as separate DDL.  
+| TABLE                 | PARTITIONING                          | boolean       | If TRUE, include partitioning clauses in the DDL. Defaults to TRUE. Unlike oracle, this extension does not support INDEX object type for this transform param as postgres indexes doesn't got any partitioning clauses.
+| TABLE                 | SEGMENT_ATTRIBUTES                    | boolean       | If TRUE, include segment attributes in the DDL. Defaults to TRUE. Currently only logging attribute is supported and only TABLE object type is supported for this transform param.
+| All objects           | DEFAULT                               | boolean       | Calling dbms_metadata.set_transform_param with this parameter set to TRUE has the effect of resetting all transform params to their default values. Setting this FALSE has no effect. There is no default.  
+| TABLE                 | STORAGE                               | boolean       | If TRUE, include storage parameters in the DDL. Defaults to TRUE. Currently only TABLE object type is supported for this transform param. Index DDL will always retrieved with storage parameters, if there are any.
+
+Example:
+```
+CALL dbms_metadata.set_transform_param('SQLTERMINATOR',true);
+```
+
+## [License](#license)
+
+This extension is free software distributed under the PostgreSQL
+License.

--- a/contrib/pg_dbms_metadata/ROADMAP.md
+++ b/contrib/pg_dbms_metadata/ROADMAP.md
@@ -1,0 +1,66 @@
+Functions Implemented
+---------------------
+The list below includes the functions that have been implemented and those that are part of future plans. Have a look at [README](README.md) to understand the meaning of any of the items below.
+- ✔︎ GET_DDL()
+- ✔︎ GET_DEPENDENT_DDL()
+- ✔︎ GET_GRANTED_DDL()
+- ✔︎ SET_TRANSFORM_PARAM()
+
+GET_DDL
+-------
+The following outlines the supported PostgreSQL objects for GET_DDL, along with those that are currently not implemented but are included in the roadmap.
+- ✔︎ TABLE
+- ✔︎ VIEW
+- ✔︎ SEQUENCE
+- ✔︎ FUNCTION
+- ✔︎ TRIGGER
+- ✔︎ INDEX
+- ✔︎ CONSTRAINT
+- ✔︎ CHECK_CONSTRAINT
+- ✔︎ REF_CONSTRAINT
+- ✔︎ TYPE
+- MATERIALIZED_VIEW
+- USER/ROLE
+- ✔︎ PARTITION TABLES(ONLY PARENT)
+- PARTITION TABLES(CHILD TABLES)
+- Generating DDL for OVERLOADED FUNCTIONS
+- TEMP TABLES
+- Including IF NOT EXISTS & CREATE OR REPLACE clauses in DDL
+
+
+GET_DEPENDENT_DDL
+-----------------
+The following lists the supported dependent PostgreSQL objects for a table in GET_DEPENDENT_DDL.
+- ✔︎ SEQUENCE
+- ✔︎ TRIGGER
+- ✔︎ CONSTRAINT
+- ✔︎ REF_CONSTRAINT
+- ✔︎ INDEX
+- VIEW
+
+GET_GRANTED_DDL
+---------------
+Following lists the supported type of grants for a user/role.
+- ✔︎ ROLE_GRANT
+- SYSTEM GRANT
+
+SET_TRANSFORM_PARAM
+-------------------
+The following outlines the supported transform params and those that are part of future plans. To understand the meaning of the items below, please refer the [README](README.md) and [Oracle DBMS_METADATA package documentation](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_METADATA.html).
+- ✔︎ SQLTERMINATOR
+- ✔︎ CONSTRAINTS
+- ✔︎ REF_CONSTRAINTS
+- ✔︎ CONSTRAINTS_AS_ALTER
+- ✔︎ PARTITIONING
+- ✔︎ SEGMENT_ATTRIBUTES
+- ✔︎ DEFAULT
+- ✔︎ STORAGE
+- PRETTY
+- TABLESPACE
+
+MISCELLANEOUS FUTURE PLANS
+---------------------------
+- ENABLE clause in trigger DDL
+- DEFERRED constraints 
+- [SET_REMAP_PARAM of Oracle](https://docs.oracle.com/database/121/ARPLS/d_metada.htm#ARPLS66910)
+- Extracting DDL of heterogeneous object types like SCHEMA_EXPORT 

--- a/contrib/pg_dbms_metadata/pg_dbms_metadata.control
+++ b/contrib/pg_dbms_metadata/pg_dbms_metadata.control
@@ -1,0 +1,5 @@
+comment = 'Extension to add Oracle DBMS_METADATA compatibility to PostgreSQL'
+default_version = '1.0.0'
+module_pathname = '$libdir/pg_dbms_metadata'
+schema = 'dbms_metadata'
+relocatable = false

--- a/contrib/pg_dbms_metadata/sql/pg_dbms_metadata--1.0.0.sql
+++ b/contrib/pg_dbms_metadata/sql/pg_dbms_metadata--1.0.0.sql
@@ -1,0 +1,1411 @@
+----
+-- Script to create the objects of the pg_dbms_metadata extension
+----
+
+----
+-- public.dual
+----
+CREATE VIEW public.dual as SELECT 'X'::character varying AS dummy;
+
+----
+-- DBMS_METADATA.GET_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_ddl (object_type text, name text, schema text DEFAULT NULL)
+    RETURNS text
+    AS $$
+DECLARE
+    l_return text;
+BEGIN
+    CASE object_type
+    WHEN 'TABLE' THEN
+        l_return := dbms_metadata.get_table_ddl (schema, name);
+    WHEN 'VIEW' THEN
+        l_return := dbms_metadata.get_view_ddl (schema, name);
+    WHEN 'SEQUENCE' THEN
+        l_return := dbms_metadata.get_sequence_ddl (schema, name);
+    WHEN 'FUNCTION' THEN
+        l_return := dbms_metadata.get_routine_ddl (schema, name, object_type);
+    WHEN 'TRIGGER' THEN
+        l_return := dbms_metadata.get_trigger_ddl (schema, name);
+    WHEN 'INDEX' THEN
+        l_return := dbms_metadata.get_index_ddl (schema, name);
+    WHEN 'CONSTRAINT' THEN
+        l_return := dbms_metadata.get_constraint_ddl (schema, name);
+    WHEN 'CHECK_CONSTRAINT' THEN
+        l_return := dbms_metadata.get_check_constraint_ddl (schema, name);
+    WHEN 'REF_CONSTRAINT' THEN
+        l_return := dbms_metadata.get_ref_constraint_ddl (schema, name);
+    WHEN 'TYPE' THEN
+        l_return := dbms_metadata.get_type_ddl (schema, name);
+    ELSE
+        -- Need to add other object types
+        RAISE EXCEPTION 'Unknown type';
+    END CASE;
+    RETURN l_return;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_ddl (text, text, text) IS 'Retrieves DDL of database objects. Supported object types are TABLE, VIEW, SEQUENCE, FUNCTION.';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_DEPENDENT_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_dependent_ddl (object_type text, base_object_name text, base_object_schema text DEFAULT NULL)
+    RETURNS text
+    AS $$
+DECLARE
+    l_return text;
+BEGIN
+    CASE object_type
+    WHEN 'SEQUENCE' THEN
+        -- This is not there in oracle
+        l_return := dbms_metadata.get_sequence_ddl_of_table (base_object_schema, base_object_name);
+    WHEN 'TRIGGER' THEN
+        l_return := dbms_metadata.get_triggers_ddl_of_table (base_object_schema, base_object_name);
+    WHEN 'CONSTRAINT' THEN
+        l_return := dbms_metadata.get_constraints_ddl_of_table (base_object_schema, base_object_name);
+    WHEN 'REF_CONSTRAINT' THEN
+        l_return := dbms_metadata.get_ref_constraints_ddl_of_table (base_object_schema, base_object_name);
+    WHEN 'INDEX' THEN
+        l_return := dbms_metadata.get_indexes_ddl_of_table (base_object_schema, base_object_name);
+    ELSE
+        -- Need to add other object types
+        RAISE EXCEPTION 'Unknown type';
+    END CASE;
+    RETURN l_return;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_dependent_ddl (text, text, text) IS 'Retrieves DDL of dependent objects on provided base object. Supported dependent object types are SEQUENCE, CONSTRAINT, INDEX.';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_dependent_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_GRANTED_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_granted_ddl (object_type text, grantee text)
+    RETURNS text
+    AS $$
+DECLARE
+    l_return text;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    CASE object_type
+    WHEN 'ROLE_GRANT' THEN
+        l_return := dbms_metadata.get_granted_roles_ddl (grantee);
+    ELSE
+        -- Need to add other object types
+        RAISE EXCEPTION 'Unknown type';
+    END CASE;
+    RETURN l_return;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_granted_ddl (text, text) IS 'Retrieves the SQL statements to recreate granted privileges and roles for a specified grantee.';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_granted_ddl FROM PUBLIC;
+
+
+----
+-- DBMS_METADATA.SET_TRANSFORM_PARAM
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.set_transform_param(name text, value boolean DEFAULT true)
+    RETURNS void
+    AS $$
+DECLARE
+    l_allowed_names text[] := ARRAY['DEFAULT', 'SQLTERMINATOR', 'CONSTRAINTS', 'REF_CONSTRAINTS', 'PARTITIONING', 'SEGMENT_ATTRIBUTES', 'STORAGE','DISTRIBUTE','GROUP'];
+BEGIN
+    IF NOT name = ANY(l_allowed_names) THEN
+        RAISE EXCEPTION 'Name:% is not supported for value as boolean', name;
+    ELSIF name = 'DEFAULT' THEN
+        IF value THEN
+            PERFORM dbms_metadata.set_default_transform_params();
+        END IF;
+    ELSE
+        PERFORM set_config('DBMS_METADATA.' || name, value::text, false);
+    END IF;
+END;
+$$ 
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.set_transform_param (text, boolean) IS 'Used to customize DDL through configuring session-level transform params.';
+
+REVOKE ALL ON FUNCTION dbms_metadata.set_transform_param FROM PUBLIC;
+
+----
+-- DBMS_METADATA.INIT_TRANSFORM_PARAMS
+----
+CREATE FUNCTION dbms_metadata.init_transform_params()
+RETURNS void AS $$
+DECLARE
+    l_sqlterminator_guc boolean;
+    l_constraints_guc boolean;
+    l_ref_constraints_guc boolean;
+    l_partitioning_guc boolean;
+    l_segment_attributes_guc boolean;
+    l_storage_guc boolean;
+    l_distribute_guc boolean;
+    l_group_guc boolean;
+BEGIN
+    -- Initialize all transform params to their default values if they have not been set before
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR', true)::boolean INTO l_sqlterminator_guc;
+    IF l_sqlterminator_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.SQLTERMINATOR', 'true', false);
+    END IF;
+    SELECT current_setting('DBMS_METADATA.CONSTRAINTS', true)::boolean INTO l_constraints_guc;
+    IF l_constraints_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.CONSTRAINTS', 'true', false);
+    END IF;
+    SELECT current_setting('DBMS_METADATA.REF_CONSTRAINTS', true)::boolean INTO l_ref_constraints_guc;
+    IF l_ref_constraints_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.REF_CONSTRAINTS', 'true', false);
+    END IF;
+    SELECT current_setting('DBMS_METADATA.PARTITIONING', true)::boolean INTO l_partitioning_guc;
+    IF l_partitioning_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.PARTITIONING', 'true', false);
+    END IF;
+    SELECT current_setting('DBMS_METADATA.SEGMENT_ATTRIBUTES', true)::boolean INTO l_segment_attributes_guc;
+    IF l_segment_attributes_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.SEGMENT_ATTRIBUTES', 'true', false);
+    END IF;
+    SELECT current_setting('DBMS_METADATA.STORAGE', true)::boolean INTO l_storage_guc;
+    IF l_storage_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.STORAGE', 'true', false);
+    END IF;
+    SELECT current_setting('DBMS_METADATA.DISTRIBUTE', true)::boolean INTO l_distribute_guc;
+    IF l_distribute_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.DISTRIBUTE', 'true', false);
+    END IF;
+    SELECT current_setting('DBMS_METADATA.GROUP', true)::boolean INTO l_group_guc;
+    IF l_group_guc IS NULL THEN
+        PERFORM set_config('DBMS_METADATA.GROUP', 'true', false);
+    END IF;
+END;
+$$
+LANGUAGE plpgsql IMMUTABLE;
+
+----
+-- DBMS_METADATA.SET_DEFAULT_TRANSFORM_PARAMS
+----
+CREATE FUNCTION dbms_metadata.set_default_transform_params()
+RETURNS void AS $$
+BEGIN
+    -- If true, Append a SQL terminator
+    PERFORM set_config('DBMS_METADATA.SQLTERMINATOR', 'false', false);
+    -- If true, include all non-referential table constraints
+    PERFORM set_config('DBMS_METADATA.CONSTRAINTS', 'true', false);
+    -- If true, include all referential constraints
+    PERFORM set_config('DBMS_METADATA.REF_CONSTRAINTS', 'true', false);
+    -- If TRUE, include partitioning clauses in the DDL
+    PERFORM set_config('DBMS_METADATA.PARTITIONING', 'true', false);
+    -- If TRUE, include segment attributes clauses in the DDL
+    PERFORM set_config('DBMS_METADATA.SEGMENT_ATTRIBUTES', 'true', false);
+    -- If TRUE, include storage clauses in the DDL. Ignored if SEGMENT_ATTRIBUTES is FALSE
+    PERFORM set_config('DBMS_METADATA.STORAGE', 'true', false);
+    -- If TRUE, include distribute clauses in the DDL. Ignored if DISTRIBUTE is FALSE
+    PERFORM set_config('DBMS_METADATA.DISTRIBUTE', 'true', false);
+    -- If TRUE, include group clauses in the DDL. Ignored if GROUP is FALSE
+    PERFORM set_config('DBMS_METADATA.GROUP', 'true', false);
+END;
+$$
+LANGUAGE plpgsql IMMUTABLE;
+
+COMMENT ON FUNCTION dbms_metadata.set_default_transform_params() IS 'Used to set default values to all transform params.';
+
+REVOKE ALL ON FUNCTION dbms_metadata.set_default_transform_params FROM PUBLIC;
+
+------------------------------------------------------------------------------
+-- DBMS_METADATA.GET_DDL utility functions
+------------------------------------------------------------------------------
+
+----
+-- DBMS_METADATA.GET_TABLE_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_table_ddl (p_schema text, p_table text)
+    RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    l_schema_name text;
+    l_table_name text;
+    l_table_def text;
+    l_tab_comments text;
+    l_col_rec text;
+    l_col_comments text;
+    l_return text;
+    l_partitioning_type text;
+    l_partitioned_columns text;
+    l_storage_options text;
+    l_relpersistence text;
+    l_constraints text;
+    l_ref_constraints text;
+    l_sqlterminator_guc boolean;
+    l_constraints_guc boolean;
+    l_ref_constraints_guc boolean;
+    l_partitioning_guc boolean;
+    l_segment_attributes_guc boolean;
+    l_storage_guc boolean;
+    l_distribute_type text;
+    l_distribute_column text;
+    l_distribute_guc boolean;
+    l_group_name text;
+    l_group_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+    SELECT current_setting('DBMS_METADATA.CONSTRAINTS')::boolean INTO l_constraints_guc;
+    SELECT current_setting('DBMS_METADATA.REF_CONSTRAINTS')::boolean INTO l_ref_constraints_guc;
+    SELECT current_setting('DBMS_METADATA.PARTITIONING')::boolean INTO l_partitioning_guc;
+    SELECT current_setting('DBMS_METADATA.SEGMENT_ATTRIBUTES')::boolean INTO l_segment_attributes_guc;
+    SELECT current_setting('DBMS_METADATA.STORAGE')::boolean INTO l_storage_guc;
+    SELECT current_setting('DBMS_METADATA.DISTRIBUTE', true)::boolean INTO l_distribute_guc;
+    SELECT current_setting('DBMS_METADATA.GROUP', true)::boolean INTO l_group_guc;
+
+    /*  Getting the OID of the table. We will make remaining code in this function independent of parameters passed. 
+        For ex: when schema passed is null
+        This sql statement is also used in many routines below */
+    SELECT dbms_metadata.get_object_oid('TABLE', p_schema, p_table) INTO l_oid;
+
+    /*  We will get schema and object names so that we will not depend on parameters passed. 
+        For ex: when schema passed is null 
+        Also we are checking oid returned is of desired object type
+        This sql statement is also used in many routines below */
+    SELECT n.nspname, c.relname INTO STRICT l_schema_name, l_table_name
+    FROM pg_class c
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.oid = l_oid
+        AND c.relkind in ('r', 'p');
+
+    -- Following SQL would get -
+    -- 1. The list of columns of the Table in the order of the attnum
+    -- 2. Datatypes set to the columns
+    -- 3. DEFAULT values set to the columns
+    -- 4. NOT NULL constraints set to the columns
+    SELECT
+        string_agg(a.col, ',')
+    FROM (
+        SELECT
+            concat(quote_ident(a.attname) || ' ' || format_type(a.atttypid, a.atttypmod), ' ', (
+                    SELECT
+                        concat('DEFAULT ', substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid)
+                                FOR 128))
+                    FROM pg_catalog.pg_attrdef d
+                    WHERE
+                        d.adrelid = a.attrelid
+                        AND d.adnum = a.attnum
+                        AND a.atthasdef), CASE WHEN a.attnotnull THEN
+                        'NOT NULL'
+                    END) AS "col"
+        FROM
+            pg_attribute a
+            JOIN pg_class b ON a.attrelid = b.oid
+        WHERE
+            a.attname NOT IN ('tableoid', 'cmax', 'xmax', 'cmin', 'xmin', 'ctid','xmin_gts','xmax_gts','shardid','xc_node_id')
+            AND attisdropped IS FALSE
+            AND b.oid = l_oid
+        ORDER BY
+            attnum) a INTO l_table_def;
+
+    IF l_segment_attributes_guc THEN
+        -- Get table persistence
+        SELECT relpersistence INTO STRICT l_relpersistence
+        FROM pg_class
+        WHERE oid = l_oid
+            AND relpersistence IN ('p','u');
+    END IF;
+    
+    -- Add Table DDL with its columns and their datatypes to the Output
+    l_return := concat(l_return, '-- Table definition' || chr(10) || 'CREATE '|| CASE l_relpersistence WHEN 'u' THEN 'UNLOGGED ' ELSE '' END ||'TABLE ' || quote_ident(l_schema_name) || '.' || quote_ident(l_table_name) || ' (' || l_table_def || ')');
+    
+    IF l_partitioning_guc THEN
+        -- Get partitioning info of table
+        SELECT
+            CASE
+                WHEN pt.partstrat = 'r' THEN 'RANGE'
+                WHEN pt.partstrat = 'l' THEN 'LIST'
+                WHEN pt.partstrat = 'h' THEN 'HASH'
+                ELSE null
+            END AS partitioning_type,
+            string_agg(quote_ident(a.attname), ', ') AS partitioned_columns
+        INTO l_partitioning_type, l_partitioned_columns
+        FROM
+            pg_class c
+        LEFT JOIN pg_partitioned_table pt ON c.oid = pt.partrelid
+        LEFT JOIN pg_attribute a ON c.oid = a.attrelid
+        WHERE
+            c.oid = l_oid
+            AND a.attnum = ANY(pt.partattrs)
+            AND a.attnum > 0
+        GROUP BY c.relname, pt.partstrat;
+
+        -- Add partitioning if any
+        IF l_partitioning_type IS NOT NULL THEN
+            l_return := concat(l_return, ' PARTITION BY ' || l_partitioning_type || '(' || l_partitioned_columns || ')');
+        END IF;
+    END IF;
+
+    IF l_segment_attributes_guc AND l_storage_guc THEN
+        -- Get storage parameters
+        SELECT array_to_string(reloptions, ',') INTO l_storage_options
+        FROM pg_class
+        WHERE oid = l_oid;
+
+        IF l_storage_options IS NOT NULL THEN
+            l_return := concat(l_return, ' WITH (' || l_storage_options || ')');
+        END IF;
+    END IF;
+
+    -- Add IF l_distribute_guc THEN
+    IF l_distribute_guc THEN
+        SELECT CASE pclocatortype 
+        WHEN 'N' THEN 'ROUND ROBIN' 
+        WHEN 'R' THEN 'REPLICATION' 
+        WHEN 'H' THEN 'HASH' 
+        WHEN 'S' THEN 'SHARD' 
+        WHEN 'M' THEN 'MODULO' 
+        END as distype,    
+        (SELECT attname where a.attrelid = c.pcrelid and a.attnum = c.pcattnum) as discolumn
+        INTO l_distribute_type,l_distribute_column
+        FROM pg_catalog.pg_attribute a right join pg_catalog.pgxc_class c 
+        on a.attrelid = c.pcrelid 
+        and a.attnum = c.pcattnum
+        WHERE pcrelid = l_oid;
+    
+        IF l_distribute_type IS NOT NULL THEN
+            l_return := concat(l_return, ' DISTRIBUTE BY ' || l_distribute_type || '(' || l_distribute_column || ')');
+        END IF;
+    END IF;
+
+    -- Add IF l_group_guc THEN
+    IF l_group_guc THEN
+        SELECT string_agg(pgxc_group.group_name,',') AS groupname INTO l_group_name 
+        FROM pg_catalog.pgxc_node, pg_catalog.pgxc_group 
+        WHERE pgxc_node.oid IN 
+        (SELECT unnest(nodeoids) 
+        FROM pg_catalog.pgxc_class 
+        WHERE pcrelid = l_oid);
+
+        IF l_group_name IS NOT NULL THEN
+            l_return := concat(l_return, ' to GROUP '||l_group_name);
+        END IF;
+    END IF;
+
+    IF l_sqlterminator_guc THEN
+        -- Add semi-colon at end
+        l_return := concat(l_return, ';');
+    END IF;
+
+    -- Get comments on the Table if any
+    SELECT
+        'COMMENT ON TABLE ' || quote_ident(l_schema_name) || '.' || quote_ident(l_table_name) || ' IS '''|| obj_description(l_oid) || '''' || CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END INTO l_tab_comments
+    FROM pg_class
+    WHERE relkind = 'r';
+    -- Get comments on the columns of the Table if any
+    FOR l_col_rec IN (
+        SELECT
+            'COMMENT ON COLUMN ' || quote_ident(l_schema_name) || '.' || quote_ident(l_table_name) || '.' || quote_ident(attname) || ' IS '''|| pg_catalog.col_description(l_oid, attnum) || '''' || CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END
+        FROM
+            pg_catalog.pg_attribute
+        WHERE
+            attname NOT IN ('tableoid', 'cmax', 'xmax', 'cmin', 'xmin', 'ctid')
+            AND attisdropped IS FALSE
+            AND attrelid = l_oid
+            AND pg_catalog.col_description(l_oid, attnum) IS NOT NULL)
+        LOOP
+            IF l_col_comments IS NULL THEN
+                l_col_comments := concat(l_col_rec, chr(10));
+            ELSE
+                l_col_comments := concat(l_col_comments, l_col_rec, chr(10));
+            END IF;
+        END LOOP;
+
+    -- Append Comments on Table to the Output
+    l_return := concat(l_return, (chr(10) || chr(10) || '-- Table comments' || chr(10) || l_tab_comments));
+    -- Append Comments on Columns of Table to the Output
+    l_return := concat(l_return, (chr(10) || chr(10) || '-- Column comments' || chr(10) || l_col_comments));
+
+    BEGIN
+        IF l_constraints_guc THEN
+            l_constraints := dbms_metadata.get_constraints_ddl_of_table(l_schema_name, l_table_name);
+            l_return := concat(l_return, (chr(10) || chr(10) || '-- Constraints' || chr(10) || l_constraints));
+        END IF;
+
+        IF l_ref_constraints_guc THEN
+            l_ref_constraints := dbms_metadata.get_ref_constraints_ddl_of_table(l_schema_name, l_table_name);
+            l_return := concat(l_return, (chr(10) || chr(10) || '-- Referential constraints' || chr(10) || l_ref_constraints));
+        END IF;
+    EXCEPTION
+        WHEN OTHERS THEN
+            NULL;
+    END;
+
+    -- Return the final Table DDL prepared with Comments on Table and Columns
+    RETURN l_return;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF p_schema IS NULL THEN
+            RAISE EXCEPTION 'Table with name % not found. Please provide schema name.', p_table;
+        ELSE
+            RAISE EXCEPTION 'Table with name % not found in schema %', p_table, p_schema;
+        END IF;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_table_ddl (text, text) IS 'This function retrieves a basic table DDL without constraints and indexes. DDL will include list of columns of the table, along with datatypes, DEFAULT values and NOT NULL constraints, in the order of the attnum. DDL will also include comments on table and columns if any.';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_table_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_VIEW_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_view_ddl (view_schema text, view_name text)
+    RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    l_schema_name text;
+    l_view_name text;
+    l_return text;
+    l_sqlterminator_guc boolean;
+BEGIN
+
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT dbms_metadata.get_object_oid('VIEW', view_schema, view_name) INTO l_oid;
+
+    SELECT n.nspname, c.relname INTO STRICT l_schema_name, l_view_name
+    FROM pg_class c
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.oid = l_oid
+        AND c.relkind = 'v';
+
+    SELECT 'CREATE VIEW ' || quote_ident(l_schema_name) || '.' || quote_ident(l_view_name) || ' AS ' || pg_get_viewdef(l_oid) INTO STRICT l_return;
+
+    IF l_return IS NULL THEN
+        RAISE EXCEPTION 'View % not found in schema %', view_name, view_schema;
+    END IF;
+
+    IF NOT l_sqlterminator_guc THEN
+        l_return := TRIM(TRAILING ';' FROM l_return);
+    END IF;
+    RETURN l_return;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF view_schema IS NULL THEN
+            RAISE EXCEPTION 'View with name % not found. Please provide schema name.', view_name;
+        ELSE
+            RAISE EXCEPTION 'View with name % not found in schema %', view_name, view_schema;
+        END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_view_ddl (text, text) IS 'This function retrieves DDL of a view';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_view_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_SEQUENCE_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_sequence_ddl (p_schema text, p_sequence text)
+    RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    l_return text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT dbms_metadata.get_object_oid('SEQUENCE', p_schema, p_sequence) INTO STRICT l_oid;
+
+    SELECT
+        'CREATE SEQUENCE ' || quote_ident(s.schemaname) || '.' || quote_ident(s.sequencename) || ' START WITH ' || start_value || ' INCREMENT BY ' || increment_by || ' MINVALUE ' || min_value || ' MAXVALUE ' || max_value || ' CACHE ' || cache_size || ' ' || CASE WHEN CYCLE IS TRUE THEN
+            'CYCLE'
+        ELSE
+            'NO CYCLE'
+        END || CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END INTO STRICT l_return
+    FROM
+        pg_sequences s
+    JOIN
+        pg_class c ON s.schemaname::regnamespace = c.relnamespace AND s.sequencename = c.relname
+    WHERE
+        c.oid = l_oid
+        AND c.relkind = 'S';
+    RETURN l_return;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF p_schema IS NULL THEN
+            RAISE EXCEPTION 'Sequence with name % not found. Please provide schema name.', p_sequence;
+        ELSE
+            RAISE EXCEPTION 'Sequence with name % not found in schema %', p_sequence, p_schema;
+        END IF;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_sequence_ddl (text, text) IS 'This function retrieves DDL of a sequence';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_sequence_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_ROUTINE_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_routine_ddl (schema_name text, routine_name text, routine_type text DEFAULT 'function')
+    RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    routine_code text;
+    routine_type_flag text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    CASE
+    WHEN routine_type = 'FUNCTION' THEN
+        routine_type_flag = 'f';
+    END CASE;
+
+    SELECT dbms_metadata.get_object_oid(routine_type, schema_name, routine_name) INTO l_oid;
+
+    SELECT
+        pg_get_functiondef(p.oid) INTO STRICT routine_code
+    FROM
+        pg_proc p
+    WHERE
+        p.oid = l_oid
+        AND p.prokind = routine_type_flag; 
+    
+    IF l_sqlterminator_guc THEN
+        routine_code := concat(routine_code, ';');
+    END IF;
+    RETURN routine_code;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF schema_name IS NULL THEN
+            RAISE EXCEPTION '% with name % not found. Please provide schema name.', routine_type, routine_name;
+        ELSE
+            RAISE EXCEPTION '% with name % not found in schema %', routine_type, routine_name, schema_name;
+        END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_routine_ddl (text, text, text) IS 'This function retrieves DDL of a function';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_routine_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_INDEX_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_index_ddl(schema_name text, index_name text)
+RETURNS text AS
+$$
+DECLARE
+    l_oid oid;
+    index_def text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT dbms_metadata.get_object_oid('INDEX', schema_name, index_name) INTO STRICT l_oid;
+
+    SELECT i.indexdef INTO STRICT index_def
+    FROM pg_indexes i
+    JOIN pg_class c 
+        ON i.schemaname::regnamespace = c.relnamespace AND i.indexname = c.relname
+    WHERE
+        c.oid = l_oid
+        AND c.relkind = 'i';
+    
+    IF l_sqlterminator_guc THEN
+        index_def := concat(index_def, ';');
+    END IF;    
+    RETURN index_def;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF schema_name IS NULL THEN
+            RAISE EXCEPTION 'Index with name % not found. Please provide schema name.',index_name;
+        ELSE
+            RAISE EXCEPTION 'Index with name % not found in schema %',index_name, schema_name;
+        END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_index_ddl (text, text) IS 'This function retrieves DDL of an index';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_index_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_CONSTRAINT_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_constraint_ddl(schema_name text, constraint_name text)
+RETURNS text AS
+$$
+DECLARE
+    l_oid oid;
+    alter_statement text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT dbms_metadata.get_object_oid('CONSTRAINT', schema_name, constraint_name) INTO l_oid;
+
+    SELECT format('ALTER TABLE %I.%I ADD CONSTRAINT %I %s', n.nspname, cl.relname, conname, pg_catalog.pg_get_constraintdef(con.oid, TRUE))
+    INTO STRICT alter_statement
+    FROM pg_constraint con
+    JOIN pg_class cl ON con.conrelid = cl.oid
+    JOIN pg_class cc ON con.connamespace = cc.relnamespace AND con.conname = cc.relname
+    JOIN pg_namespace n ON cc.relnamespace = n.oid 
+    WHERE cc.oid = l_oid
+        AND cc.relkind = 'i'
+        AND contype <> 'f';
+
+    IF l_sqlterminator_guc THEN
+        alter_statement := concat(alter_statement, ';');
+    END IF; 
+    RETURN alter_statement;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF schema_name IS NULL THEN
+            RAISE EXCEPTION 'Constraint with name % not found. Please provide schema name.',constraint_name;
+        ELSE
+            RAISE EXCEPTION 'Constraint with name % not found in schema %',constraint_name, schema_name;
+        END IF;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_constraint_ddl (text, text) IS 'This function retrieves DDL of a constraint';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_constraint_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_CHECK_CONSTRAINT_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_check_constraint_ddl(schema_name text, constraint_name text)
+RETURNS text AS
+$$
+DECLARE
+    alter_statement text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    IF schema_name IS NULL THEN
+        RAISE EXCEPTION 'schema cannot be null for type CHECK_CONSTRAINT';
+    END IF;
+
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT format('ALTER TABLE %I.%I ADD CONSTRAINT %I %s', schema_name, cl.relname, conname, pg_catalog.pg_get_constraintdef(con.oid, TRUE))
+    INTO STRICT alter_statement
+    FROM pg_constraint con
+    JOIN pg_class cl ON con.conrelid = cl.oid
+    WHERE conname = constraint_name
+        AND contype = 'c'
+        AND connamespace = (SELECT oid FROM pg_namespace WHERE nspname = schema_name);
+    
+    IF l_sqlterminator_guc THEN
+        alter_statement := concat(alter_statement, ';');
+    END IF; 
+    
+    RETURN alter_statement;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        RAISE EXCEPTION 'Check constraint with name % not found in schema %',constraint_name, schema_name;
+    WHEN TOO_MANY_ROWS THEN
+        /* In postgres there can be duplicate check constraint names defined in one schema, as long as they belong to different tables
+           So we need error out if the check constraint name is duplicated */
+        RAISE EXCEPTION 'Duplicate check constraints found with name % in schema %', constraint_name, schema_name;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_check_constraint_ddl (text, text) IS 'This function retrieves DDL of a check constraint';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_check_constraint_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_REF_CONSTRAINT_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_ref_constraint_ddl(schema_name text, constraint_name text)
+RETURNS text AS
+$$
+DECLARE
+    alter_statement text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    IF schema_name IS NULL THEN
+        RAISE EXCEPTION 'schema cannot be null for type REF_CONSTRAINT';
+    END IF;
+
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT format('ALTER TABLE %I.%I ADD CONSTRAINT %I %s', schema_name, cl.relname, conname, pg_catalog.pg_get_constraintdef(con.oid, TRUE))
+    INTO STRICT alter_statement
+    FROM pg_constraint con
+    JOIN pg_class cl ON con.conrelid = cl.oid
+    WHERE conname = constraint_name
+        AND contype = 'f'
+        AND connamespace = (SELECT oid FROM pg_namespace WHERE nspname = schema_name);
+    
+    IF l_sqlterminator_guc THEN
+        alter_statement := concat(alter_statement, ';');
+    END IF; 
+    RETURN alter_statement;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        RAISE EXCEPTION 'Referential constraint with name % not found in schema %',constraint_name, schema_name;
+    WHEN TOO_MANY_ROWS THEN
+        /* In postgres there can be duplicate ref constraint names defined in one schema, as long as they belong to different tables
+           So we need to check and error out if the ref constraint name is duplicated */
+        RAISE EXCEPTION 'Duplicate ref constraints found with name % in schema %', constraint_name, schema_name;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_ref_constraint_ddl (text, text) IS 'This function retrieves DDL of a referential constraint';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_ref_constraint_ddl FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_TRIGGER_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_trigger_ddl(schema_name text, trigger_name text)
+RETURNS text AS
+$$
+DECLARE
+    trigger_def text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    IF schema_name IS NULL THEN
+        RAISE EXCEPTION 'schema cannot be null for type TRIGGER';
+    END IF;
+
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT pg_get_triggerdef(t.oid)
+    INTO STRICT trigger_def
+    FROM pg_trigger t
+    JOIN pg_class c ON t.tgrelid = c.oid
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE t.tgname = trigger_name
+      AND n.nspname = schema_name;
+
+    IF l_sqlterminator_guc THEN
+        trigger_def := concat(trigger_def, ';');
+    END IF; 
+    RETURN trigger_def;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        RAISE EXCEPTION 'Trigger with name % not found in schema %', trigger_name, schema_name;
+    WHEN TOO_MANY_ROWS THEN
+        /* In postgres there can be duplicate trigger names defined in one schema, as long as they belong to different tables
+           So we need to check and error out if the trigger name is duplicated */
+        RAISE EXCEPTION 'Duplicate triggers found with name % in schema %', trigger_name, schema_name;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_trigger_ddl (text, text) IS 'This function retrieves DDL of a trigger';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_trigger_ddl FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION dbms_metadata.get_type_ddl(p_schema_name text, p_type_name text)
+RETURNS text AS $$
+DECLARE
+    l_oid oid;
+    l_schema_name text;
+    l_type_name text;
+    l_create_statement text;
+    l_attribute_list text;
+    l_attribute record;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+    
+    SELECT dbms_metadata.get_object_oid('TYPE', p_schema_name, p_type_name) INTO l_oid;
+
+    SELECT n.nspname, c.relname INTO STRICT l_schema_name, l_type_name
+    FROM pg_class c
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.oid = l_oid
+        AND c.relkind = 'c';
+    
+    FOR l_attribute IN
+        SELECT quote_ident(a.attname) as attname, format_type(a.atttypid, a.atttypmod) AS format_type
+        FROM pg_attribute a
+        JOIN pg_class c ON a.attrelid = c.oid
+        WHERE c.oid = l_oid
+            AND c.relkind = 'c' 
+            AND a.attnum > 0
+        ORDER BY a.attnum
+    LOOP
+        l_attribute_list := concat(l_attribute_list, ' ', l_attribute.attname, ' ', l_attribute.format_type, ',');
+    END LOOP;
+
+    -- Construct the CREATE TYPE statement
+    IF l_attribute_list IS NULL THEN
+        RAISE EXCEPTION 'Type % does not exist in schema %.', p_type_name, p_schema_name;
+    ELSE
+        l_attribute_list := TRIM(TRAILING ',' FROM l_attribute_list);
+        l_create_statement := concat('CREATE TYPE ', quote_ident(l_schema_name), '.', quote_ident(l_type_name), ' AS (', l_attribute_list, ')');
+        IF l_sqlterminator_guc THEN
+            l_create_statement := concat(l_create_statement, ';');
+        END IF; 
+    END IF;
+
+    RETURN l_create_statement;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF p_schema IS NULL THEN
+            RAISE EXCEPTION 'Type % does not exist. Please provide schema name.', p_type_name;
+        ELSE
+            RAISE EXCEPTION 'Type % does not exist in schema %', p_type_name, p_schema;
+        END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_type_ddl (text, text) IS 'This function retrieves DDL of a user defined type';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_type_ddl FROM PUBLIC;
+
+------------------------------------------------------------------------------
+-- DBMS_METADATA.GET_DEPENDENT_DDL utility functions
+------------------------------------------------------------------------------
+
+----
+-- DBMS_METADATA.GET_SEQUENCE_DDL_OF_TABLE
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_sequence_ddl_of_table (p_schema text, p_table text)
+    RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    l_seq_rec text;
+    l_sequences text;
+    l_return text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    SELECT dbms_metadata.get_object_oid('TABLE', p_schema, p_table) INTO l_oid;
+
+    -- Get the CREATE SEQUENCE statements
+    --     for all the sequences belonging to the table
+    FOR l_seq_rec IN (
+        SELECT
+            'CREATE SEQUENCE ' || quote_ident(seq.schemaname) || '.' || quote_ident(seq.sequencename) || ' START WITH ' || seq.start_value || ' INCREMENT BY ' || seq.increment_by || ' MINVALUE ' || seq.min_value || ' MAXVALUE ' || seq.max_value || ' CACHE ' || seq.cache_size || ' ' || CASE WHEN seq.CYCLE IS TRUE THEN
+                'CYCLE'
+            ELSE
+                'NO CYCLE'
+            END || CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END
+        FROM
+            pg_class s
+            JOIN pg_namespace sn ON sn.oid = s.relnamespace
+            JOIN pg_depend d ON d.refobjid = s.oid
+                AND d.refclassid = 'pg_class'::regclass
+            JOIN pg_attrdef ad ON ad.oid = d.objid
+                AND d.classid = 'pg_attrdef'::regclass
+            JOIN pg_attribute col ON col.attrelid = ad.adrelid
+                AND col.attnum = ad.adnum
+            JOIN pg_class tbl ON tbl.oid = ad.adrelid
+            JOIN pg_namespace ts ON ts.oid = tbl.relnamespace
+            JOIN pg_sequences seq ON seq.schemaname = sn.nspname 
+                AND seq.sequencename = s.relname
+        WHERE
+            s.relkind = 'S'
+            AND tbl.relkind in ('r', 'p')
+            AND d.deptype IN ('a', 'n')
+            AND tbl.oid = l_oid)
+            LOOP
+                IF l_sequences IS NULL THEN
+                    l_sequences := concat(l_seq_rec, chr(10));
+                ELSE
+                    l_sequences := concat(l_sequences, l_seq_rec, chr(10));
+                END IF;
+            END LOOP;
+    
+    IF l_sequences IS NULL THEN
+        RAISE EXCEPTION 'specified object of type SEQUENCE not found';
+    END IF;
+    -- Return the CREATE SEQUENCE statements to the DDL Output
+    l_return := concat(l_sequences || chr(10));
+    -- Return the final Sequences DDL prepared
+    RETURN l_return;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_sequence_ddl_of_table (text, text) IS 'This function retrieves DDL of all dependent sequences on provided table';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_sequence_ddl_of_table FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_CONSTRAINTS_DDL_OF_TABLE
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_constraints_ddl_of_table (
+    p_schema text, 
+    p_table text
+) RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    l_schema_name text;
+    l_table_name text;
+    l_const_rec record;
+    l_constraints text;
+    l_return text;
+    l_check_con_ddls text := '';
+    l_constraint_rec record;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    -- Getting the OID of the table
+    SELECT dbms_metadata.get_object_oid('TABLE', p_schema, p_table) INTO l_oid;
+    
+    SELECT n.nspname, c.relname INTO STRICT l_schema_name, l_table_name
+    FROM pg_class c
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.oid = l_oid
+        AND c.relkind in ('r', 'p');
+
+    -- Get Constraints Definitions
+    FOR l_const_rec IN (
+        SELECT
+            c2.relname,
+            i.indisprimary,
+            i.indisunique,
+            i.indisclustered,
+            i.indisvalid,
+            pg_catalog.pg_get_indexdef(i.indexrelid, 0, TRUE),
+            pg_catalog.pg_get_constraintdef(con.oid, TRUE),
+            contype,
+            condeferrable,
+            condeferred,
+            c2.reltablespace,
+            conname
+        FROM
+            pg_catalog.pg_class c,
+            pg_catalog.pg_class c2,
+            pg_catalog.pg_index i
+        LEFT JOIN pg_catalog.pg_constraint con ON (conrelid = i.indrelid
+                AND conindid = i.indexrelid
+                AND contype IN ('p', 'u', 'x', 'f'))
+    WHERE
+        c.oid = l_oid
+        AND c.relkind in ('r', 'p')
+        AND c.oid = i.indrelid
+        AND i.indexrelid = c2.oid
+    ORDER BY
+        i.indisprimary DESC,
+        i.indisunique DESC,
+        c2.relname)
+        LOOP
+            IF l_const_rec.contype IS NOT NULL THEN
+                l_constraints := concat(l_constraints, format('ALTER TABLE %I.%I ADD CONSTRAINT %I ', l_schema_name, l_table_name, l_const_rec.conname), l_const_rec.pg_get_constraintdef, CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END, chr(10));
+            END IF;
+        END LOOP;
+
+    -- Get check constraints
+    FOR l_constraint_rec IN (
+        SELECT pg_get_constraintdef(c.oid) AS constraint_def
+        FROM pg_constraint c
+        JOIN pg_class t ON c.conrelid = t.oid
+        WHERE t.oid = l_oid
+            AND t.relkind in ('r', 'p')
+            AND c.contype = 'c'
+    ) LOOP
+        l_check_con_ddls := l_check_con_ddls || E'ALTER TABLE ' || quote_ident(l_schema_name) || '.' || quote_ident(l_table_name) || ' ADD ' || l_constraint_rec.constraint_def || CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END || E'\n';
+    END LOOP;
+
+    l_return := l_constraints || chr(10) || l_check_con_ddls;
+
+    IF l_return IS NULL THEN
+        RAISE EXCEPTION 'specified object of type CONSTRAINT not found';
+    END IF;
+
+    -- Return the final DDL prepared
+    RETURN l_return;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        IF p_schema IS NULL THEN
+            RAISE EXCEPTION 'Table with name % not found. Please provide schema name.', p_table;
+        ELSE
+            RAISE EXCEPTION 'Table with name % not found in schema %', p_table, p_schema;
+        END IF;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_constraints_ddl_of_table (text, text) IS 'This function retrieves DDL of all constraints of provided table';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_constraints_ddl_of_table FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_REF_CONSTRAINTS_DDL_OF_TABLE
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_ref_constraints_ddl_of_table (
+    p_schema text, 
+    p_table text
+) RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    l_const_rec record;
+    l_return text;
+    l_fkey_rec text;
+    l_fkey text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    -- Getting the OID of the table
+    SELECT dbms_metadata.get_object_oid('TABLE', p_schema, p_table) INTO l_oid;
+    
+    FOR l_fkey_rec IN (
+        SELECT
+            'ALTER TABLE ' || quote_ident(nspname) || '.' || quote_ident(relname) || ' ADD CONSTRAINT ' || quote_ident(conname) || ' ' || pg_get_constraintdef(pg_constraint.oid) || CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END
+        FROM
+            pg_constraint
+            INNER JOIN pg_class ON conrelid = pg_class.oid
+            INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+        WHERE
+            contype = 'f'
+            AND pg_class.oid = l_oid
+            AND pg_class.relkind in ('r', 'p'))
+        LOOP
+            IF l_fkey IS NULL THEN
+                l_fkey := concat(l_fkey_rec, chr(10));
+            ELSE
+                l_fkey := concat(l_fkey, l_fkey_rec, chr(10));
+            END IF;
+        END LOOP;
+
+    IF l_fkey IS NULL THEN
+        RAISE EXCEPTION 'specified object of type REF_CONSTRAINT not found';
+    END IF;
+    
+    l_return := l_fkey;
+
+    -- Return the final DDL prepared
+    RETURN l_return;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_ref_constraints_ddl_of_table (text, text) IS 'This function retrieves DDL of all constraints of provided table';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_ref_constraints_ddl_of_table FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_INDEXES_DDL_OF_TABLE
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_indexes_ddl_of_table (p_schema text, p_table text)
+    RETURNS text
+    AS $$
+DECLARE
+    l_oid oid;
+    l_const_rec record;
+    l_indexes text;
+    l_return text;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    -- Getting the OID of the table
+    SELECT dbms_metadata.get_object_oid('TABLE', p_schema, p_table) INTO l_oid;
+    
+    -- Get Index Definitions
+    FOR l_const_rec IN (
+        SELECT
+            c2.relname,
+            i.indisprimary,
+            i.indisunique,
+            i.indisclustered,
+            i.indisvalid,
+            pg_catalog.pg_get_indexdef(i.indexrelid, 0, TRUE),
+            pg_catalog.pg_get_constraintdef(con.oid, TRUE),
+            contype,
+            condeferrable,
+            condeferred,
+            c2.reltablespace,
+            conname
+        FROM
+            pg_catalog.pg_class c,
+            pg_catalog.pg_class c2,
+            pg_catalog.pg_index i
+        LEFT JOIN pg_catalog.pg_constraint con ON (conrelid = i.indrelid
+                AND conindid = i.indexrelid
+                AND contype IN ('p', 'u', 'x', 'f'))
+    WHERE
+        c.oid = l_oid
+        AND c.relkind in ('r', 'p')
+        AND c.oid = i.indrelid
+        AND i.indexrelid = c2.oid
+    ORDER BY
+        i.indisprimary DESC,
+        i.indisunique DESC,
+        c2.relname)
+        LOOP
+            IF l_const_rec.contype IS NULL THEN
+                l_indexes := concat(l_indexes, l_const_rec.pg_get_indexdef, CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END, chr(10));
+            END IF;
+        END LOOP;
+    
+    IF l_indexes IS NULL THEN
+        RAISE EXCEPTION 'specified object of type INDEX not found';
+    END IF;
+    l_return := l_indexes;
+    -- Return the final DDL prepared
+    RETURN l_return;
+END;
+$$
+LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION dbms_metadata.get_indexes_ddl_of_table (text, text) IS 'This function retrieves DDL of all indexes of provided table';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_indexes_ddl_of_table FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_TRIGGERS_DDL_OF_TABLE
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_triggers_ddl_of_table(schema_name text, table_name text)
+RETURNS text AS
+$$
+DECLARE
+    l_oid oid;
+    trigger_def text;
+    l_return text := '';
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+
+    -- Getting the OID of the table
+    SELECT dbms_metadata.get_object_oid('TABLE', schema_name, table_name) INTO l_oid;
+
+    FOR trigger_def IN
+        SELECT pg_get_triggerdef(t.oid)
+        FROM pg_trigger t
+        JOIN pg_class c ON t.tgrelid = c.oid
+        WHERE c.oid = l_oid
+          AND c.relkind in ('r', 'p')
+          AND t.tgisinternal = FALSE -- Exclude system triggers
+    LOOP
+        l_return := l_return || trigger_def || CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END || E'\n\n';
+    END LOOP;
+
+    IF l_return IS NULL OR l_return = '' THEN
+        RAISE EXCEPTION 'specified object of type TRIGGER not found';
+    END IF;
+    
+    RETURN l_return;
+END;
+$$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_triggers_ddl_of_table (text, text) IS 'This function retrieves DDL of all triggers of provided table';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_triggers_ddl_of_table FROM PUBLIC;
+
+------------------------------------------------------------------------------
+-- DBMS_METADATA.GET_GRANTED_DDL utility functions
+------------------------------------------------------------------------------
+
+----
+-- DBMS_METADATA.GET_GRANTED_ROLES_DDL
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_granted_roles_ddl(p_grantee text)
+RETURNS text AS $$
+DECLARE
+    l_grant_statements text;
+    l_role_info record;
+    l_sqlterminator_guc boolean;
+BEGIN
+    -- Initialize transform params if they have not been set before
+    PERFORM dbms_metadata.init_transform_params();
+
+    -- Getting values of transform params
+    SELECT current_setting('DBMS_METADATA.SQLTERMINATOR')::boolean INTO l_sqlterminator_guc;
+    
+    FOR l_role_info IN 
+        SELECT r.rolname AS role_name
+        FROM pg_roles r
+        JOIN pg_auth_members m ON r.oid = m.roleid
+        JOIN pg_roles u ON m.member = u.oid
+        WHERE u.rolname = p_grantee
+        ORDER BY r.rolname
+    LOOP
+        l_grant_statements := concat(l_grant_statements, 'GRANT ', quote_ident(l_role_info.role_name), ' TO ', quote_ident(p_grantee), CASE l_sqlterminator_guc WHEN TRUE THEN ';' ELSE '' END, E'\n');
+    END LOOP;
+    IF l_grant_statements IS NULL THEN
+        RAISE EXCEPTION 'role grant for grantee % not found', p_grantee;
+    END IF;    
+    RETURN l_grant_statements;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_granted_roles_ddl (text) IS 'This function extracts the SQL statements to recreate roles granted to a specified grantee';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_granted_roles_ddl FROM PUBLIC;
+
+------------------------------------------------------------------------------
+-- Other Utility functions
+------------------------------------------------------------------------------
+
+----
+-- DBMS_METADATA.GET_OBJECT_OID
+----
+/*  This function may not return OID of given object type sometimes. For example if TABLE is passed as object_type, 
+    but actually there is no table with that name, but there is a view. This function will then return oid of the view. 
+    So object type check must be done after fetting oid from this function. */
+CREATE OR REPLACE FUNCTION dbms_metadata.get_object_oid(p_object_type text, p_schema text, p_object_name text)
+RETURNS oid AS $$
+DECLARE
+    l_oid oid;
+    l_schema_oid oid;
+    l_pg_class_objs text[] := ARRAY['TABLE', 'VIEW', 'SEQUENCE', 'INDEX', 'CONSTRAINT', 'REF_CONSTRAINT', 'TYPE'];
+    l_pg_proc_objs text[] := ARRAY['FUNCTION'];
+BEGIN
+    IF p_schema IS NOT NULL THEN
+        SELECT dbms_metadata.get_schema_oid(p_schema) INTO l_schema_oid;
+    END IF;
+
+    IF p_object_type = ANY(l_pg_class_objs) THEN
+        IF p_schema IS NULL THEN
+            SELECT quote_ident(p_object_name)::regclass::oid INTO STRICT l_oid;
+        ELSE
+            SELECT
+                oid INTO STRICT l_oid
+            FROM
+                pg_class
+            WHERE
+                relname = p_object_name
+                AND relnamespace = l_schema_oid;
+        END IF;
+    ELSIF p_object_type = ANY(l_pg_proc_objs) THEN
+        IF p_schema IS NULL THEN
+            SELECT quote_ident(p_object_name)::regproc::oid INTO STRICT l_oid;
+        ELSE
+            SELECT 
+                oid INTO STRICT l_oid
+            FROM 
+                pg_proc 
+            WHERE 
+                proname = p_object_name
+                AND pronamespace = l_schema_oid;
+        END IF;
+    END IF;
+
+    RETURN l_oid;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        RAISE EXCEPTION '% % does not exist in schema %', p_object_type, p_object_name, p_schema;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_object_oid (text, text, text) IS 'This function returns oid of given object';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_object_oid FROM PUBLIC;
+
+----
+-- DBMS_METADATA.GET_SCHEMA_OID
+----
+CREATE OR REPLACE FUNCTION dbms_metadata.get_schema_oid(p_schema text)
+RETURNS oid AS $$
+DECLARE
+    l_schema_oid oid;
+BEGIN
+    SELECT
+        oid
+    INTO STRICT l_schema_oid
+    FROM
+        pg_namespace
+    WHERE
+        nspname = p_schema;
+        
+    RETURN l_schema_oid;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        RAISE EXCEPTION 'Schema % does not exist', p_schema;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION dbms_metadata.get_schema_oid (text) IS 'This function returns oid of given schema';
+
+REVOKE ALL ON FUNCTION dbms_metadata.get_schema_oid FROM PUBLIC;
+
+------------------------------------------------------------------------------
+-- GRANTS
+------------------------------------------------------------------------------
+GRANT USAGE ON SCHEMA dbms_metadata TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA dbms_metadata TO PUBLIC;

--- a/contrib/pg_dbms_metadata/test/expected/00_init.out
+++ b/contrib/pg_dbms_metadata/test/expected/00_init.out
@@ -1,0 +1,147 @@
+/*
+ * Must be executed before all regression test.
+ */
+CREATE EXTENSION pg_dbms_metadata;
+-- Create all objects used in the regression tests
+CREATE SCHEMA gdmmm;
+----
+-- Table 1
+----
+CREATE TABLE gdmmm.table_all (
+    a serial PRIMARY KEY,   -- dependent sequence test
+    b int NOT NULL, -- NOT NULL test
+    c varchar(20) DEFAULT 'def',    -- default value test
+    d int
+) WITH (
+    autovacuum_enabled = false,            
+    fillfactor = 70,           
+    autovacuum_vacuum_scale_factor = 0.2,  
+    autovacuum_analyze_scale_factor = 0.1  
+)DISTRIBUTE BY SHARD (a);
+COMMENT ON TABLE gdmmm.table_all IS 'This is a comment for the table.';
+COMMENT ON COLUMN gdmmm.table_all.a IS 'This is a comment for the column.';
+COMMENT ON COLUMN gdmmm.table_all.b IS 'This is a comment for the column.';
+CREATE INDEX perf_index ON gdmmm.table_all (c);
+----
+-- Table 2
+----
+CREATE TABLE gdmmm.table_all_child (
+    id int,
+    CONSTRAINT "Fk_customer" FOREIGN KEY (id) REFERENCES gdmmm.table_all (a)
+)DISTRIBUTE BY SHARD (id);
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE(id);
+----
+-- Partition Table
+----
+CREATE TABLE IF NOT EXISTS gdmmm.sales
+(
+    sale_id integer NOT NULL,
+    "Sale date" date NOT NULL,
+    amount numeric,
+    CONSTRAINT sales_pkey PRIMARY KEY (sale_id, "Sale date")
+) PARTITION BY RANGE ("Sale date");
+CREATE TABLE gdmmm.sales_february PARTITION OF gdmmm.sales
+    FOR VALUES FROM ('2023-02-01') TO ('2023-03-01');
+CREATE TABLE gdmmm.sales_january PARTITION OF gdmmm.sales
+    FOR VALUES FROM ('2023-01-01') TO ('2023-02-01');
+----
+-- Unlogged Table
+----
+CREATE UNLOGGED TABLE gdmmm."Sample unlogged table" (
+    id serial PRIMARY KEY,
+    "name of customer" varchar(255),    -- quote ident test
+    "Age" integer,
+    "Birth_Date" DATE,
+    CONSTRAINT "check" CHECK ("Birth_Date" > '1900-01-01')
+);
+COMMENT ON COLUMN gdmmm."Sample unlogged table"."name of customer" IS 'This is a comment for the column.';
+CREATE INDEX "Gin_Index_Name" ON gdmmm."Sample unlogged table" USING spgist ("name of customer");
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE(id,"Age"); 
+----
+-- View 1
+----
+CREATE OR REPLACE VIEW gdmmm.gg_d AS
+SELECT
+    table_all.a
+FROM
+    gdmmm.table_all;
+----
+-- View 2
+----
+CREATE OR REPLACE VIEW gdmmm."Global fines" AS
+SELECT
+    "Sample unlogged table"."name of customer"
+FROM
+    gdmmm."Sample unlogged table";
+----
+-- Trigger 1
+----
+CREATE OR REPLACE FUNCTION gdmmm.double_salary ()
+    RETURNS TRIGGER
+    AS $$
+BEGIN
+    NEW.b = NEW.b * 2;
+    RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+CREATE TRIGGER "order"
+    BEFORE INSERT ON gdmmm.table_all
+    FOR EACH ROW
+    EXECUTE PROCEDURE gdmmm.double_salary ();
+----
+-- Trigger 2
+----
+CREATE OR REPLACE FUNCTION gdmmm.edit_text()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.c = NEW.c || 'edit';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER trigger_edit_text
+BEFORE INSERT ON gdmmm.table_all
+FOR EACH ROW
+EXECUTE PROCEDURE gdmmm.edit_text();
+----
+-- Sequence
+----
+CREATE SEQUENCE IF NOT EXISTS gdmmm."attach Line"
+INCREMENT 1 START 1
+MINVALUE 1
+MAXVALUE 9223372036854775807
+CACHE 1;
+----
+-- Type 1
+----
+CREATE TYPE gdmmm.location AS (
+    lat double precision,
+    lon double precision
+);
+----
+-- Type 2
+----
+CREATE TYPE gdmmm."Address" AS (
+    "City" character varying,
+    loc gdmmm.location,
+    pin bigint
+);
+----
+-- Function
+----
+CREATE OR REPLACE FUNCTION gdmmm."Merge objects" ("First_val" text, actual_finder gdmmm."Address")
+    RETURNS text
+    LANGUAGE 'plpgsql'
+    COST 100 VOLATILE PARALLEL UNSAFE
+    AS $BODY$
+BEGIN
+    RETURN "First_val" || actual_finder."City";
+END
+$BODY$;
+----
+-- Users and Roles
+----
+CREATE ROLE "Dbms_Metadata_test_user2873487";
+CREATE ROLE dbms_metadata_test_user8987987;
+CREATE USER "dbms_metadata_test_User565667";
+GRANT "Dbms_Metadata_test_user2873487", dbms_metadata_test_user8987987 TO "dbms_metadata_test_User565667";

--- a/contrib/pg_dbms_metadata/test/expected/01_get_ddl.out
+++ b/contrib/pg_dbms_metadata/test/expected/01_get_ddl.out
@@ -1,0 +1,316 @@
+-- Test tables DDL export
+\i test/sql/get_ddl/get_ddl_table.sql
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm') from dual;
+                                                                                                                                                                 get_ddl                                                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE TABLE gdmmm.table_all (a integer DEFAULT nextval('gdmmm.table_all_a_seq'::regclass)NOT NULL,b integer NOT NULL,c character varying(20) DEFAULT 'def'::character varying,d integer ) WITH (autovacuum_enabled=false,fillfactor=70,autovacuum_vacuum_scale_factor=0.2,autovacuum_analyze_scale_factor=0.1) DISTRIBUTE BY SHARD(a) to GROUP default_group;
+
+-- Table comments
+COMMENT ON TABLE gdmmm.table_all IS 'This is a comment for the table.';
+
+-- Column comments
+COMMENT ON COLUMN gdmmm.table_all.a IS 'This is a comment for the column.';
+COMMENT ON COLUMN gdmmm.table_all.b IS 'This is a comment for the column.';
+
+
+-- Constraints
+ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_pkey PRIMARY KEY (a);
+
+
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TABLE','table_all_child','gdmmm') from dual;
+                                                    get_ddl                                                    
+---------------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE TABLE gdmmm.table_all_child (id integer NOT NULL) DISTRIBUTE BY SHARD(id) to GROUP default_group;
+
+-- Constraints
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE (id);
+
+
+
+-- Referential constraints
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT "Fk_customer" FOREIGN KEY (id) REFERENCES gdmmm.table_all(a);
+
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TABLE','sales','gdmmm') from dual;
+                                                             get_ddl                                                             
+---------------------------------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE TABLE gdmmm.sales (sale_id integer NOT NULL,"Sale date" date NOT NULL,amount numeric ) PARTITION BY RANGE("Sale date") DISTRIBUTE BY SHARD(sale_id) to GROUP default_group;
+
+-- Constraints
+ALTER TABLE gdmmm.sales ADD CONSTRAINT sales_pkey PRIMARY KEY (sale_id, "Sale date");
+                                                                                                                              +
+ 
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TABLE','Sample unlogged table','gdmmm') from dual;
+                                                                                                         get_ddl                                                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE UNLOGGED TABLE gdmmm."Sample unlogged table" (id integer DEFAULT nextval('gdmmm."Sample unlogged table_id_seq"'::regclass)NOT NULL,"name of customer" character varying(255) ,"Age" integer ,"Birth_Date" date ) DISTRIBUTE BY SHARD(id) to GROUP default_group;
+
+-- Column comments
+COMMENT ON COLUMN gdmmm."Sample unlogged table"."name of customer" IS 'This is a comment for the column.';
+
+
+-- Constraints
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Sample unlogged table_pkey" PRIMARY KEY (id);
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE (id, "Age");
+
+ALTER TABLE gdmmm."Sample unlogged table" ADD CHECK (("Birth_Date" > '1900-01-01'::date));
+ 
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_ddl('TABLE','table_all') from dual;
+                                                                                                                                                              get_ddl                                                                                                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE TABLE gdmmm.table_all (a integer DEFAULT nextval('table_all_a_seq'::regclass)NOT NULL,b integer NOT NULL,c character varying(20) DEFAULT 'def'::character varying,d integer ) WITH (autovacuum_enabled=false,fillfactor=70,autovacuum_vacuum_scale_factor=0.2,autovacuum_analyze_scale_factor=0.1) DISTRIBUTE BY SHARD(a) to GROUP default_group;
+
+-- Table comments
+COMMENT ON TABLE gdmmm.table_all IS 'This is a comment for the table.';
+
+-- Column comments
+COMMENT ON COLUMN gdmmm.table_all.a IS 'This is a comment for the column.';
+COMMENT ON COLUMN gdmmm.table_all.b IS 'This is a comment for the column.';
+
+
+-- Constraints
+ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_pkey PRIMARY KEY (a);
+
+
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TABLE','table_all_child') from dual;
+                                                 get_ddl                                                 
+---------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE TABLE gdmmm.table_all_child (id integer NOT NULL) DISTRIBUTE BY SHARD(id) to GROUP default_group;
+
+-- Constraints
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE (id);
+
+
+
+-- Referential constraints
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT "Fk_customer" FOREIGN KEY (id) REFERENCES table_all(a);
+
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TABLE','sales') from dual;
+                                                             get_ddl                                                             
+---------------------------------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE TABLE gdmmm.sales (sale_id integer NOT NULL,"Sale date" date NOT NULL,amount numeric ) PARTITION BY RANGE("Sale date") DISTRIBUTE BY SHARD(sale_id) to GROUP default_group;
+
+-- Constraints
+ALTER TABLE gdmmm.sales ADD CONSTRAINT sales_pkey PRIMARY KEY (sale_id, "Sale date");
+
+
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TABLE','Sample unlogged table') from dual;
+                                                                                                      get_ddl                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- Table definition
+CREATE UNLOGGED TABLE gdmmm."Sample unlogged table" (id integer DEFAULT nextval('"Sample unlogged table_id_seq"'::regclass)NOT NULL,"name of customer" character varying(255) ,"Age" integer ,"Birth_Date" date ) DISTRIBUTE BY SHARD(id) to GROUP default_group;
+
+-- Column comments
+COMMENT ON COLUMN gdmmm."Sample unlogged table"."name of customer" IS 'This is a comment for the column.';
+
+
+-- Constraints
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Sample unlogged table_pkey" PRIMARY KEY (id);
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE (id, "Age");
+
+ALTER TABLE gdmmm."Sample unlogged table" ADD CHECK (("Birth_Date" > '1900-01-01'::date));
+
+(1 row)
+
+-- Test views DDL export
+\i test/sql/get_ddl/get_ddl_view.sql
+SELECT dbms_metadata.get_ddl('VIEW','gg_d','gdmmm') from dual;
+               get_ddl               
+-------------------------------------
+CREATE VIEW gdmmm.gg_d AS  SELECT table_all.a
+   FROM table_all;
+(1 row)
+
+SELECT dbms_metadata.get_ddl('VIEW','Global fines','gdmmm') from dual;
+                            get_ddl                             
+----------------------------------------------------------------
+CREATE VIEW gdmmm."Global fines" AS  SELECT "Sample unlogged table"."name of customer"
+   FROM "Sample unlogged table";
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_ddl('VIEW','gg_d') from dual;
+               get_ddl               
+-------------------------------------
+CREATE VIEW gdmmm.gg_d AS  SELECT table_all.a
+   FROM table_all;
+(1 row)
+
+SELECT dbms_metadata.get_ddl('VIEW','Global fines') from dual;
+                            get_ddl                             
+----------------------------------------------------------------
+CREATE VIEW gdmmm."Global fines" AS  SELECT "Sample unlogged table"."name of customer"
+   FROM "Sample unlogged table";
+(1 row)
+
+-- Test sequences DDL export
+\i test/sql/get_ddl/get_ddl_sequence.sql
+SELECT dbms_metadata.get_ddl('SEQUENCE','attach Line','gdmmm') from dual;
+                                                         get_ddl                                                          
+--------------------------------------------------------------------------------------------------------------------------
+CREATE SEQUENCE gdmmm."attach Line" START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 CACHE 1 NO CYCLE;
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_ddl('SEQUENCE','attach Line') from dual;
+                                                         get_ddl                                                          
+--------------------------------------------------------------------------------------------------------------------------
+CREATE SEQUENCE gdmmm."attach Line" START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 CACHE 1 NO CYCLE;
+(1 row)
+
+-- Test routines DDL export
+\i test/sql/get_ddl/get_ddl_routine.sql
+SELECT dbms_metadata.get_ddl('FUNCTION','Merge objects','gdmmm') from dual;
+                                           get_ddl                                           
+---------------------------------------------------------------------------------------------
+ CREATE OR REPLACE FUNCTION gdmmm."Merge objects"("First_val" text, actual_finder "Address")+
+  RETURNS text                                                                              +
+  LANGUAGE plpgsql                                                                          +
+ AS $function$                                                                              +
+ BEGIN                                                                                      +
+     RETURN "First_val" || actual_finder."City";                                            +
+ END                                                                                        +
+ $function$                                                                                 +
+ 
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_ddl('FUNCTION','Merge objects') from dual;
+                                           get_ddl                                           
+---------------------------------------------------------------------------------------------
+ CREATE OR REPLACE FUNCTION gdmmm."Merge objects"("First_val" text, actual_finder "Address")+
+  RETURNS text                                                                              +
+  LANGUAGE plpgsql                                                                          +
+ AS $function$                                                                              +
+ BEGIN                                                                                      +
+     RETURN "First_val" || actual_finder."City";                                            +
+ END                                                                                        +
+ $function$                                                                                 +
+ 
+(1 row)
+
+-- Test triggers DDL export
+\i test/sql/get_ddl/get_ddl_trigger.sql
+SELECT dbms_metadata.get_ddl('TRIGGER','order','gdmmm') from dual;
+                                                get_ddl                                                
+-------------------------------------------------------------------------------------------------------
+CREATE TRIGGER "order" BEFORE INSERT ON table_all FOR EACH ROW EXECUTE PROCEDURE double_salary();
+(1 row)
+
+-- Test index and constraint DDL export
+\i test/sql/get_ddl/get_ddl_index_constraint.sql
+SELECT dbms_metadata.get_ddl('INDEX','perf_index','gdmmm') from dual;
+                          get_ddl                           
+------------------------------------------------------------
+CREATE INDEX perf_index ON table_all USING btree (c);
+(1 row)
+
+SELECT dbms_metadata.get_ddl('INDEX','Gin_Index_Name','gdmmm') from dual;
+                                             get_ddl                                              
+--------------------------------------------------------------------------------------------------
+CREATE INDEX "Gin_Index_Name" ON "Sample unlogged table" USING spgist ("name of customer");
+(1 row)
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','child_uniq','gdmmm') from dual;
+                                 get_ddl                                 
+-------------------------------------------------------------------------
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE (id);
+(1 row)
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','Unique age','gdmmm') from dual;
+                                       get_ddl                                        
+--------------------------------------------------------------------------------------
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE (id, "Age");
+(1 row)
+
+SELECT dbms_metadata.get_ddl('CHECK_CONSTRAINT','check','gdmmm') from dual;
+                                                  get_ddl                                                   
+------------------------------------------------------------------------------------------------------------
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "check" CHECK ("Birth_Date" > '1900-01-01'::date);
+(1 row)
+
+SELECT dbms_metadata.get_ddl('REF_CONSTRAINT','Fk_customer','gdmmm') from dual;
+                                                 get_ddl                                                 
+---------------------------------------------------------------------------------------------------------
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT "Fk_customer" FOREIGN KEY (id) REFERENCES table_all(a);
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_ddl('INDEX','perf_index') from dual;
+                          get_ddl                           
+------------------------------------------------------------
+CREATE INDEX perf_index ON table_all USING btree (c);
+(1 row)
+
+SELECT dbms_metadata.get_ddl('INDEX','Gin_Index_Name') from dual;
+                                             get_ddl                                              
+--------------------------------------------------------------------------------------------------
+CREATE INDEX "Gin_Index_Name" ON "Sample unlogged table" USING spgist ("name of customer");
+(1 row)
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','child_uniq') from dual;
+                                 get_ddl                                 
+-------------------------------------------------------------------------
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE (id);
+(1 row)
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','Unique age') from dual;
+                                       get_ddl                                        
+--------------------------------------------------------------------------------------
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE (id, "Age");
+(1 row)
+
+-- Test type DDL export
+\i test/sql/get_ddl/get_ddl_type.sql
+SELECT dbms_metadata.get_ddl('TYPE','Address','gdmmm') from dual;
+                                       get_ddl                                        
+--------------------------------------------------------------------------------------
+CREATE TYPE gdmmm."Address" AS ( "City" character varying, loc location, pin bigint);
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TYPE','location','gdmmm') from dual;
+                                   get_ddl                                   
+-----------------------------------------------------------------------------
+CREATE TYPE gdmmm.location AS ( lat double precision, lon double precision);
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_ddl('TYPE','Address') from dual;
+                                       get_ddl                                        
+--------------------------------------------------------------------------------------
+CREATE TYPE gdmmm."Address" AS ( "City" character varying, loc location, pin bigint);
+(1 row)
+
+SELECT dbms_metadata.get_ddl('TYPE','location') from dual;
+                                   get_ddl                                   
+-----------------------------------------------------------------------------
+CREATE TYPE gdmmm.location AS ( lat double precision, lon double precision);
+(1 row)
+

--- a/contrib/pg_dbms_metadata/test/expected/02_get_dependent_ddl.out
+++ b/contrib/pg_dbms_metadata/test/expected/02_get_dependent_ddl.out
@@ -1,0 +1,139 @@
+-- test for retrieving dependent index constraint ddl
+\i test/sql/get_dependent_ddl/get_dependent_ddl_index_constraint.sql
+SELECT dbms_metadata.get_dependent_ddl('INDEX','table_all','gdmmm') from dual;
+                     get_dependent_ddl                      
+------------------------------------------------------------
+ CREATE INDEX perf_index ON gdmmm.table_all USING btree (c);+
+ 
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('INDEX','Sample unlogged table','gdmmm') from dual;
+                                        get_dependent_ddl                                         
+--------------------------------------------------------------------------------------------------
+ CREATE INDEX "Gin_Index_Name" ON gdmmm."Sample unlogged table" USING spgist ("name of customer");+
+
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all','gdmmm') from dual;
+                             get_dependent_ddl                             
+---------------------------------------------------------------------------
+ ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_pkey PRIMARY KEY (a);+
+                                                                           +
+ 
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all_child','gdmmm') from dual;
+                            get_dependent_ddl                            
+-------------------------------------------------------------------------
+ ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE (id);+
+                                                                         +
+ 
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','Sample unlogged table','gdmmm') from dual;
+                                           get_dependent_ddl                                            
+--------------------------------------------------------------------------------------------------------
+ ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Sample unlogged table_pkey" PRIMARY KEY (id);+
+ ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE (id, "Age");              +
+                                                                                                        +
+ ALTER TABLE gdmmm."Sample unlogged table" ADD CHECK (("Birth_Date" > '1900-01-01'::date));             +
+
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('REF_CONSTRAINT','table_all_child','gdmmm') from dual;
+                                               get_dependent_ddl                                               
+---------------------------------------------------------------------------------------------------------------
+ ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT "Fk_customer" FOREIGN KEY (id) REFERENCES gdmmm.table_all(a);+
+ 
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_dependent_ddl('INDEX','table_all') from dual;
+                  get_dependent_ddl                   
+------------------------------------------------------
+ CREATE INDEX perf_index ON table_all USING btree (c);+
+ 
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('INDEX','Sample unlogged table') from dual;
+                                     get_dependent_ddl                                      
+--------------------------------------------------------------------------------------------
+ CREATE INDEX "Gin_Index_Name" ON "Sample unlogged table" USING spgist ("name of customer");+
+
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all') from dual;
+                             get_dependent_ddl                             
+---------------------------------------------------------------------------
+ ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_pkey PRIMARY KEY (a);+
+                                                                           +
+
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all_child') from dual;
+                            get_dependent_ddl                            
+-------------------------------------------------------------------------
+ ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE (id);+
+                                                                         +
+
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','Sample unlogged table') from dual;
+                                           get_dependent_ddl                                            
+--------------------------------------------------------------------------------------------------------
+ ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Sample unlogged table_pkey" PRIMARY KEY (id);+
+ ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE (id, "Age");              +
+                                                                                                        +
+ ALTER TABLE gdmmm."Sample unlogged table" ADD CHECK (("Birth_Date" > '1900-01-01'::date));             +
+ 
+(1 row)
+
+-- test for retrieving dependent sequence ddl
+\i test/sql/get_dependent_ddl/get_dependent_ddl_sequence.sql
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','table_all','gdmmm') from dual;
+                                                 get_dependent_ddl                                                 
+-------------------------------------------------------------------------------------------------------------------
+ CREATE SEQUENCE gdmmm.table_all_a_seq START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 NO CYCLE+
+                                                                                                                  +
+ 
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','Sample unlogged table','gdmmm') from dual;
+                                                        get_dependent_ddl                                                         
+----------------------------------------------------------------------------------------------------------------------------------
+ CREATE SEQUENCE gdmmm."Sample unlogged table_id_seq" START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 NO CYCLE+
+                                                                                                                                 +
+ 
+(1 row)
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','table_all') from dual;
+                                                 get_dependent_ddl                                                 
+-------------------------------------------------------------------------------------------------------------------
+ CREATE SEQUENCE gdmmm.table_all_a_seq START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 NO CYCLE+
+                                                                                                                  +
+ 
+(1 row)
+
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','Sample unlogged table') from dual;
+                                                        get_dependent_ddl                                                         
+----------------------------------------------------------------------------------------------------------------------------------
+ CREATE SEQUENCE gdmmm."Sample unlogged table_id_seq" START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 1 NO CYCLE+
+                                                                                                                                 +
+ 
+(1 row)
+
+-- test for retrieving dependent trigger ddl
+\i test/sql/get_dependent_ddl/get_dependent_ddl_trigger.sql
+SELECT dbms_metadata.get_dependent_ddl('TRIGGER','table_all','gdmmm') from dual;
+                                              get_dependent_ddl                                              
+-------------------------------------------------------------------------------------------------------------
+ CREATE TRIGGER "order" BEFORE INSERT ON table_all FOR EACH ROW EXECUTE PROCEDURE double_salary();      +
+                                                                                                        +
+ CREATE TRIGGER trigger_edit_text BEFORE INSERT ON table_all FOR EACH ROW EXECUTE PROCEDURE edit_text();+
+                                                                                                        +
+ 
+(1 row)
+

--- a/contrib/pg_dbms_metadata/test/expected/03_get_granted_ddl.out
+++ b/contrib/pg_dbms_metadata/test/expected/03_get_granted_ddl.out
@@ -1,0 +1,10 @@
+-- test for retrieving granted roles ddl
+\i test/sql/get_granted_ddl/get_granted_ddl_role.sql
+SELECT dbms_metadata.get_granted_ddl('ROLE_GRANT','dbms_metadata_test_User565667') from dual;
+                              get_granted_ddl                              
+---------------------------------------------------------------------------
+ GRANT "Dbms_Metadata_test_user2873487" TO "dbms_metadata_test_User565667"+
+ GRANT dbms_metadata_test_user8987987 TO "dbms_metadata_test_User565667"  +
+ 
+(1 row)
+

--- a/contrib/pg_dbms_metadata/test/expected/04_set_transform_param.out
+++ b/contrib/pg_dbms_metadata/test/expected/04_set_transform_param.out
@@ -1,0 +1,74 @@
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm') from dual;
+                                                                                                                                                                 get_ddl                                                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ -- Table definition                                                                                                                                                                                       
+                                                                                                                                              +
+ CREATE TABLE gdmmm.table_all (a integer DEFAULT nextval('table_all_a_seq'::regclass)NOT NULL,b integer NOT NULL,c character varying(20) DEFAULT 'def'::character varying,d integer ) WITH (autovacuum_enab
+led=false,fillfactor=70,autovacuum_vacuum_scale_factor=0.2,autovacuum_analyze_scale_factor=0.1) DISTRIBUTE BY SHARD(a) to GROUP default_group;+
+                                                                                                                                       +
+ -- Table comments                                                                                                                                                                                         
+                                                                                                                                              +
+ COMMENT ON TABLE gdmmm.table_all IS 'This is a comment for the table.';                                                                                                                                   
+                                                                                                                                           +
+ -- Column comments                                                                                                                                                                                        
+                                                                                                                                              +
+ COMMENT ON COLUMN gdmmm.table_all.a IS 'This is a comment for the column.';                                                                                                                               
+                                                                                                                                              +
+ COMMENT ON COLUMN gdmmm.table_all.b IS 'This is a comment for the column.';                                                                                                                               
+                                                                                                                                             +
+ -- Constraints                                                                                                                                                                                            
+                                                                                                                                              +
+ ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_pkey PRIMARY KEY (a);                                                                                                                                
+                                                                                                                                              +
+                                                                                                                                                                                                           
+                                                                                                                                              +
+(1 row)
+
+
+SELECT dbms_metadata.set_transform_param('SQLTERMINATOR',false);
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm');
+                                                                                                                                                                  get_ddl                                                                                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ -- Table definition                                                                                                                                                                                       
+                                                                                                                                             +
+ CREATE TABLE gdmmm.table_all (a integer DEFAULT nextval('table_all_a_seq'::regclass)NOT NULL,b integer NOT NULL,c character varying(20) DEFAULT 'def'::character varying,d integer ) WITH (autovacuum_enab
+led=false,fillfactor=70,autovacuum_vacuum_scale_factor=0.2,autovacuum_analyze_scale_factor=0.1) DISTRIBUTE BY SHARD(a) to GROUP default_group+
+                                                                                                                                                                                                                                                                                                                                                    +
+ -- Table comments                                                                                                                                                                                         
+                                                                                                                                             +
+ COMMENT ON TABLE gdmmm.table_all IS 'This is a comment for the table.'                                                                                                                                    
+                                                                                                                                            +
+ -- Column comments                                                                                                                                                                                        
+                                                                                                                                             +
+ COMMENT ON COLUMN gdmmm.table_all.a IS 'This is a comment for the column.'                                                                                                                                
+                                                                                                                                             +
+ COMMENT ON COLUMN gdmmm.table_all.b IS 'This is a comment for the column.'                                                                                                                                
+                                                                                                                                            +
+ -- Constraints                                                                                                                                                                                            
+                                                                                                                                             +
+ ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_pkey PRIMARY KEY (a)                                                                                                                                 
+                                                                                                                                             +     
+(1 row)
+
+SELECT dbms_metadata.set_transform_param('DEFAULT');
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm');
+                                                                                                                                                                 get_ddl                                                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ -- Table definition                                                                                                                                                                                                                                                                                                                     +
+ CREATE TABLE gdmmm.table_all (a integer DEFAULT nextval('gdmmm.table_all_a_seq'::regclass) NOT NULL,b integer  NOT NULL,c character varying(20) DEFAULT 'def'::character varying,d integer ) WITH (autovacuum_enabled=false,fillfactor=70,toast_tuple_target=200,autovacuum_vacuum_scale_factor=0.2,autovacuum_analyze_scale_factor=0.1)+
+                                                                                                                                                                                                                                                                                                                                         +
+ -- Table comments                                                                                                                                                                                                                                                                                                                       +
+ COMMENT ON TABLE gdmmm.table_all IS 'This is a comment for the table.'                                                                                                                                                                                                                                                                  +
+                                                                                                                                                                                                                                                                                                                                         +
+ -- Column comments                                                                                                                                                                                                                                                                                                                      +
+ COMMENT ON COLUMN gdmmm.table_all.a IS 'This is a comment for the column.'                                                                                                                                                                                                                                                              +
+ COMMENT ON COLUMN gdmmm.table_all.b IS 'This is a comment for the column.'                                                                                                                                                                                                                                                              +
+                                                                                                                                                                                                                                                                                                                                         +
+                                                                                                                                                                                                                                                                                                                                         +
+ -- Constraints                                                                                                                                                                                                                                                                                                                          +
+ ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_pkey PRIMARY KEY (a)                                                                                                                                                                                                                                                               +
+ ALTER TABLE gdmmm.table_all ADD CONSTRAINT table_all_d_key UNIQUE (d)                                                                                                                                                                                                                                                                   +
+                                                                                                                                                                                                                                                                                                                                         +
+ 
+(1 row)
+

--- a/contrib/pg_dbms_metadata/test/expected/05_clean_up.out
+++ b/contrib/pg_dbms_metadata/test/expected/05_clean_up.out
@@ -1,0 +1,3 @@
+DROP ROLE "dbms_metadata_test_User565667";
+DROP ROLE "Dbms_Metadata_test_user2873487";
+DROP ROLE dbms_metadata_test_user8987987;

--- a/contrib/pg_dbms_metadata/test/sql/00_init.sql
+++ b/contrib/pg_dbms_metadata/test/sql/00_init.sql
@@ -1,0 +1,171 @@
+/*
+ * Must be executed before all regression test.
+ */
+CREATE EXTENSION pg_dbms_metadata;
+-- Create all objects used in the regression tests
+CREATE SCHEMA gdmmm;
+----
+-- Table 1
+----
+CREATE TABLE gdmmm.table_all (
+    a serial PRIMARY KEY,   -- dependent sequence test
+    b int NOT NULL, -- NOT NULL test
+    c varchar(20) DEFAULT 'def',    -- default value test
+    d int
+) WITH (
+    autovacuum_enabled = false,            
+    fillfactor = 70,            
+    autovacuum_vacuum_scale_factor = 0.2,  
+    autovacuum_analyze_scale_factor = 0.1  
+)DISTRIBUTE BY SHARD (a);
+
+COMMENT ON TABLE gdmmm.table_all IS 'This is a comment for the table.';
+
+COMMENT ON COLUMN gdmmm.table_all.a IS 'This is a comment for the column.';
+
+COMMENT ON COLUMN gdmmm.table_all.b IS 'This is a comment for the column.';
+
+CREATE INDEX perf_index ON gdmmm.table_all (c);
+
+----
+-- Table 2
+----
+CREATE TABLE gdmmm.table_all_child (
+    id int,
+    CONSTRAINT "Fk_customer" FOREIGN KEY (id) REFERENCES gdmmm.table_all (a)
+)DISTRIBUTE BY SHARD (id);
+
+ALTER TABLE gdmmm.table_all_child ADD CONSTRAINT child_uniq UNIQUE(id);
+
+----
+-- Partition Table
+----
+CREATE TABLE IF NOT EXISTS gdmmm.sales
+(
+    sale_id integer NOT NULL,
+    "Sale date" date NOT NULL,
+    amount numeric,
+    CONSTRAINT sales_pkey PRIMARY KEY (sale_id, "Sale date")
+) PARTITION BY RANGE ("Sale date");
+
+CREATE TABLE gdmmm.sales_february PARTITION OF gdmmm.sales
+    FOR VALUES FROM ('2023-02-01') TO ('2023-03-01');
+
+CREATE TABLE gdmmm.sales_january PARTITION OF gdmmm.sales
+    FOR VALUES FROM ('2023-01-01') TO ('2023-02-01');
+
+----
+-- Unlogged Table
+----
+CREATE UNLOGGED TABLE gdmmm."Sample unlogged table" (
+    id serial PRIMARY KEY,
+    "name of customer" varchar(255),    -- quote ident test
+    "Age" integer,
+    "Birth_Date" DATE,
+    CONSTRAINT "check" CHECK ("Birth_Date" > '1900-01-01')
+);
+
+COMMENT ON COLUMN gdmmm."Sample unlogged table"."name of customer" IS 'This is a comment for the column.';
+
+CREATE INDEX "Gin_Index_Name" ON gdmmm."Sample unlogged table" USING spgist ("name of customer");
+
+ALTER TABLE gdmmm."Sample unlogged table" ADD CONSTRAINT "Unique age" UNIQUE(id,"Age"); 
+
+----
+-- View 1
+----
+CREATE OR REPLACE VIEW gdmmm.gg_d AS
+SELECT
+    table_all.a
+FROM
+    gdmmm.table_all;
+
+----
+-- View 2
+----
+CREATE OR REPLACE VIEW gdmmm."Global fines" AS
+SELECT
+    "Sample unlogged table"."name of customer"
+FROM
+    gdmmm."Sample unlogged table";
+
+----
+-- Trigger 1
+----
+CREATE OR REPLACE FUNCTION gdmmm.double_salary ()
+    RETURNS TRIGGER
+    AS $$
+BEGIN
+    NEW.b = NEW.b * 2;
+    RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER "order"
+    BEFORE INSERT ON gdmmm.table_all
+    FOR EACH ROW
+    EXECUTE PROCEDURE gdmmm.double_salary ();
+
+----
+-- Trigger 2
+----
+CREATE OR REPLACE FUNCTION gdmmm.edit_text()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.c = NEW.c || 'edit';
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_edit_text
+BEFORE INSERT ON gdmmm.table_all
+FOR EACH ROW
+EXECUTE PROCEDURE gdmmm.edit_text();
+
+----
+-- Sequence
+----
+CREATE SEQUENCE IF NOT EXISTS gdmmm."attach Line"
+INCREMENT 1 START 1
+MINVALUE 1
+MAXVALUE 9223372036854775807
+CACHE 1;
+
+----
+-- Type 1
+----
+CREATE TYPE gdmmm.location AS (
+    lat double precision,
+    lon double precision
+);
+
+----
+-- Type 2
+----
+CREATE TYPE gdmmm."Address" AS (
+    "City" character varying,
+    loc gdmmm.location,
+    pin bigint
+);
+
+----
+-- Function
+----
+CREATE OR REPLACE FUNCTION gdmmm."Merge objects" ("First_val" text, actual_finder gdmmm."Address")
+    RETURNS text
+    LANGUAGE 'plpgsql'
+    COST 100 VOLATILE PARALLEL UNSAFE
+    AS $BODY$
+BEGIN
+    RETURN "First_val" || actual_finder."City";
+END
+$BODY$;
+
+----
+-- Users and Roles
+----
+CREATE ROLE "Dbms_Metadata_test_user2873487";
+CREATE ROLE dbms_metadata_test_user8987987;
+CREATE USER "dbms_metadata_test_User565667";
+GRANT "Dbms_Metadata_test_user2873487", dbms_metadata_test_user8987987 TO "dbms_metadata_test_User565667";

--- a/contrib/pg_dbms_metadata/test/sql/01_get_ddl.sql
+++ b/contrib/pg_dbms_metadata/test/sql/01_get_ddl.sql
@@ -1,0 +1,21 @@
+-- Test tables DDL export
+\i test/sql/get_ddl/get_ddl_table.sql
+
+-- Test views DDL export
+\i test/sql/get_ddl/get_ddl_view.sql
+
+-- Test sequences DDL export
+\i test/sql/get_ddl/get_ddl_sequence.sql
+
+-- Test routines DDL export
+\i test/sql/get_ddl/get_ddl_routine.sql
+
+-- Test triggers DDL export
+\i test/sql/get_ddl/get_ddl_trigger.sql
+
+-- Test index and constraint DDL export
+\i test/sql/get_ddl/get_ddl_index_constraint.sql
+
+-- Test type DDL export
+\i test/sql/get_ddl/get_ddl_type.sql
+

--- a/contrib/pg_dbms_metadata/test/sql/02_get_dependent_ddl.sql
+++ b/contrib/pg_dbms_metadata/test/sql/02_get_dependent_ddl.sql
@@ -1,0 +1,9 @@
+-- test for retrieving dependent index constraint ddl
+\i test/sql/get_dependent_ddl/get_dependent_ddl_index_constraint.sql
+
+-- test for retrieving dependent sequence ddl
+\i test/sql/get_dependent_ddl/get_dependent_ddl_sequence.sql
+
+-- test for retrieving dependent trigger ddl
+\i test/sql/get_dependent_ddl/get_dependent_ddl_trigger.sql
+

--- a/contrib/pg_dbms_metadata/test/sql/03_get_granted_ddl.sql
+++ b/contrib/pg_dbms_metadata/test/sql/03_get_granted_ddl.sql
@@ -1,0 +1,3 @@
+-- test for retrieving granted roles ddl
+\i test/sql/get_granted_ddl/get_granted_ddl_role.sql
+

--- a/contrib/pg_dbms_metadata/test/sql/04_set_transform_param.sql
+++ b/contrib/pg_dbms_metadata/test/sql/04_set_transform_param.sql
@@ -1,0 +1,5 @@
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm');
+SELECT dbms_metadata.set_transform_param('SQLTERMINATOR',false);
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm');
+SELECT dbms_metadata.set_transform_param('DEFAULT');
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm');

--- a/contrib/pg_dbms_metadata/test/sql/05_clean_up.sql
+++ b/contrib/pg_dbms_metadata/test/sql/05_clean_up.sql
@@ -1,0 +1,3 @@
+DROP ROLE "dbms_metadata_test_User565667";
+DROP ROLE "Dbms_Metadata_test_user2873487";
+DROP ROLE dbms_metadata_test_user8987987;

--- a/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_index_constraint.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_index_constraint.sql
@@ -1,0 +1,22 @@
+SELECT dbms_metadata.get_ddl('INDEX','perf_index','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('INDEX','Gin_Index_Name','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','child_uniq','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','Unique age','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('CHECK_CONSTRAINT','check','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('REF_CONSTRAINT','Fk_customer','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_ddl('INDEX','perf_index') from dual;
+
+SELECT dbms_metadata.get_ddl('INDEX','Gin_Index_Name') from dual;
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','child_uniq') from dual;
+
+SELECT dbms_metadata.get_ddl('CONSTRAINT','Unique age') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_routine.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_routine.sql
@@ -1,0 +1,6 @@
+SELECT dbms_metadata.get_ddl('FUNCTION','Merge objects','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_ddl('FUNCTION','Merge objects') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_sequence.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_sequence.sql
@@ -1,0 +1,6 @@
+SELECT dbms_metadata.get_ddl('SEQUENCE','attach Line','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_ddl('SEQUENCE','attach Line') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_table.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_table.sql
@@ -1,0 +1,18 @@
+SELECT dbms_metadata.get_ddl('TABLE','table_all','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('TABLE','table_all_child','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('TABLE','sales','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('TABLE','Sample unlogged table','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_ddl('TABLE','table_all') from dual;
+
+SELECT dbms_metadata.get_ddl('TABLE','table_all_child') from dual;
+
+SELECT dbms_metadata.get_ddl('TABLE','sales') from dual;
+
+SELECT dbms_metadata.get_ddl('TABLE','Sample unlogged table') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_trigger.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_trigger.sql
@@ -1,0 +1,1 @@
+SELECT dbms_metadata.get_ddl('TRIGGER','order','gdmmm') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_type.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_type.sql
@@ -1,0 +1,10 @@
+SELECT dbms_metadata.get_ddl('TYPE','Address','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('TYPE','location','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_ddl('TYPE','Address') from dual;
+
+SELECT dbms_metadata.get_ddl('TYPE','location') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_view.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_ddl/get_ddl_view.sql
@@ -1,0 +1,10 @@
+SELECT dbms_metadata.get_ddl('VIEW','gg_d','gdmmm') from dual;
+
+SELECT dbms_metadata.get_ddl('VIEW','Global fines','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_ddl('VIEW','gg_d') from dual;
+
+SELECT dbms_metadata.get_ddl('VIEW','Global fines') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_dependent_ddl/get_dependent_ddl_index_constraint.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_dependent_ddl/get_dependent_ddl_index_constraint.sql
@@ -1,0 +1,24 @@
+SELECT dbms_metadata.get_dependent_ddl('INDEX','table_all','gdmmm') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('INDEX','Sample unlogged table','gdmmm') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all','gdmmm') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all_child','gdmmm') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','Sample unlogged table','gdmmm') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('REF_CONSTRAINT','table_all_child','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_dependent_ddl('INDEX','table_all') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('INDEX','Sample unlogged table') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','table_all_child') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('CONSTRAINT','Sample unlogged table') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_dependent_ddl/get_dependent_ddl_sequence.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_dependent_ddl/get_dependent_ddl_sequence.sql
@@ -1,0 +1,10 @@
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','table_all','gdmmm') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','Sample unlogged table','gdmmm') from dual;
+
+-- tests for schema as NULL
+SET search_path TO public, gdmmm;
+
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','table_all') from dual;
+
+SELECT dbms_metadata.get_dependent_ddl('SEQUENCE','Sample unlogged table') from dual;

--- a/contrib/pg_dbms_metadata/test/sql/get_dependent_ddl/get_dependent_ddl_trigger.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_dependent_ddl/get_dependent_ddl_trigger.sql
@@ -1,0 +1,2 @@
+SELECT dbms_metadata.get_dependent_ddl('TRIGGER','table_all','gdmmm') from dual;
+

--- a/contrib/pg_dbms_metadata/test/sql/get_granted_ddl/get_granted_ddl_role.sql
+++ b/contrib/pg_dbms_metadata/test/sql/get_granted_ddl/get_granted_ddl_role.sql
@@ -1,0 +1,1 @@
+SELECT dbms_metadata.get_granted_ddl('ROLE_GRANT','dbms_metadata_test_User565667');


### PR DESCRIPTION
功能：通过创建pg_dbms_metadata插件,在opentenbase上实现oracle 19C DBMS_METADATA兼容属性。
许可：延续原作者HexaCluster Corp的PG开源协议，支持二次开发与使用
代码改动量：基础上所有文件都涉及更改，估算更改量占原插件的30%。

相对于原插件，主要改动点：
1）添加oracle兼容性视图dual，以便更贴近oracle对dbms_metadata包的使用
2）添加opentenbase分布式特有的建表方式，如DISTRIBUTE BY分布式方式和存储GROUP等
3）移除存储过程支持，因为目前opentenbase是基于PostgreSQL 10的，不支持创建存储过程
4）将原需存储过程实现的调整为通过函数实现
5）调整插件中的几乎所有测试用例，添加opentenbase分布式语法，默认dual调用，取消存储过程调用等