### PR TITLE
kbzhang|fix pgxc_ctl print bug

### DIFF
--- a/contrib/pgxc_ctl/datanode_cmd.c
+++ b/contrib/pgxc_ctl/datanode_cmd.c
@@ -2001,7 +2001,7 @@ int show_config_datanodeMaster(int flag, int idx, char *hostname)
     if (outBuf[0])
         elog(NOTICE, "%s", outBuf);
     elog(NOTICE, "    Nodename: '%s', port: %s, pooler port %s\n",
-         aval(VAR_datanodeNames)[idx], aval(VAR_datanodePorts)[idx], aval(VAR_poolerPorts)[idx]);
+         aval(VAR_datanodeNames)[idx], aval(VAR_datanodePorts)[idx], aval(VAR_datanodePoolerPorts)[idx]);
     elog(NOTICE, "    MaxWALSenders: %s, Dir: '%s'\n",
          aval(VAR_datanodeMaxWALSenders)[idx], aval(VAR_datanodeMasterDirs)[idx]);
     elog(NOTICE, "    ExtraConfig: '%s', Specific Extra Config: '%s'\n",
@@ -2038,7 +2038,7 @@ int show_config_datanodeSlave(int flag, int idx, char *hostname)
     if (outBuf[0])
         elog(NOTICE, "%s", outBuf);
     elog(NOTICE, "    Nodename: '%s', port: %s, pooler port: %s\n",
-         aval(VAR_datanodeNames)[idx], aval(VAR_datanodeSlavePorts)[idx], aval(VAR_poolerPorts)[idx]);
+         aval(VAR_datanodeNames)[idx], aval(VAR_datanodeSlavePorts)[idx], aval(VAR_datanodeSlavePoolerPorts)[idx]);
     elog(NOTICE,"    Dir: '%s', Archive Log Dir: '%s'\n",
          aval(VAR_datanodeSlaveDirs)[idx], aval(VAR_datanodeArchLogDirs)[idx]);
     unlockLogFile();


### PR DESCRIPTION
Settings in pgxc_ctl.conf is 
<img width="319" alt="企业微信截图_c58fb881-57be-4a6d-b940-cdae2b27f43c" src="https://github.com/user-attachments/assets/a99304c8-b916-4e33-889b-bec9284ac755">

Before fix:
<img width="642" alt="企业微信截图_cc60a6aa-b496-4e8c-a1b2-6ffe62703f0d" src="https://github.com/user-attachments/assets/c087aa5a-fec3-42b2-bb41-f34e0879405a">

After fix:
<img width="670" alt="企业微信截图_69d4ca1a-badc-4a58-8b4d-386bc785cffc" src="https://github.com/user-attachments/assets/e9e57197-2729-4150-ab49-31bfd1627432">
