### PR TITLE
fix: A compilation error caused by int being assigned a null pointer in src/gtm/main/gtm_store.c

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -53,6 +53,10 @@
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+
+// NCU奶龙 FIX
+#include "../include/commands/proclang.h"
+
 #ifdef __OPENTENBASE__
 #include "optimizer/planner.h"
 #include "tcop/pquery.h"
@@ -920,6 +924,7 @@ contain_user_defined_functions_checker(Oid func_id, void *context)
 		float cost;
 
 		func_lang_oid = get_func_lang(func_id);
+        // 这里的函数调用有一个未知的头文件缺失问题 proclang.h
 		plpgsql_oid = get_language_oid("plpgsql", true);
 		sql_oid = get_language_oid("sql", true);
 		cost = get_func_cost_with_sign(func_id);

--- a/src/gtm/main/gtm_store.c
+++ b/src/gtm/main/gtm_store.c
@@ -3348,7 +3348,8 @@ int32 GTM_StoreDropAllSeqInDatabase(GTM_SequenceKey seq_database_key)
 
             if (seq_count >= seq_maxcount)
             {
-                int                   newcount = NULL;
+                // I guess 0 is better
+                int                   newcount = 0;//NULL;
                 GTM_StoredSeqInfo    *newlist  = NULL;
 
                 newcount = 2 * seq_maxcount;
@@ -3444,8 +3445,8 @@ ProcessListStorageSequenceCommand(Port *myport, StringInfo message)
         {    
             seq_info = GetSeqStore(bucket_handle);
             if (seq_count >= seq_maxcount)
-            {
-                int                   newcount = NULL;
+            {   // I guess 0 is better
+                int                   newcount = 0; // NULL;
                 GTM_StoredSeqInfo    *newlist  = NULL;
                 
                 newcount = 2 * seq_maxcount;
@@ -3557,7 +3558,8 @@ ProcessListStorageTransactionCommand(Port *myport, StringInfo message)
             txn_info = GetTxnStore(bucket_handle);
             if (txn_count >= txn_maxcount)
             {
-                int             newcount = NULL;
+                // I guess 0 is better
+                int                             newcount = 0; // NULL;
                 GTM_StoredTransactionInfo   *newlist     = NULL;
                 
                 newcount = 2 * txn_maxcount;
@@ -4274,7 +4276,8 @@ GTMStorageHandle *GTM_StoreGetAllSeqInDatabase(GTM_SequenceKey seq_database_key,
 
             if (seq_count >= seq_maxcount)
             {
-                int                  newcount = NULL;
+                // I guess 0 is better
+                int                 newcount  = 0; // NULL;
                 GTMStorageHandle    *newlist  = NULL;
 
                 newcount = 2 * seq_maxcount;


### PR DESCRIPTION
这是一个很奇怪的报错，貌似和编译器实现有关，对于目前的GCC版本和Ubuntu系统，newcount应该被赋值为0，这个效果和使用宏NULL(即(void*)0)是一样的。并且可以正常通过编译。