### PR TITLE
Build local opentenbase project in docker

### DIFF
--- a/docker/buildImage.sh
+++ b/docker/buildImage.sh
@@ -1,7 +1,9 @@
-pushd ./base
+#!/bin/bash
+
+echo "Building base image..."
+pushd ./docker/base
 docker build -t opentenbasebase:1.0.0 .
 popd
 
-pushd ./host
-docker build -t opentenbase:1.0.0 .
-popd
+echo "Building host image..."
+docker build -f docker/host/Dockerfile -t opentenbase:1.0.0 .

--- a/docker/host/Dockerfile
+++ b/docker/host/Dockerfile
@@ -22,14 +22,18 @@ RUN apt-get update && \
         openssh-server \
         iputils-ping # ping command
 
-# Clone the source code repository
-RUN git clone https://github.com/OpenTenBase/OpenTenBase /data/opentenbase/OpenTenBase
+# Create the target directory
+RUN mkdir -p /data/opentenbase
+
+# Copy the local OpenTenBase source code to the container
+# Build context should be the project root directory
+COPY . /data/opentenbase/OpenTenBase
 
 # Set environment variables
 ENV SOURCECODE_PATH=/data/opentenbase/OpenTenBase
 ENV INSTALL_PATH=/data/opentenbase/install
 
-COPY ./copy-ssh-keys /usr/bin
+COPY docker/host/copy-ssh-keys /usr/bin
 
 # Navigate to the source code directory
 WORKDIR $SOURCECODE_PATH

--- a/example/1c_2d_cluster/README
+++ b/example/1c_2d_cluster/README
@@ -8,8 +8,8 @@ In this example, we try to build a cluster which includes 1 Coordinator Node and
 ## 1.Build docker images
 
 ```shell
-cd {OpenTenbase Dir}/docker
-./buildImage.sh
+chmod +x docker/buildImage.sh
+./docker/buildImage.sh
 ```
 
 Commands above will build `opentenbasebase` and `opentenbase` images.


### PR DESCRIPTION
change the way of building dockerfile from `git clone` to `COPY files`, and update the relevant README.
related issue #24 