### PR TITLE
feat: Add OpenTenBase integration with Apache SeaTunnel

### DIFF
--- a/example/1c_2d_cluster/docker-compose.yaml
+++ b/example/1c_2d_cluster/docker-compose.yaml
@@ -12,14 +12,16 @@ services:
     tty: true
 
   opentenbaseDN1:
-    image: docker.io/library/opentenbasebase:1.0.0
+    image: docker.io/library/opentenbase:1.0.0
     networks:
       OpenTenBaseNetWork:
         ipv4_address: 172.16.200.10
     container_name: opentenbaseDN1
     restart: unless-stopped
+    ports:
+      - 30004:30004
     volumes:
-      - "./pgxc_conf/dn1:/home/opentenbasebase/pgxc_conf"
+      - "./pgxc_conf/dn1:/home/opentenbase/pgxc_conf"
     tty: true
 
   opentenbaseDN2:

--- a/seatunnel/README.md
+++ b/seatunnel/README.md
@@ -1,0 +1,145 @@
+# OpenTenBase Integration with Apache SeaTunnel
+
+## Overview
+
+This document describes how to integrate OpenTenBase with Apache SeaTunnel to achieve efficient data transformation and synchronization between OpenTenBase and other data sources.
+
+## Technical Architecture
+
+```
+OpenTenBase (PostgreSQL Compatible) ←→ Apache SeaTunnel ←→ MySQL/Other Data Sources
+    Distributed HTAP Database            Data Integration Platform    Target Data Sources
+```
+
+## Deployment Steps
+
+### 1. Deploy Apache SeaTunnel
+
+1. Download SeaTunnel 2.3.11 release package, refer to [Apache Seatunnel quickstart](https://seatunnel.incubator.apache.org/zh-CN/docs/2.3.11/start-v2/locally/deployment)
+
+2. Install necessary JDBC drivers:
+```bash
+cd $SEATUNNEL_HOME/lib
+
+# Download PostgreSQL JDBC driver (compatible with OpenTenBase)
+wget https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.24/postgresql-42.2.24.jar
+
+# Download MySQL JDBC driver
+wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.2.0/mysql-connector-j-8.2.0.jar
+```
+
+### 2. Deploy OpenTenBase Cluster
+
+1. Start the OpenTenBase cluster according to the instructions in `opentenbase/example/1c_2d_cluster`
+2. Configure DN port mapping in `example/1c_2d_cluster/docker-compose.yaml`
+
+### 3. Prepare Data Structures
+
+#### 3.1 OpenTenBase Data Structure
+
+```sql
+-- Connect to OpenTenBase
+psql -h localhost -p 30004 -U opentenbase -d postgres
+
+-- Create basic test table
+CREATE TABLE foo(id bigint, str text) DISTRIBUTE BY shard(id);
+INSERT INTO foo VALUES(1, 'tencent'), (2, 'shenzhen');
+
+-- Create complex data type test table
+CREATE TABLE test_data_types (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100),
+    age INTEGER,
+    salary DECIMAL(10,2),
+    birth_date DATE,
+    created_time TIMESTAMP,
+    is_active BOOLEAN,
+    description TEXT,
+    metadata JSONB
+) DISTRIBUTE BY shard(id);
+
+INSERT INTO test_data_types (name, age, salary, birth_date, created_time, is_active, description, metadata)
+VALUES 
+    ('zhangsan', 25, 8500.50, '1998-05-15', '2024-01-01 10:30:00', true, 'test user 1', '{"dept": "IT", "level": "junior"}'),
+    ('lisi', 30, 12000.00, '1993-12-20', '2024-01-02 14:20:00', true, 'test user 2', '{"dept": "Sales", "level": "senior"}'),
+    ('wangwu', 28, 9500.75, '1995-08-10', '2024-01-03 09:15:00', false, 'test user 3', '{"dept": "HR", "level": "middle"}');
+```
+
+#### 3.2 MySQL Data Structure
+
+```sql
+-- Connect to MySQL
+mysql -u root -p
+
+-- Create test database
+CREATE DATABASE test;
+USE test;
+
+-- Create corresponding target table
+CREATE TABLE foo (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100),
+    value INT
+);
+
+-- Create complex data type target table
+CREATE TABLE test_data_types (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100),
+    age INT,
+    salary DECIMAL(10,2),
+    level VARCHAR(20),
+    birth_year INT
+);
+```
+
+### 4. Run SeaTunnel Tasks
+
+```bash
+cd apache-seatunnel-2.3.11
+
+# Run basic synchronization task
+./bin/seatunnel.sh --config ../seatunnel/jobs/opentenbase_basic_test.conf -e local
+
+# Run data transformation task
+./bin/seatunnel.sh --config ../seatunnel/jobs/opentenbase_transform_test.conf -e local
+```
+
+### 5. Verify Results
+
+```sql
+-- Connect to MySQL to verify data
+mysql -u root -p test
+
+-- Check basic synchronization results
+SELECT * FROM foo;
+
+-- Check data transformation results
+SELECT * FROM test_data_types;
+```
+
+## Test Scenarios
+
+### Basic Data Synchronization Test
+
+**Configuration File**: `opentenbase_basic_test.conf`
+
+**Function Verification**:
+- ✅ Basic connection between OpenTenBase and SeaTunnel
+- ✅ Simple table structure data reading and writing (bigint, text types)
+- ✅ Pure synchronization without data transformation
+
+### Advanced Data Transformation Test
+
+**Configuration File**: `opentenbase_transform_test.conf`
+
+**Function Verification**:
+- ✅ Complex SQL queries (CASE WHEN, EXTRACT functions)
+- ✅ Field aliases and computed fields
+- ✅ WHERE condition filtering and ORDER BY sorting
+- ✅ Transform field mapping
+- ✅ Complex table structure support (multiple data types)
+
+## Summary
+
+Through the above steps, you have successfully completed the integration of OpenTenBase with Apache SeaTunnel and achieved cross-data-source data synchronization functionality. This solution supports various application scenarios from basic data synchronization to complex data transformation.

--- a/seatunnel/jobs/opentenbase_basic_test.conf
+++ b/seatunnel/jobs/opentenbase_basic_test.conf
@@ -1,0 +1,27 @@
+env {
+    parallelism = 2
+    job.mode = "BATCH"
+}
+source {
+    Jdbc {
+        url = "jdbc:postgresql://localhost:30004/postgres"
+        driver = "org.postgresql.Driver"
+        user = "opentenbase"
+        password = "qwerty"
+        connection_check_timeout_sec = 100
+        query = "SELECT * FROM foo;"
+    }
+}
+sink {
+    Jdbc {
+        url = "jdbc:mysql://localhost:3306/test"
+        driver = "com.mysql.cj.jdbc.Driver"
+        user = "root"
+        password = ""
+        database = "test"
+        table = "foo"
+        connection_check_timeout_sec = 100
+        sink.mode = "insert"
+        generate_sink_sql = true
+  }
+}

--- a/seatunnel/jobs/opentenbase_transform_test.conf
+++ b/seatunnel/jobs/opentenbase_transform_test.conf
@@ -1,0 +1,48 @@
+env {
+    parallelism = 2
+    job.mode = "BATCH"
+}
+source {
+    Jdbc {
+        url = "jdbc:postgresql://localhost:30004/postgres"
+        driver = "org.postgresql.Driver"
+        user = "opentenbase"
+        password = "qwerty"
+        connection_check_timeout_sec = 100
+        query = """
+            SELECT 
+            name,
+            age,
+            salary,
+            CASE WHEN age > 25 THEN 'Senior' ELSE 'Junior' END as level,
+            EXTRACT(YEAR FROM birth_date) as birth_year
+            FROM test_data_types 
+            WHERE is_active = true 
+            ORDER BY salary DESC
+        """
+    }
+}
+transform {
+    FieldMapper {
+        field_mapper = {
+            name = name
+            age = age
+            salary = salary
+            level = level
+            birth_year = birth_year
+        }
+    }
+}
+sink {
+    Jdbc {
+        url = "jdbc:mysql://localhost:3306/test"
+        driver = "com.mysql.cj.jdbc.Driver"
+        user = "root"
+        password = ""
+        database = "test"
+        table = "test_data_types"
+        connection_check_timeout_sec = 100
+        sink.mode = "insert"
+        generate_sink_sql = true
+    }
+}


### PR DESCRIPTION
## Overview
This PR adds integration support between OpenTenBase and Apache SeaTunnel, enabling efficient data transformation between OpenTenBase and other data sources.

Solve issue: #44 

## New Content

### 1. Integration Documentation (`seatunnel/README.md`)
- Detailed deployment instructions
- Technical architecture overview
- Test scenario validation
- Complete operation guide

### 2. Configuration Files (`seatunnel/jobs/`)
- **Basic Synchronization Config** (`opentenbase_basic_test.conf`): Implements basic data synchronization from OpenTenBase to MySQL
- **Advanced Transformation Config** (`opentenbase_transform_test.conf`): Supports complex SQL queries, field mapping, and data transformation

@gh-Devin 