### PR TITLE
RUN su opentenbase not work

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update && \
 # add user
 RUN useradd -m -r -s /bin/bash opentenbase
 
+RUN mkdir /data
+RUN chown opentenbase /data -R
+RUN chgrp opentenbase /data -R
+
 RUN echo "export OPENTENBASE_HOME=/data/opentenbase/install/opentenbase_bin_v2.0 \n\
 export PATH=/data/opentenbase/install/opentenbase_bin_v2.0/bin:$PATH \n\
 export LD_LIBRARY_PATH=$OPENTENBASE_HOME/lib:${LD_LIBRARY_PATH} \n\
@@ -28,12 +32,9 @@ EXPOSE 30004
 CMD ["/usr/sbin/sshd", "-D"]
 
 # Share belive configure
-RUN su opentenbase
+USER opentenbase
 RUN mkdir /home/opentenbase/.ssh -p
 RUN ssh-keygen -t rsa -f /home/opentenbase/.ssh/id_rsa -N ''
 # Set right
 RUN chown opentenbase /home/opentenbase/.ssh -R
 RUN chgrp opentenbase /home/opentenbase/.ssh -R
-RUN mkdir /data
-RUN chown opentenbase /data -R
-RUN chgrp opentenbase /data -R

--- a/docker/host/Dockerfile
+++ b/docker/host/Dockerfile
@@ -56,6 +56,9 @@ RUN make -sj && \
 # Add opentenbase user
 RUN useradd -m -r -s /bin/bash opentenbase
 
+RUN chown opentenbase /data -R
+RUN chgrp opentenbase /data -R
+
 RUN echo "export OPENTENBASE_HOME=/data/opentenbase/install/opentenbase_bin_v2.0 \n\
 export PATH=/data/opentenbase/install/opentenbase_bin_v2.0/bin:$PATH \n\
 export LD_LIBRARY_PATH=$OPENTENBASE_HOME/lib:${LD_LIBRARY_PATH} \n\
@@ -74,11 +77,9 @@ EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]
 
 # Share belive config
-RUN su opentenbase
+USER opentenbase
 RUN mkdir /home/opentenbase/.ssh -p
 RUN ssh-keygen -t rsa -f /home/opentenbase/.ssh/id_rsa -N ''
 # Set right
 RUN chown opentenbase /home/opentenbase/.ssh -R
 RUN chgrp opentenbase /home/opentenbase/.ssh -R
-RUN chown opentenbase /data -R
-RUN chgrp opentenbase /data -R


### PR DESCRIPTION
Docker's RUN is non-interactive, with each command running in a new shell. I added a whoami command as testing, and it shows:
```bash
Step 14/23 : RUN su opentenbase
 ---> Running in 32b32cd39639
 ---> Removed intermediate container 32b32cd39639
 ---> 3f7ff4393583
Step 15/23 : RUN whoami
 ---> Running in e3b055d04de7
root
```

So `su` is invalid, and change it to USER