### PR TITLE
f新增用于活动和锁的分布式状态视图

### DIFF
--- a/contrib/pg_dist_stat_views/Makefile
+++ b/contrib/pg_dist_stat_views/Makefile
@@ -1,0 +1,33 @@
+# contrib/pg_dist_stat_views/Makefile
+#
+# Copyright (c) 2023 THL A29 Limited, a Tencent company.
+#
+# This source code file is licensed under the BSD 3-Clause License,
+# you may obtain a copy of the License at http://opensource.org/license/bsd-3-clause/
+#
+
+MODULE_big = pg_dist_stat_views
+OBJS = pg_dist_stat_views.o $(WIN32RES)
+
+EXTENSION = pg_dist_stat_views
+DATA = pg_dist_stat_views--1.0.sql
+PGFILEDESC = "pg_dist_stat_views - distributed statistics views"
+
+LDFLAGS_SL += $(filter -lm, $(LIBS))
+
+REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_dist_stat_views/pg_dist_stat_views.conf
+REGRESS = pg_dist_stat_views
+# Disabled because these tests require "shared_preload_libraries=pg_stat_cluster_activity",
+# which typical installcheck users do not have (e.g. buildfarm clients).
+NO_INSTALLCHECK = 1
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/pg_dist_stat_views
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -41,7 +41,8 @@ CREATE OR REPLACE FUNCTION dist_pg_stat_get_activity(
     OUT backend_xid xid,
     OUT backend_xmin xid,
     OUT backend_type text,
-    OUT global_query_id text
+    OUT global_query_id text,
+    OUT gxid text
 )
 RETURNS SETOF record
 AS 'MODULE_PATHNAME'
@@ -65,7 +66,9 @@ CREATE OR REPLACE FUNCTION get_dist_pg_locks(
     OUT mode text,
     OUT granted boolean,
     OUT fastpath boolean,
-    OUT gxid text
+    OUT gxid text,
+    OUT blocking_pid integer,
+    OUT blocking_gxid text
 )
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'get_dist_pg_locks'
@@ -261,69 +264,103 @@ ORDER BY
     -- 3. 最后，按节点名排序
     gid.nodename;
 
--- 创建用户视图：dist_pg_locks
--- 创建一个基础的、只封装C函数的锁视图
+-- 创建一个基础的、只封装C函数的锁视图：dist_pg_locks_raw
 CREATE OR REPLACE VIEW dist_pg_locks_raw AS
   SELECT * FROM get_dist_pg_locks(false);
 
--- 创建在SQL层推断阻塞关系的 dist_pg_locks 视图
+-- 【dist_pg_locks 视图
+-- 它的职责是，在C函数返回的原始锁信息基础上，
+-- 通过关联 dist_pg_stat_activity，为阻塞者补全其所在的节点名称。
+-- 这个视图是所有更高级分析（如锁链、死锁）的、信息完备的基础。
 CREATE OR REPLACE VIEW dist_pg_locks AS
 WITH 
-waiters AS (
-    SELECT * FROM dist_pg_locks_raw WHERE NOT granted
-),
-holders AS (
-    SELECT * FROM dist_pg_locks_raw WHERE granted
-),
-blocking_pairs AS (
-    SELECT DISTINCT
-        w.node_name AS waiter_node,
-        w.pid AS waiter_pid,
-        h.node_name AS blocking_node_name,
-        h.pid AS blocking_pid,
-        h.gxid AS blocking_gxid
-    FROM waiters w JOIN holders h 
-      ON w.database = h.database AND (
-         -- 匹配表、页、元组锁
-         (w.relation IS NOT NULL AND w.relation = h.relation) OR
-         -- 匹配事务ID锁
-         (w.locktype = 'transactionid' AND w.transactionid = h.transactionid) OR
-         -- 匹配 advisory lock
-         (w.locktype = 'advisory' AND w.classid = h.classid AND w.objid = h.objid)
-      )
-    WHERE w.pid != h.pid
+-- 第一步：创建一个“干净”的、只包含潜在阻塞者的活动信息集
+potential_blockers AS (
+    SELECT
+        nodename,
+        pid,
+        gxid
+    FROM
+        dist_pg_stat_activity
+    WHERE
+        -- 关键的预过滤条件：
+        -- 1. 进程必须有一个有效的分布式事务ID
+        gxid IS NOT NULL 
+        -- 2. 进程不能是完全空闲的
+        AND state != 'idle'
 )
--- 整合输出
-SELECT 
-    -- 核心锁信息
+SELECT
+    -- 从 dist_pg_locks_raw 中获取的所有原始信息
     raw.node_name,
     raw.granted,
     raw.gxid,
     raw.pid,
     raw.locktype,
+    raw.database,
+    raw.relation,
+    raw.page,
+    raw.tuple,
+    raw.virtualxid,
+    raw.transactionid,
+    raw.classid,
+    raw.objid,
+    raw.objsubid,
+    raw.virtualtransaction,
     raw.mode,
+    raw.fastpath,
     
-    -- 锁定的对象
+    -- 【核心逻辑】通过JOIN我们预过滤后的 potential_blockers，来查找并补全 blocking_node_name
+    blockers.nodename AS blocking_node_name,
+    
+    -- 从 dist_pg_locks_raw 中获取的、由C代码精确找到的阻塞者ID
+    raw.blocking_pid,
+    raw.blocking_gxid,
+
+    -- 为了方便用户，增加一个可读的 lock_target 列
     CASE 
         WHEN raw.locktype = 'relation' THEN raw.relation::regclass::text 
         WHEN raw.locktype = 'transactionid' THEN raw.transactionid::text
         ELSE pg_describe_object(raw.classid, raw.objid, raw.objsubid)
-    END AS lock_target,
-    
-    -- 推断出的阻塞者信息
-    bp.blocking_node_name,
-    bp.blocking_pid,
-    bp.blocking_gxid,
-
-    -- 保留一些原始列用于深入分析
-    raw.relation,
-    raw.transactionid AS local_xid,
-    raw.virtualtransaction
-FROM 
+    END AS lock_target
+FROM
     dist_pg_locks_raw AS raw
--- 做一次 LEFT JOIN，关联内部计算出的阻塞关系
+-- 使用 LEFT JOIN，以防阻塞者信息因时序问题暂时不可见
 LEFT JOIN
-    blocking_pairs bp ON raw.pid = bp.waiter_pid AND raw.node_name = bp.waiter_node;
+    potential_blockers AS blockers
+    -- 使用最精确的关联键：阻塞者的 PID 和 GXID
+    ON raw.blocking_pid = blockers.pid AND raw.blocking_gxid = blockers.gxid;
+
+-- 包含所有活动信息的大而全视图
+CREATE OR REPLACE VIEW dist_pg_locks_all_info AS
+SELECT 
+    l.node_name,
+    l.granted,
+    l.gxid,
+    l.pid,
+    act.usename AS waiter_usename,
+    act.state AS waiter_state,
+    act.query AS waiter_query,
+    l.locktype,
+    l.mode,
+    CASE 
+        WHEN l.locktype = 'relation' THEN l.relation::regclass::text 
+        WHEN l.locktype = 'transactionid' THEN l.transactionid::text
+        ELSE pg_describe_object(l.classid, l.objid, l.objsubid)
+    END AS lock_target,
+    l.blocking_node_name,
+    l.blocking_pid,
+    l.blocking_gxid,
+    blocker_act.usename AS blocker_usename,
+    blocker_act.state AS blocking_state,
+    blocker_act.query AS blocking_query
+FROM 
+    dist_pg_locks AS l
+LEFT JOIN
+    dist_pg_stat_activity AS act 
+    ON l.pid = act.pid AND l.node_name = act.nodename
+LEFT JOIN
+    dist_pg_stat_activity AS blocker_act 
+    ON l.blocking_pid = blocker_act.pid AND l.blocking_node_name = blocker_act.nodename;
 
 -- ===================================================================
 -- ==      Advanced Lock Analysis Views (Wait Chains & Deadlocks)   ==
@@ -470,5 +507,6 @@ GRANT SELECT ON dist_pg_stat_query_summary TO PUBLIC;
 GRANT SELECT ON dist_pg_stat_query_details TO PUBLIC;
 GRANT SELECT ON dist_pg_locks_raw TO PUBLIC;
 GRANT SELECT ON dist_pg_locks TO PUBLIC;
+GRANT SELECT ON dist_pg_locks_all_info TO PUBLIC;
 GRANT SELECT ON dist_pg_lock_wait_chains TO PUBLIC;
 GRANT SELECT ON dist_pg_deadlocks TO PUBLIC;

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -11,9 +11,9 @@
 
 /* Now redefine */
 CREATE OR REPLACE FUNCTION dist_pg_stat_get_activity(
-    sessionid text,
-    coordonly bool,
-    localonly bool,
+    IN sessionid text,
+    IN coordonly bool,
+    IN localonly bool,
 
     -- 在第一阶段，你可以保持和原来完全一样，以求功能对等。
     -- 在第二阶段（功能增强），你就可以在这里增加、删除或修改列了！
@@ -48,6 +48,37 @@ CREATE OR REPLACE FUNCTION dist_pg_stat_get_activity(
 RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
+
+-- ===================================================================
+-- ==                 Distributed Locks Information                 ==
+-- ===================================================================
+
+-- 定义新的SRF函数，这是用户查询的入口
+CREATE OR REPLACE FUNCTION get_dist_pg_locks(
+    IN localonly boolean DEFAULT false,
+    OUT node_name text,
+    OUT locktype text,
+    OUT database oid,
+    OUT relation oid,
+    OUT page integer,
+    OUT tuple smallint,
+    OUT virtualxid text,
+    OUT transactionid xid,
+    OUT classid oid,
+    OUT objid oid,
+    OUT objsubid smallint,
+    OUT virtualtransaction text,
+    OUT pid integer,
+    OUT mode text,
+    OUT granted boolean,
+    OUT fastpath boolean,
+    OUT gxid text
+    -- OUT blocking_pid integer,
+    -- OUT blocking_gxid text
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'get_dist_pg_locks'
+LANGUAGE C STRICT VOLATILE;
 
 -- 你的首要目标是实现视图。等视图功能稳定后，再考虑是否需要实现这些管理功能。
 -- 如果要保留，也需要把它们的名字和实现都改成你自己的版本。
@@ -280,8 +311,216 @@ ORDER BY
     -- 3. 最后，按节点名排序，让输出更稳定。
     gid.nodename;
 
+-- 创建最终用户视图：dist_pg_locks
+-- 创建一个基础的、只封装C函数的锁视图
+CREATE OR REPLACE VIEW dist_pg_locks_raw AS
+  SELECT * FROM get_dist_pg_locks(false);
+
+-- 创建最终的、在SQL层推断阻塞关系的 dist_pg_locks 视图
+CREATE OR REPLACE VIEW dist_pg_locks AS
+WITH 
+waiters AS (
+    SELECT * FROM dist_pg_locks_raw WHERE NOT granted
+),
+holders AS (
+    SELECT * FROM dist_pg_locks_raw WHERE granted
+),
+blocking_pairs AS (
+    SELECT DISTINCT
+        w.node_name AS waiter_node,
+        w.pid AS waiter_pid,
+        h.node_name AS blocking_node_name,
+        h.pid AS blocking_pid,
+        h.gxid AS blocking_gxid
+    FROM waiters w JOIN holders h 
+      ON w.database = h.database AND (
+         -- 精确匹配表、页、元组锁
+         (w.relation IS NOT NULL AND w.relation = h.relation) OR
+         -- 精确匹配事务ID锁
+         (w.locktype = 'transactionid' AND w.transactionid = h.transactionid) OR
+         -- 精确匹配 advisory lock (假设 classid 和 objid 相同)
+         (w.locktype = 'advisory' AND w.classid = h.classid AND w.objid = h.objid)
+      )
+    WHERE w.pid != h.pid
+)
+-- 最终整合输出
+SELECT 
+    -- 核心锁信息
+    raw.node_name,
+    raw.granted,
+    raw.gxid,
+    raw.pid,
+    raw.locktype,
+    raw.mode,
+    
+    -- 锁定的对象
+    CASE 
+        WHEN raw.locktype = 'relation' THEN raw.relation::regclass::text 
+        WHEN raw.locktype = 'transactionid' THEN raw.transactionid::text
+        ELSE pg_describe_object(raw.classid, raw.objid, raw.objsubid)
+    END AS lock_target,
+    
+    -- 【核心】推断出的阻塞者信息
+    bp.blocking_node_name,
+    bp.blocking_pid,
+    bp.blocking_gxid,
+
+    -- 保留一些原始列用于深入分析
+    raw.relation,
+    raw.transactionid AS local_xid,
+    raw.virtualtransaction
+FROM 
+    dist_pg_locks_raw AS raw
+-- 只做一次 LEFT JOIN，关联我们内部计算出的阻塞关系
+LEFT JOIN
+    blocking_pairs bp ON raw.pid = bp.waiter_pid AND raw.node_name = bp.waiter_node;
+
+-- ===================================================================
+-- ==      Advanced Lock Analysis Views (Wait Chains & Deadlocks)   ==
+-- ===================================================================
+
+-- in pg_dist_stat_views--1.0.sql
+
+-- 视图 1: 完整的分布式锁等待链 (修正版)
+CREATE OR REPLACE VIEW dist_pg_lock_wait_chains AS
+WITH RECURSIVE lock_chain AS (
+    -- 递归的起点 (Anchor)
+    SELECT
+        1 AS level,
+        locks.gxid AS waiter_gxid,
+        locks.pid AS waiter_pid,
+        locks.node_name AS waiter_node,
+        locks.blocking_gxid,
+        locks.blocking_pid,
+        locks.blocking_node_name,
+        ARRAY[locks.gxid] AS path,
+        (locks.node_name || ':' || locks.pid) AS path_detail
+    FROM
+        dist_pg_locks AS locks
+    WHERE
+        NOT locks.granted
+
+    UNION ALL
+
+    -- 递归的递推 (Recursive Step)
+    SELECT
+        lc.level + 1,
+        lc.blocking_gxid,
+        lc.blocking_pid,
+        lc.blocking_node_name,
+        locks.blocking_gxid,
+        locks.blocking_pid,
+        locks.blocking_node_name,
+        lc.path || lc.blocking_gxid,
+        lc.path_detail || ' -> ' || (locks.node_name || ':' || locks.pid)
+    FROM
+        lock_chain lc
+    JOIN
+        dist_pg_locks locks ON lc.blocking_gxid = locks.gxid AND lc.blocking_pid = locks.pid
+    WHERE
+        NOT locks.granted AND NOT (locks.gxid = ANY(lc.path))
+)
+-- 最终输出: 将递归结果与锁信息和【活动信息】进行关联
+SELECT
+    c.level AS wait_level,
+    c.path_detail AS wait_chain,
+    -- 等待者信息
+    c.waiter_node,
+    c.waiter_pid,
+    c.waiter_gxid,
+    -- 【核心修正】从 dist_pg_stat_activity (别名 act) 获取 state 和 query
+    act.state AS waiter_state,
+    (now() - act.query_start)::interval(3) AS waiter_duration,
+    act.query AS waiter_query,
+    -- 锁信息 (来自 dist_pg_locks, 别名 l)
+    l.lock_target,
+    l.mode AS lock_mode,
+    -- 阻塞者信息
+    c.blocking_node_name,
+    c.blocking_pid,
+    c.blocking_gxid
+FROM
+    lock_chain c
+-- 关联 dist_pg_locks 以获取锁的详细信息
+JOIN
+    dist_pg_locks l ON c.waiter_gxid = l.gxid AND c.waiter_pid = l.pid
+-- 【核心修正】关联 dist_pg_stat_activity 以获取等待者的活动信息
+JOIN
+    dist_pg_stat_activity act ON c.waiter_pid = act.pid AND c.waiter_node = act.nodename
+ORDER BY
+    c.path, c.level;
+
+
+-- 视图 2: 分布式死锁检测 (最终修正版)
+CREATE OR REPLACE VIEW dist_pg_deadlocks AS
+WITH RECURSIVE lock_chain ( -- 【核心修正】在这里显式声明所有列名
+    waiter_gxid,
+    waiter_pid,
+    waiter_node,
+    blocking_gxid,
+    blocking_pid,
+    blocking_node_name,
+    path,
+    is_cycle -- 确保 is_cycle 在这里被声明
+) AS (
+    -- 递归的起点 (Anchor)
+    SELECT
+        locks.gxid,
+        locks.pid,
+        locks.node_name,
+        locks.blocking_gxid,
+        locks.blocking_pid,
+        locks.blocking_node_name,
+        ARRAY[locks.gxid],
+        (locks.gxid = locks.blocking_gxid)
+    FROM
+        dist_pg_locks AS locks
+    WHERE
+        NOT locks.granted
+
+    UNION ALL
+
+    -- 递归的递推 (Recursive Step)
+    SELECT
+        lc.blocking_gxid,
+        lc.blocking_pid,
+        lc.blocking_node_name,
+        locks.blocking_gxid,
+        locks.blocking_pid,
+        locks.blocking_node_name,
+        lc.path || lc.blocking_gxid,
+        lc.blocking_gxid = ANY(lc.path)
+    FROM
+        lock_chain lc
+    JOIN
+        dist_pg_locks locks ON lc.blocking_gxid = locks.gxid AND lc.blocking_pid = locks.pid
+    WHERE
+        NOT locks.granted AND NOT lc.is_cycle -- 这里的 lc.is_cycle 引用现在是绝对清晰的
+)
+-- 最终输出
+SELECT
+    c.path || c.blocking_gxid AS deadlock_cycle_gxid,
+    l.node_name, l.pid, l.gxid, l.lock_target, l.mode AS lock_mode,
+    act.query AS waiter_query,
+    l.blocking_node_name, l.blocking_pid, l.blocking_gxid,
+    blocker_act.query AS blocking_query
+FROM
+    lock_chain c
+JOIN
+    dist_pg_locks l ON c.waiter_gxid = l.gxid AND c.waiter_pid = l.pid
+JOIN
+    dist_pg_stat_activity act ON l.pid = act.pid AND l.node_name = act.nodename
+LEFT JOIN
+    dist_pg_stat_activity blocker_act ON l.blocking_pid = blocker_act.pid AND l.blocking_node_name = blocker_act.nodename
+WHERE
+    c.is_cycle;
+
 -- 授权
 GRANT SELECT ON dist_pg_stat_activity TO PUBLIC;
 GRANT SELECT ON dist_pg_stat_activity_cn TO PUBLIC;
 GRANT SELECT ON dist_pg_stat_query_summary TO PUBLIC;
 GRANT SELECT ON dist_pg_stat_query_details TO PUBLIC;
+GRANT SELECT ON dist_pg_locks_raw TO PUBLIC;
+GRANT SELECT ON dist_pg_locks TO PUBLIC;
+GRANT SELECT ON dist_pg_lock_wait_chains TO PUBLIC; -- 授权新视图
+GRANT SELECT ON dist_pg_deadlocks TO PUBLIC;      -- 授权新视图

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -296,9 +296,36 @@ enriched_locks AS (
         raw.*, -- 包含所有原始锁信息
         blockers.nodename AS blocking_node_name,
         CASE 
-            WHEN raw.locktype = 'relation' THEN raw.relation::regclass::text 
-            WHEN raw.locktype = 'transactionid' THEN raw.transactionid::text
-            ELSE pg_describe_object(raw.classid, raw.objid, raw.objsubid)
+            WHEN raw.locktype = 'relation' THEN
+                raw.relation::regclass::text
+            
+            WHEN raw.locktype = 'extend' THEN
+                'extend relation ' || raw.relation::regclass::text
+
+            WHEN raw.locktype = 'page' THEN
+                'page ' || raw.page || ' in ' || raw.relation::regclass::text
+
+            WHEN raw.locktype = 'tuple' THEN 
+                'row (' || raw.page || ',' || raw.tuple || ') in ' || raw.relation::regclass::text
+
+            WHEN raw.locktype = 'transactionid' THEN
+                'transaction ' || raw.transactionid::text
+
+            WHEN raw.locktype = 'virtualxid' THEN
+                'virtual transaction ' || raw.virtualxid
+
+            WHEN raw.locktype = 'advisory' THEN
+                -- advisory锁的key存储在classid和objid中
+                'advisory lock [' || raw.classid::text || ',' || raw.objid::text || ']'
+
+            -- 对于 object, userlock 等，pg_describe_object 是最佳选择
+            -- 【安全检查】只有当 classid 有效时，才调用
+            WHEN raw.classid != 0 THEN
+                pg_describe_object(raw.classid, raw.objid, raw.objsubid)
+            
+            -- 对于所有其他未知或不需要特殊描述的类型
+            ELSE
+                raw.locktype
         END AS lock_target
     FROM
         dist_pg_locks_raw AS raw
@@ -350,20 +377,23 @@ ORDER BY
 -- 包含所有活动信息的大而全视图
 CREATE OR REPLACE VIEW dist_pg_locks_all_info AS
 SELECT 
+    -- 现场信息
     l.node_name,
     l.granted,
-    l.gxid,
-    l.pid,
+    
+    -- 等待者信息
+    l.gxid AS waiter_gxid,
+    l.pid AS waiter_pid,
     act.usename AS waiter_usename,
     act.state AS waiter_state,
     act.query AS waiter_query,
+    
+    -- 锁信息
     l.locktype,
     l.mode,
-    CASE -- 直接显示出被锁的表名
-        WHEN l.locktype = 'relation' THEN l.relation::regclass::text 
-        WHEN l.locktype = 'transactionid' THEN l.transactionid::text
-        ELSE pg_describe_object(l.classid, l.objid, l.objsubid)
-    END AS lock_target,
+    l.lock_target, -- lock_target 已经在 dist_pg_locks 中被正确创建
+    
+    -- 阻塞者信息
     l.blocking_node_name,
     l.blocking_pid,
     l.blocking_gxid,
@@ -452,7 +482,6 @@ JOIN
 ORDER BY
     c.path, c.level;
 
-
 -- 视图 2: 分布式死锁检测
 CREATE OR REPLACE VIEW dist_pg_deadlocks AS
 WITH RECURSIVE lock_chain ( -- 在这里显式声明所有列名
@@ -517,6 +546,90 @@ LEFT JOIN
 WHERE
     c.is_cycle;
 
+-- in pg_dist_stat_views--1.0.sql
+
+-- ===================================================================
+-- ==             Distributed Lock Waits Summary View             ==
+-- ==                   (Ultimate & Corrected Edition)            ==
+-- ===================================================================
+-- 视图目标：将同一组“等待-阻塞”关系的所有底层锁等待信息，智能地聚合为一行，
+--          并附加上事务的“源头”信息，提供一个高度浓缩的诊断快照。
+-- ===================================================================
+CREATE OR REPLACE VIEW dist_pg_lock_waits_summary AS
+WITH 
+-- 第一步：从 dist_pg_stat_activity 中筛选出所有 CN 的活动记录，作为“源头”信息库
+cn_activities AS (
+    SELECT DISTINCT ON (gxid)
+        gxid,
+        nodename, -- 【核心修正】添加源头节点名称
+        usename,
+        datname,
+        application_name,
+        client_addr,
+        query AS top_level_query
+    FROM 
+        dist_pg_stat_activity
+    WHERE 
+        role = 'coordinator' AND gxid IS NOT NULL
+    ORDER BY gxid, query_start DESC
+)
+-- 第二步：进行最终的聚合
+SELECT
+    -- 【核心关联ID】
+    lw.waiter_gxid,
+    lw.blocking_gxid,
+
+    -- 【等待者源头信息 (完整版)】
+    waiter_cn.nodename AS waiter_source_node, -- 【核心修正】展示等待者的源头节点
+    waiter_cn.usename AS waiter_user_source,
+    waiter_cn.client_addr AS waiter_client_source,
+    waiter_cn.top_level_query AS waiter_query_source,
+
+    -- 【阻塞者源头信息 (完整版)】
+    blocker_cn.nodename AS blocker_source_node, -- 【核心修正】展示阻塞者的源头节点
+    blocker_cn.usename AS blocker_user_source,
+    blocker_cn.client_addr AS blocker_client_source,
+    blocker_cn.top_level_query AS blocker_query_source,
+
+    -- 【锁等待现场详情 (JSON格式)】
+    JSONB_AGG(
+        DISTINCT jsonb_build_object(
+            'wait_happen_node', lw.node_name,
+            'waiter_pid', lw.waiter_pid,
+            'waiter_state', lw.waiter_state,
+            'blocking_node_name', lw.blocking_node_name,
+            'blocking_pid', lw.blocking_pid,
+            'blocking_state', lw.blocking_state
+        )
+    ) AS wait_scene_details,
+
+    -- 【等待的锁 (聚合字符串)】
+    STRING_AGG(
+        DISTINCT lw.mode || '{' || lw.lock_target || '}', 
+        ', '
+    ) AS locks_waited
+
+FROM
+    dist_pg_locks_all_info AS lw
+LEFT JOIN
+    cn_activities AS waiter_cn ON lw.waiter_gxid = waiter_cn.gxid
+LEFT JOIN
+    cn_activities AS blocker_cn ON lw.blocking_gxid = blocker_cn.gxid
+WHERE
+    NOT lw.granted
+GROUP BY
+    -- 【核心修正】将源头节点名称加入GROUP BY子句
+    lw.waiter_gxid,
+    lw.blocking_gxid,
+    waiter_cn.nodename,
+    waiter_cn.usename,
+    waiter_cn.client_addr,
+    waiter_cn.top_level_query,
+    blocker_cn.nodename,
+    blocker_cn.usename,
+    blocker_cn.client_addr,
+    blocker_cn.top_level_query;
+
 -- 授权
 GRANT SELECT ON dist_pg_stat_activity TO PUBLIC;
 GRANT SELECT ON dist_pg_stat_activity_cn TO PUBLIC;
@@ -527,3 +640,4 @@ GRANT SELECT ON dist_pg_locks TO PUBLIC;
 GRANT SELECT ON dist_pg_locks_all_info TO PUBLIC;
 GRANT SELECT ON dist_pg_lock_wait_chains TO PUBLIC;
 GRANT SELECT ON dist_pg_deadlocks TO PUBLIC;
+GRANT SELECT ON dist_pg_lock_waits_summary TO PUBLIC;

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2023 THL A29 Limited, a Tencent company.
+ *
+ * This source code file is licensed under the BSD 3-Clause License,
+ * you may obtain a copy of the License at http://opensource.org/license/bsd-3-clause
+ * 
+ */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "CREATE EXTENSION pg_dist_stat_views" to load this file. \quit
+
+/* Now redefine */
+CREATE OR REPLACE FUNCTION dist_pg_stat_get_activity(
+    sessionid text,
+    coordonly bool,
+    localonly bool,
+
+    -- 在第一阶段，你可以保持和原来完全一样，以求功能对等。
+    -- 在第二阶段（功能增强），你就可以在这里增加、删除或修改列了！
+    OUT sessionid text,
+    OUT pid integer,
+    OUT client_addr inet,
+    OUT client_hostname text,
+    OUT client_port integer,
+    OUT nodename text,
+    OUT role text,
+    OUT datname text,
+    OUT usename text,
+    OUT wait_event_type text,
+    OUT wait_event text,
+    OUT state text,
+    OUT sqname text,
+    OUT sqdone bool,
+    OUT query text,
+    OUT planstate text,
+    OUT portal text,
+    OUT cursors text,
+    OUT backend_start timestamp with time zone,
+    OUT xact_start timestamp with time zone,
+    OUT query_start timestamp with time zone,
+    OUT state_change timestamp with time zone,
+    OUT application_name text,
+    OUT backend_xid xid,
+    OUT backend_xmin xid,
+    OUT backend_type text,
+    OUT global_query_id text
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+-- 你的首要目标是实现视图。等视图功能稳定后，再考虑是否需要实现这些管理功能。
+-- 如果要保留，也需要把它们的名字和实现都改成你自己的版本。
+/*
+CREATE OR REPLACE FUNCTION pg_signal_session(text, integer, bool)
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION pg_terminate_session(text)
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+CREATE OR REPLACE FUNCTION pg_cancel_session(text)
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+*/
+
+CREATE OR REPLACE VIEW dist_pg_stat_activity AS
+  SELECT * FROM dist_pg_stat_get_activity(NULL, false, false);
+
+CREATE OR REPLACE VIEW dist_pg_stat_activity_cn AS
+  SELECT * FROM dist_pg_stat_get_activity(NULL, true, false);
+
+-- ===================================================================
+-- 视图名称: dist_pg_stat_query_summary
+-- 视图目标: 提供一个以“全局查询ID (global_query_id)”为核心的聚合摘要视图。
+--          每一行代表一个正在运行的完整分布式查询，将所有参与节点的
+--          关键信息进行语义化整合，旨在帮助DBA快速定位慢查询、
+--          识别性能瓶颈和理解分布式查询的执行模式。
+-- ===================================================================
+CREATE OR REPLACE VIEW dist_pg_stat_query_summary AS
+
+-- 使用 WITH 子句 (CTE - Common Table Expression) 定义一个基础数据集。
+-- 这样做可以避免在后续的多个子查询中重复书写 FROM 和 WHERE 子句，
+-- 使代码更简洁，也可能让查询规划器更好地优化。
+WITH query_activities AS (
+    SELECT *
+    FROM dist_pg_stat_activity
+    -- 核心过滤条件：只关心那些已经被我们的扩展模块成功打上 GID 标签的活动。
+    -- 这会自动排除掉后台进程、空闲的连接池连接等“噪音”。
+    WHERE global_query_id IS NOT NULL AND global_query_id != ''
+),
+
+-- 2. 【核心】直接、纯粹地拼接字段，创建“复合角色”
+activities_with_compound_role AS (
+    SELECT
+        *,
+        -- 使用 COALESCE 确保即使某个字段为 NULL，拼接也能正常工作
+        -- 将 role 和 backend_type 直接用 '-' 连接
+        (COALESCE(role, 'unknown_role') || '-' || COALESCE(backend_type, 'unknown_type')) 
+            AS compound_role
+    FROM
+        query_activities
+)
+
+SELECT
+    -- 【1. 核心关联ID】
+    -- 这是聚合的唯一键，代表一次完整的分布式查询。
+    gid.global_query_id,
+
+    -- 【2. 查询发起者信息】
+    -- 通过 FILTER 子句，我们只从角色为 'coordinator' 的记录中提取这些信息，
+    -- 因为只有协调节点才能代表查询的“源头”。
+    MAX(gid.query) FILTER (WHERE gid.role = 'coordinator') AS top_level_query,
+    MAX(gid.usename) FILTER (WHERE gid.role = 'coordinator') AS username,
+    MAX(gid.application_name) FILTER (WHERE gid.role = 'coordinator') AS application_name,
+    MAX(gid.client_addr) FILTER (WHERE gid.role = 'coordinator') AS client_address,
+
+    -- 【3. 性能与事务指标】
+    -- 这个查询从在协调节点上开始，到当前的总耗时。是定位慢查询最直接的指标。
+    (NOW() - MIN(gid.query_start))::interval(3) AS total_duration,
+    -- 参与本次查询的进程（Process）总数
+    COUNT(*) AS involved_processes,
+    -- 参与本次查询的独立节点（CN/DN）的总数。
+    COUNT(DISTINCT gid.nodename) AS distinct_nodes,
+    -- 整个分布式查询的最小 xmin。这个值长时间不推进，可能导致表膨胀。
+    -- 【修正】在聚合前，将 xid 类型强制转换为 bigint，先转test字符串
+    MIN((gid.backend_xmin::text)::bigint) AS cluster_xmin_horizon,
+
+    /*
+    xid (Transaction ID) 是一个PostgreSQL内部专用的、32位的无符号整数类型。
+    虽然它本质上是数字，但它有特殊的“回卷 (wraparound)”行为。
+    为了防止用户对它进行无意义的数学运算（比如求平均事务ID），
+    PostgreSQL 没有为 xid 类型预定义 MIN 或 MAX 这些聚合函数。
+    */
+    
+    /*
+     * ===================================================================
+     * 【4. 语义化聚合展示区】
+     * 通过子查询和字符串/数组聚合函数，将多行明细数据浓缩成高度可读的文本摘要。
+     * ===================================================================
+     */
+
+    /*
+     * 【状态摘要】
+     * 将所有参与进程的状态进行分组统计，以 "状态名(数量){节点-进程列表}" 的格式呈现。
+     * 示例: "active(7){cn001:pid1,dn001:pid2,dn001:pid3...}"
+     */
+    (SELECT STRING_AGG(
+                state_summary.state || '(' || state_summary.count || '){' || array_to_string(state_summary.node_pids, ',') || '}',
+                ', '
+            )
+     FROM (SELECT 
+                state, 
+                COUNT(*) as count, 
+                -- 将 "nodename:pid" 拼接起来，再聚合成数组
+                ARRAY_AGG(nodename || ':' || pid ORDER BY nodename, pid) as node_pids
+           FROM query_activities
+           WHERE global_query_id = gid.global_query_id
+           GROUP BY state
+           ORDER BY state
+          ) AS state_summary
+    ) AS states_summary,
+
+    /*
+     * 【等待事件摘要】
+     * 将所有正在发生的等待事件进行分组统计，聚合信息中包含具体的PID，格式与状态摘要类似。
+     * 示例: "PgSleep(2){dn001:pid1,dn002:pid2}"
+     * 这是定位性能瓶颈最关键的字段之一。
+     */
+    (SELECT STRING_AGG(
+                wait_summary.wait_event || '(' || wait_summary.count || '){' || array_to_string(wait_summary.node_pids, ',') || '}',
+                ', '
+            )
+     FROM (SELECT 
+                wait_event, 
+                COUNT(*) as count, 
+                -- 将 "nodename:pid" 拼接起来，再聚合成数组
+                ARRAY_AGG(nodename || ':' || pid ORDER BY nodename, pid) as node_pids
+           FROM query_activities
+           WHERE global_query_id = gid.global_query_id AND wait_event IS NOT NULL
+           GROUP BY wait_event
+           ORDER BY wait_event
+          ) AS wait_summary
+    ) AS waits_summary,
+    
+    /*
+     * 【后端参与者摘要】
+     * 将分布式角色(role)和后端类型(backend_type)结合，提供最精确的参与者画像。
+     * 格式: "角色-类型(数量){PID列表}"
+     * 示例: "coordinator-client backend(1){123}, datanode-parallel worker(6){...}"
+     * 揭示了查询的并行执行模式。
+     */
+    (SELECT STRING_AGG(
+                -- 直接使用我们拼接好的 compound_role 进行展示
+                role_summary.compound_role 
+                || '(' || role_summary.count || '){' || array_to_string(role_summary.pids, ',') || '}',
+                ', '
+            )
+     FROM (SELECT 
+                compound_role, 
+                COUNT(*) as count, 
+                ARRAY_AGG(pid ORDER BY pid) as pids
+           FROM activities_with_compound_role
+           WHERE global_query_id = gid.global_query_id AND compound_role IS NOT NULL
+           GROUP BY compound_role -- 【只按拼接后的新字段分组！】
+           ORDER BY compound_role
+          ) AS role_summary
+    ) AS backends_summary
+
+FROM
+    query_activities AS gid
+GROUP BY
+    gid.global_query_id
+-- 【最终过滤】
+-- 使用 HAVING 子句，确保只显示那些【当前至少还有一个进程在 active 状态】的查询。
+-- 这解决了因统计延迟而导致的“幽灵摘要”（已结束查询的摘要残留）问题，
+-- 使得这个视图成为一个真正的“实时”仪表盘。
+HAVING
+    COUNT(*) FILTER (WHERE gid.state = 'active') > 0;
+
+-- ===================================================================
+-- 【新增】分布式查询活动明细视图 (按 GID 排序)
+-- ===================================================================
+CREATE OR REPLACE VIEW dist_pg_stat_query_details AS
+SELECT
+    -- 核心关联与身份信息
+    gid.global_query_id,
+    gid.sessionid,
+    gid.nodename,
+    gid.role,
+    gid.pid,
+    gid.usename,
+    gid.datname,
+    gid.application_name, -- 【新增】
+    gid.client_addr,
+    gid.backend_type,     -- 【新增】
+
+    -- 状态与等待信息
+    gid.state,
+    gid.wait_event_type,
+    gid.wait_event,
+    
+    -- 事务信息
+    gid.backend_xid,      -- 【新增】
+    gid.backend_xmin,     -- 【新增】
+    
+    -- 时间戳信息
+    gid.query_start,
+    gid.xact_start,
+    gid.backend_start,
+    gid.state_change,
+    
+    -- 查询与计划文本 (通常比较长，放在后面)
+    gid.query,
+    gid.planstate
+FROM
+    dist_pg_stat_activity AS gid
+WHERE
+    -- 同样，我们只关心那些有 GID 的、真正的分布式查询活动
+    gid.global_query_id IS NOT NULL AND gid.global_query_id != ''
+ORDER BY
+    -- 【核心排序逻辑】
+    -- 1. 首先，按照 global_query_id 排序，把同一个查询的所有活动都聚在一起。
+    gid.global_query_id,
+    
+    -- 2. 在同一个 GID 内部，我们进行二次排序，让结果更有条理。
+    --    这里用一个 CASE 语句来给节点角色赋予一个排序优先级：
+    --    CN (1) > DN (2) > 其他。
+    --    这确保了发起查询的 CN 记录总是出现在每个分组的最前面。
+    CASE gid.role
+        WHEN 'coordinator' THEN 1
+        WHEN 'datanode' THEN 2
+        ELSE 3
+    END,
+
+    -- 3. 最后，按节点名排序，让输出更稳定。
+    gid.nodename;
+
+-- 授权
+GRANT SELECT ON dist_pg_stat_activity TO PUBLIC;
+GRANT SELECT ON dist_pg_stat_activity_cn TO PUBLIC;
+GRANT SELECT ON dist_pg_stat_query_summary TO PUBLIC;
+GRANT SELECT ON dist_pg_stat_query_details TO PUBLIC;

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -415,72 +415,111 @@ LEFT JOIN
 
 -- 视图 1: 完整的分布式锁等待链
 CREATE OR REPLACE VIEW dist_pg_lock_wait_chains AS
-WITH RECURSIVE lock_chain AS (
-    -- 递归的起点 (Anchor)
+WITH RECURSIVE 
+lock_chains_raw AS (
+    -- ==========================================================
+    -- 1. 递归的起点 (Anchor Member)
+    -- ==========================================================
     SELECT
         1 AS level,
-        locks.gxid AS waiter_gxid,
-        locks.pid AS waiter_pid,
+        -- 我们需要传递等待者和阻塞者的所有关键信息
+        locks.waiter_gxid,
+        locks.waiter_pid,
         locks.node_name AS waiter_node,
         locks.blocking_gxid,
         locks.blocking_pid,
         locks.blocking_node_name,
-        ARRAY[locks.gxid] AS path,
-        (locks.node_name || ':' || locks.pid) AS path_detail
-    FROM
-        dist_pg_locks AS locks
-    WHERE
-        NOT locks.granted
+        
+        -- 路径数组，用于递归和展示
+        ARRAY[locks.waiter_gxid] AS gxid_path,
+        ARRAY[locks.waiter_pid || ':' || locks.node_name] AS physical_path,
+        
+        -- 链头的唯一标识 (就是等待者自己)
+        locks.waiter_gxid AS chain_head_gxid
+        
+    FROM 
+        dist_pg_locks_all_info AS locks
+    WHERE 
+        NOT locks.granted AND locks.blocking_gxid IS NOT NULL
 
     UNION ALL
 
-    -- 递归的递推
+    -- ==========================================================
+    -- 2. 递归的递推部分 (Recursive Member)
+    -- ==========================================================
     SELECT
         lc.level + 1,
-        lc.blocking_gxid,
-        lc.blocking_pid,
-        lc.blocking_node_name,
+        
+        lc.blocking_gxid AS waiter_gxid,
+        locks.waiter_pid,
+        locks.node_name AS waiter_node,
+        
         locks.blocking_gxid,
         locks.blocking_pid,
         locks.blocking_node_name,
-        lc.path || lc.blocking_gxid,
-        lc.path_detail || ' -> ' || (locks.node_name || ':' || locks.pid)
-    FROM
-        lock_chain lc
-    JOIN
-        dist_pg_locks locks ON lc.blocking_gxid = locks.gxid AND lc.blocking_pid = locks.pid
-    WHERE
-        NOT locks.granted AND NOT (locks.gxid = ANY(lc.path))
+        
+        lc.gxid_path || lc.blocking_gxid,
+        lc.physical_path || (locks.waiter_pid || ':' || locks.node_name),
+        
+        lc.chain_head_gxid
+    FROM 
+        lock_chains_raw lc
+    -- 【核心JOIN】使用 GXID 作为唯一的连接条件！
+    JOIN 
+        dist_pg_locks_all_info AS locks 
+      ON lc.blocking_gxid = locks.waiter_gxid
+    WHERE 
+        NOT locks.granted AND locks.blocking_gxid IS NOT NULL
+      AND NOT (lc.blocking_gxid = ANY(lc.gxid_path))
+),
+-- 第二步：为每个链头，找到其最长的链
+longest_chains AS (
+    SELECT DISTINCT ON (chain_head_gxid)
+        chain_head_gxid,
+        level AS chain_length,
+        gxid_path,
+        physical_path,
+        blocking_gxid AS root_blocker_gxid,
+        blocking_pid AS root_blocker_pid,
+        blocking_node_name AS root_blocker_node
+    FROM lock_chains_raw
+    ORDER BY chain_head_gxid, level DESC
+),
+-- 第三步：准备源头信息
+cn_activities AS (
+    SELECT DISTINCT ON (gxid)
+        gxid, usename, client_addr, query AS top_level_query, nodename AS source_node
+    FROM dist_pg_stat_activity
+    WHERE role = 'coordinator' AND gxid IS NOT NULL
+    ORDER BY gxid, query_start DESC
 )
--- 最终输出: 将递归结果与锁信息和活动信息进行关联
-SELECT
-    c.level AS wait_level,
-    c.path_detail AS wait_chain,
-    -- 等待者信息
-    c.waiter_node,
-    c.waiter_pid,
-    c.waiter_gxid,
-    -- 从 dist_pg_stat_activity (别名 act) 获取 state 和 query
-    act.state AS waiter_state,
-    (now() - act.query_start)::interval(3) AS waiter_duration,
-    act.query AS waiter_query,
-    -- 锁信息 (来自 dist_pg_locks, 别名 l)
-    l.lock_target,
-    l.mode AS lock_mode,
-    -- 阻塞者信息
-    c.blocking_node_name,
-    c.blocking_pid,
-    c.blocking_gxid
+-- 第四步：最终输出，将所有信息整合
+SELECT 
+    lc.chain_length,
+    array_to_string(lc.gxid_path, ' -> ') || ' -> ' || lc.root_blocker_gxid AS full_wait_chain_gxid,
+    array_to_string(lc.physical_path, ' -> ') || ' -> ' || (lc.root_blocker_pid || ':' || lc.root_blocker_node) AS full_wait_chain_pids,
+    
+    -- 链头信息 (最初的等待者)
+    head_cn.source_node AS chain_head_source_node,
+    head_cn.usename AS chain_head_user,
+    lc.chain_head_gxid,
+    
+    -- 根源信息 (最终的阻塞者)
+    root_cn.source_node AS root_blocker_source_node,
+    root_cn.usename AS root_blocker_user,
+    lc.root_blocker_gxid,
+    
+    -- 链头和根源的顶层查询
+    head_cn.top_level_query AS chain_head_query,
+    root_cn.top_level_query AS root_blocker_query
 FROM
-    lock_chain c
--- 关联 dist_pg_locks 以获取锁的详细信息
-JOIN
-    dist_pg_locks l ON c.waiter_gxid = l.gxid AND c.waiter_pid = l.pid
--- 关联 dist_pg_stat_activity 以获取等待者的活动信息
-JOIN
-    dist_pg_stat_activity act ON c.waiter_pid = act.pid AND c.waiter_node = act.nodename
-ORDER BY
-    c.path, c.level;
+    longest_chains lc
+-- 关联链头事务的“源头”信息
+LEFT JOIN
+    cn_activities AS head_cn ON lc.chain_head_gxid = head_cn.gxid
+-- 关联根源阻塞事务的“源头”信息
+LEFT JOIN
+    cn_activities AS root_cn ON lc.root_blocker_gxid = root_cn.gxid;
 
 -- 视图 2: 分布式死锁检测
 CREATE OR REPLACE VIEW dist_pg_deadlocks AS

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -286,49 +286,66 @@ potential_blockers AS (
         -- 关键的预过滤条件：
         -- 1. 进程必须有一个有效的分布式事务ID
         gxid IS NOT NULL 
-        -- 2. 进程不能是完全空闲的
+        -- 2. 进程不能是完全空闲的，但【必须包括】idle in transaction
         AND state != 'idle'
-)
-SELECT
-    -- 从 dist_pg_locks_raw 中获取的所有原始信息
-    raw.node_name,
-    raw.granted,
-    raw.gxid,
-    raw.pid,
-    raw.locktype,
-    raw.database,
-    raw.relation,
-    raw.page,
-    raw.tuple,
-    raw.virtualxid,
-    raw.transactionid,
-    raw.classid,
-    raw.objid,
-    raw.objsubid,
-    raw.virtualtransaction,
-    raw.mode,
-    raw.fastpath,
-    
-    -- 【核心逻辑】通过JOIN我们预过滤后的 potential_blockers，来查找并补全 blocking_node_name
-    blockers.nodename AS blocking_node_name,
-    
-    -- 从 dist_pg_locks_raw 中获取的、由C代码精确找到的阻塞者ID
-    raw.blocking_pid,
-    raw.blocking_gxid,
+),
 
-    -- 为了方便用户，增加一个可读的 lock_target 列
-    CASE 
-        WHEN raw.locktype = 'relation' THEN raw.relation::regclass::text 
-        WHEN raw.locktype = 'transactionid' THEN raw.transactionid::text
-        ELSE pg_describe_object(raw.classid, raw.objid, raw.objsubid)
-    END AS lock_target
+-- 第二步：将原始锁信息与阻塞者地址（nodename）进行关联
+enriched_locks AS (
+    SELECT
+        raw.*, -- 包含所有原始锁信息
+        blockers.nodename AS blocking_node_name,
+        CASE 
+            WHEN raw.locktype = 'relation' THEN raw.relation::regclass::text 
+            WHEN raw.locktype = 'transactionid' THEN raw.transactionid::text
+            ELSE pg_describe_object(raw.classid, raw.objid, raw.objsubid)
+        END AS lock_target
+    FROM
+        dist_pg_locks_raw AS raw
+    LEFT JOIN
+        potential_blockers AS blockers
+        ON raw.blocking_pid = blockers.pid AND raw.blocking_gxid = blockers.gxid
+)
+
+-- 第三步：【核心】对增强后的结果进行最终的去重和选择
+SELECT DISTINCT ON (node_name, pid, granted, lock_target)
+    -- 选择所有需要的列
+    node_name,
+    granted,
+    gxid,
+    pid,
+    locktype,
+    database,
+    relation,
+    page,
+    tuple,
+    virtualxid,
+    transactionid,
+    classid,
+    objid,
+    objsubid,
+    virtualtransaction,
+    mode,
+    fastpath,
+    blocking_node_name,
+    blocking_pid,
+    blocking_gxid,
+    lock_target
 FROM
-    dist_pg_locks_raw AS raw
--- 使用 LEFT JOIN，以防阻塞者信息因时序问题暂时不可见
-LEFT JOIN
-    potential_blockers AS blockers
-    -- 使用最精确的关联键：阻塞者的 PID 和 GXID
-    ON raw.blocking_pid = blockers.pid AND raw.blocking_gxid = blockers.gxid;
+    enriched_locks
+-- ORDER BY 必须以 DISTINCT ON 的列开始
+ORDER BY
+    node_name, pid, granted, lock_target,
+    -- 内部排序：优先保留最重要的锁模式记录
+    CASE mode
+        WHEN 'AccessExclusiveLock' THEN 1
+        WHEN 'ExclusiveLock' THEN 2
+        WHEN 'ShareRowExclusiveLock' THEN 3
+        WHEN 'RowExclusiveLock' THEN 4
+        WHEN 'ShareLock' THEN 5
+        -- ... (其他锁模式的优先级)
+        ELSE 99
+    END;
 
 -- 包含所有活动信息的大而全视图
 CREATE OR REPLACE VIEW dist_pg_locks_all_info AS
@@ -342,7 +359,7 @@ SELECT
     act.query AS waiter_query,
     l.locktype,
     l.mode,
-    CASE 
+    CASE -- 直接显示出被锁的表名
         WHEN l.locktype = 'relation' THEN l.relation::regclass::text 
         WHEN l.locktype = 'transactionid' THEN l.transactionid::text
         ELSE pg_describe_object(l.classid, l.objid, l.objsubid)

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -15,8 +15,6 @@ CREATE OR REPLACE FUNCTION dist_pg_stat_get_activity(
     IN coordonly bool,
     IN localonly bool,
 
-    -- 在第一阶段，你可以保持和原来完全一样，以求功能对等。
-    -- 在第二阶段（功能增强），你就可以在这里增加、删除或修改列了！
     OUT sessionid text,
     OUT pid integer,
     OUT client_addr inet,
@@ -49,11 +47,6 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
--- ===================================================================
--- ==                 Distributed Locks Information                 ==
--- ===================================================================
-
--- 定义新的SRF函数，这是用户查询的入口
 CREATE OR REPLACE FUNCTION get_dist_pg_locks(
     IN localonly boolean DEFAULT false,
     OUT node_name text,
@@ -73,31 +66,10 @@ CREATE OR REPLACE FUNCTION get_dist_pg_locks(
     OUT granted boolean,
     OUT fastpath boolean,
     OUT gxid text
-    -- OUT blocking_pid integer,
-    -- OUT blocking_gxid text
 )
 RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'get_dist_pg_locks'
 LANGUAGE C STRICT VOLATILE;
-
--- 你的首要目标是实现视图。等视图功能稳定后，再考虑是否需要实现这些管理功能。
--- 如果要保留，也需要把它们的名字和实现都改成你自己的版本。
-/*
-CREATE OR REPLACE FUNCTION pg_signal_session(text, integer, bool)
-RETURNS bool
-AS 'MODULE_PATHNAME'
-LANGUAGE C;
-
-CREATE OR REPLACE FUNCTION pg_terminate_session(text)
-RETURNS bool
-AS 'MODULE_PATHNAME'
-LANGUAGE C;
-
-CREATE OR REPLACE FUNCTION pg_cancel_session(text)
-RETURNS bool
-AS 'MODULE_PATHNAME'
-LANGUAGE C;
-*/
 
 CREATE OR REPLACE VIEW dist_pg_stat_activity AS
   SELECT * FROM dist_pg_stat_get_activity(NULL, false, false);
@@ -120,12 +92,10 @@ CREATE OR REPLACE VIEW dist_pg_stat_query_summary AS
 WITH query_activities AS (
     SELECT *
     FROM dist_pg_stat_activity
-    -- 核心过滤条件：只关心那些已经被我们的扩展模块成功打上 GID 标签的活动。
-    -- 这会自动排除掉后台进程、空闲的连接池连接等“噪音”。
+    -- 排除掉后台进程、空闲的连接池连接等“噪音”。
     WHERE global_query_id IS NOT NULL AND global_query_id != ''
 ),
 
--- 2. 【核心】直接、纯粹地拼接字段，创建“复合角色”
 activities_with_compound_role AS (
     SELECT
         *,
@@ -138,19 +108,16 @@ activities_with_compound_role AS (
 )
 
 SELECT
-    -- 【1. 核心关联ID】
     -- 这是聚合的唯一键，代表一次完整的分布式查询。
     gid.global_query_id,
 
-    -- 【2. 查询发起者信息】
-    -- 通过 FILTER 子句，我们只从角色为 'coordinator' 的记录中提取这些信息，
+    -- 通过 FILTER 子句，从角色为 'coordinator' 的记录中提取这些信息，
     -- 因为只有协调节点才能代表查询的“源头”。
     MAX(gid.query) FILTER (WHERE gid.role = 'coordinator') AS top_level_query,
     MAX(gid.usename) FILTER (WHERE gid.role = 'coordinator') AS username,
     MAX(gid.application_name) FILTER (WHERE gid.role = 'coordinator') AS application_name,
     MAX(gid.client_addr) FILTER (WHERE gid.role = 'coordinator') AS client_address,
 
-    -- 【3. 性能与事务指标】
     -- 这个查询从在协调节点上开始，到当前的总耗时。是定位慢查询最直接的指标。
     (NOW() - MIN(gid.query_start))::interval(3) AS total_duration,
     -- 参与本次查询的进程（Process）总数
@@ -158,7 +125,7 @@ SELECT
     -- 参与本次查询的独立节点（CN/DN）的总数。
     COUNT(DISTINCT gid.nodename) AS distinct_nodes,
     -- 整个分布式查询的最小 xmin。这个值长时间不推进，可能导致表膨胀。
-    -- 【修正】在聚合前，将 xid 类型强制转换为 bigint，先转test字符串
+    -- 在聚合前，将 xid 类型强制转换为 bigint，先转test字符串
     MIN((gid.backend_xmin::text)::bigint) AS cluster_xmin_horizon,
 
     /*
@@ -167,13 +134,6 @@ SELECT
     为了防止用户对它进行无意义的数学运算（比如求平均事务ID），
     PostgreSQL 没有为 xid 类型预定义 MIN 或 MAX 这些聚合函数。
     */
-    
-    /*
-     * ===================================================================
-     * 【4. 语义化聚合展示区】
-     * 通过子查询和字符串/数组聚合函数，将多行明细数据浓缩成高度可读的文本摘要。
-     * ===================================================================
-     */
 
     /*
      * 【状态摘要】
@@ -197,10 +157,8 @@ SELECT
     ) AS states_summary,
 
     /*
-     * 【等待事件摘要】
      * 将所有正在发生的等待事件进行分组统计，聚合信息中包含具体的PID，格式与状态摘要类似。
      * 示例: "PgSleep(2){dn001:pid1,dn002:pid2}"
-     * 这是定位性能瓶颈最关键的字段之一。
      */
     (SELECT STRING_AGG(
                 wait_summary.wait_event || '(' || wait_summary.count || '){' || array_to_string(wait_summary.node_pids, ',') || '}',
@@ -219,11 +177,9 @@ SELECT
     ) AS waits_summary,
     
     /*
-     * 【后端参与者摘要】
      * 将分布式角色(role)和后端类型(backend_type)结合，提供最精确的参与者画像。
      * 格式: "角色-类型(数量){PID列表}"
      * 示例: "coordinator-client backend(1){123}, datanode-parallel worker(6){...}"
-     * 揭示了查询的并行执行模式。
      */
     (SELECT STRING_AGG(
                 -- 直接使用我们拼接好的 compound_role 进行展示
@@ -237,7 +193,7 @@ SELECT
                 ARRAY_AGG(pid ORDER BY pid) as pids
            FROM activities_with_compound_role
            WHERE global_query_id = gid.global_query_id AND compound_role IS NOT NULL
-           GROUP BY compound_role -- 【只按拼接后的新字段分组！】
+           GROUP BY compound_role
            ORDER BY compound_role
           ) AS role_summary
     ) AS backends_summary
@@ -246,15 +202,12 @@ FROM
     query_activities AS gid
 GROUP BY
     gid.global_query_id
--- 【最终过滤】
--- 使用 HAVING 子句，确保只显示那些【当前至少还有一个进程在 active 状态】的查询。
--- 这解决了因统计延迟而导致的“幽灵摘要”（已结束查询的摘要残留）问题，
--- 使得这个视图成为一个真正的“实时”仪表盘。
+-- 使用 HAVING 子句，确保只显示那些（当前至少还有一个进程在 active 状态）的查询。
 HAVING
     COUNT(*) FILTER (WHERE gid.state = 'active') > 0;
 
 -- ===================================================================
--- 【新增】分布式查询活动明细视图 (按 GID 排序)
+-- 布式查询活动明细视图 (按 GID 排序)
 -- ===================================================================
 CREATE OR REPLACE VIEW dist_pg_stat_query_details AS
 SELECT
@@ -266,9 +219,9 @@ SELECT
     gid.pid,
     gid.usename,
     gid.datname,
-    gid.application_name, -- 【新增】
+    gid.application_name,
     gid.client_addr,
-    gid.backend_type,     -- 【新增】
+    gid.backend_type,
 
     -- 状态与等待信息
     gid.state,
@@ -276,8 +229,8 @@ SELECT
     gid.wait_event,
     
     -- 事务信息
-    gid.backend_xid,      -- 【新增】
-    gid.backend_xmin,     -- 【新增】
+    gid.backend_xid,
+    gid.backend_xmin,
     
     -- 时间戳信息
     gid.query_start,
@@ -285,38 +238,35 @@ SELECT
     gid.backend_start,
     gid.state_change,
     
-    -- 查询与计划文本 (通常比较长，放在后面)
+    -- 查询与计划文本
     gid.query,
     gid.planstate
 FROM
     dist_pg_stat_activity AS gid
 WHERE
-    -- 同样，我们只关心那些有 GID 的、真正的分布式查询活动
     gid.global_query_id IS NOT NULL AND gid.global_query_id != ''
 ORDER BY
-    -- 【核心排序逻辑】
     -- 1. 首先，按照 global_query_id 排序，把同一个查询的所有活动都聚在一起。
     gid.global_query_id,
     
-    -- 2. 在同一个 GID 内部，我们进行二次排序，让结果更有条理。
-    --    这里用一个 CASE 语句来给节点角色赋予一个排序优先级：
+    -- 2. 在同一个 GID 内部，进行二次排序，让结果更有条理。
+    --    用一个 CASE 语句来给节点角色赋予一个排序优先级：
     --    CN (1) > DN (2) > 其他。
-    --    这确保了发起查询的 CN 记录总是出现在每个分组的最前面。
     CASE gid.role
         WHEN 'coordinator' THEN 1
         WHEN 'datanode' THEN 2
         ELSE 3
     END,
 
-    -- 3. 最后，按节点名排序，让输出更稳定。
+    -- 3. 最后，按节点名排序
     gid.nodename;
 
--- 创建最终用户视图：dist_pg_locks
+-- 创建用户视图：dist_pg_locks
 -- 创建一个基础的、只封装C函数的锁视图
 CREATE OR REPLACE VIEW dist_pg_locks_raw AS
   SELECT * FROM get_dist_pg_locks(false);
 
--- 创建最终的、在SQL层推断阻塞关系的 dist_pg_locks 视图
+-- 创建在SQL层推断阻塞关系的 dist_pg_locks 视图
 CREATE OR REPLACE VIEW dist_pg_locks AS
 WITH 
 waiters AS (
@@ -334,16 +284,16 @@ blocking_pairs AS (
         h.gxid AS blocking_gxid
     FROM waiters w JOIN holders h 
       ON w.database = h.database AND (
-         -- 精确匹配表、页、元组锁
+         -- 匹配表、页、元组锁
          (w.relation IS NOT NULL AND w.relation = h.relation) OR
-         -- 精确匹配事务ID锁
+         -- 匹配事务ID锁
          (w.locktype = 'transactionid' AND w.transactionid = h.transactionid) OR
-         -- 精确匹配 advisory lock (假设 classid 和 objid 相同)
+         -- 匹配 advisory lock
          (w.locktype = 'advisory' AND w.classid = h.classid AND w.objid = h.objid)
       )
     WHERE w.pid != h.pid
 )
--- 最终整合输出
+-- 整合输出
 SELECT 
     -- 核心锁信息
     raw.node_name,
@@ -360,7 +310,7 @@ SELECT
         ELSE pg_describe_object(raw.classid, raw.objid, raw.objsubid)
     END AS lock_target,
     
-    -- 【核心】推断出的阻塞者信息
+    -- 推断出的阻塞者信息
     bp.blocking_node_name,
     bp.blocking_pid,
     bp.blocking_gxid,
@@ -371,7 +321,7 @@ SELECT
     raw.virtualtransaction
 FROM 
     dist_pg_locks_raw AS raw
--- 只做一次 LEFT JOIN，关联我们内部计算出的阻塞关系
+-- 做一次 LEFT JOIN，关联内部计算出的阻塞关系
 LEFT JOIN
     blocking_pairs bp ON raw.pid = bp.waiter_pid AND raw.node_name = bp.waiter_node;
 
@@ -379,9 +329,7 @@ LEFT JOIN
 -- ==      Advanced Lock Analysis Views (Wait Chains & Deadlocks)   ==
 -- ===================================================================
 
--- in pg_dist_stat_views--1.0.sql
-
--- 视图 1: 完整的分布式锁等待链 (修正版)
+-- 视图 1: 完整的分布式锁等待链
 CREATE OR REPLACE VIEW dist_pg_lock_wait_chains AS
 WITH RECURSIVE lock_chain AS (
     -- 递归的起点 (Anchor)
@@ -402,7 +350,7 @@ WITH RECURSIVE lock_chain AS (
 
     UNION ALL
 
-    -- 递归的递推 (Recursive Step)
+    -- 递归的递推
     SELECT
         lc.level + 1,
         lc.blocking_gxid,
@@ -420,7 +368,7 @@ WITH RECURSIVE lock_chain AS (
     WHERE
         NOT locks.granted AND NOT (locks.gxid = ANY(lc.path))
 )
--- 最终输出: 将递归结果与锁信息和【活动信息】进行关联
+-- 最终输出: 将递归结果与锁信息和活动信息进行关联
 SELECT
     c.level AS wait_level,
     c.path_detail AS wait_chain,
@@ -428,7 +376,7 @@ SELECT
     c.waiter_node,
     c.waiter_pid,
     c.waiter_gxid,
-    -- 【核心修正】从 dist_pg_stat_activity (别名 act) 获取 state 和 query
+    -- 从 dist_pg_stat_activity (别名 act) 获取 state 和 query
     act.state AS waiter_state,
     (now() - act.query_start)::interval(3) AS waiter_duration,
     act.query AS waiter_query,
@@ -444,16 +392,16 @@ FROM
 -- 关联 dist_pg_locks 以获取锁的详细信息
 JOIN
     dist_pg_locks l ON c.waiter_gxid = l.gxid AND c.waiter_pid = l.pid
--- 【核心修正】关联 dist_pg_stat_activity 以获取等待者的活动信息
+-- 关联 dist_pg_stat_activity 以获取等待者的活动信息
 JOIN
     dist_pg_stat_activity act ON c.waiter_pid = act.pid AND c.waiter_node = act.nodename
 ORDER BY
     c.path, c.level;
 
 
--- 视图 2: 分布式死锁检测 (最终修正版)
+-- 视图 2: 分布式死锁检测
 CREATE OR REPLACE VIEW dist_pg_deadlocks AS
-WITH RECURSIVE lock_chain ( -- 【核心修正】在这里显式声明所有列名
+WITH RECURSIVE lock_chain ( -- 在这里显式声明所有列名
     waiter_gxid,
     waiter_pid,
     waiter_node,
@@ -495,7 +443,7 @@ WITH RECURSIVE lock_chain ( -- 【核心修正】在这里显式声明所有列�
     JOIN
         dist_pg_locks locks ON lc.blocking_gxid = locks.gxid AND lc.blocking_pid = locks.pid
     WHERE
-        NOT locks.granted AND NOT lc.is_cycle -- 这里的 lc.is_cycle 引用现在是绝对清晰的
+        NOT locks.granted AND NOT lc.is_cycle
 )
 -- 最终输出
 SELECT
@@ -522,5 +470,5 @@ GRANT SELECT ON dist_pg_stat_query_summary TO PUBLIC;
 GRANT SELECT ON dist_pg_stat_query_details TO PUBLIC;
 GRANT SELECT ON dist_pg_locks_raw TO PUBLIC;
 GRANT SELECT ON dist_pg_locks TO PUBLIC;
-GRANT SELECT ON dist_pg_lock_wait_chains TO PUBLIC; -- 授权新视图
-GRANT SELECT ON dist_pg_deadlocks TO PUBLIC;      -- 授权新视图
+GRANT SELECT ON dist_pg_lock_wait_chains TO PUBLIC;
+GRANT SELECT ON dist_pg_deadlocks TO PUBLIC;

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views--1.0.sql
@@ -9,7 +9,15 @@
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "CREATE EXTENSION pg_dist_stat_views" to load this file. \quit
 
-/* Now redefine */
+/******************************************************************************
+ * Section 1: C Function Definitions
+ ******************************************************************************/
+
+--
+-- Name: dist_pg_stat_get_activity(...)
+-- Description: The underlying C function for the distributed activity view.
+--              It collects and fuses activity information from all cluster nodes.
+--
 CREATE OR REPLACE FUNCTION dist_pg_stat_get_activity(
     IN sessionid text,
     IN coordonly bool,
@@ -48,6 +56,12 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
+--
+-- Name: get_dist_pg_locks(boolean)
+-- Description: The underlying C function for the distributed locks view.
+--              It safely collects raw lock information and GXIDs from all nodes.
+--              This function intentionally does not resolve blocking relationships.
+--
 CREATE OR REPLACE FUNCTION get_dist_pg_locks(
     IN localonly boolean DEFAULT false,
     OUT node_name text,
@@ -74,207 +88,43 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME', 'get_dist_pg_locks'
 LANGUAGE C STRICT VOLATILE;
 
+/******************************************************************************
+ * Section 2: Core Data Views
+ ******************************************************************************/
+
+--
+-- View: dist_pg_stat_activity
+-- Description: Provides a cluster-wide, real-time view of backend activity,
+--              analogous to the single-node pg_stat_activity.
+--
 CREATE OR REPLACE VIEW dist_pg_stat_activity AS
   SELECT * FROM dist_pg_stat_get_activity(NULL, false, false);
 
+--
+-- View: dist_pg_stat_activity_cn
+-- Description: A convenience view showing activity only on coordinator nodes.
+--
 CREATE OR REPLACE VIEW dist_pg_stat_activity_cn AS
   SELECT * FROM dist_pg_stat_get_activity(NULL, true, false);
 
--- ===================================================================
--- 视图名称: dist_pg_stat_query_summary
--- 视图目标: 提供一个以“全局查询ID (global_query_id)”为核心的聚合摘要视图。
---          每一行代表一个正在运行的完整分布式查询，将所有参与节点的
---          关键信息进行语义化整合，旨在帮助DBA快速定位慢查询、
---          识别性能瓶颈和理解分布式查询的执行模式。
--- ===================================================================
-CREATE OR REPLACE VIEW dist_pg_stat_query_summary AS
-
--- 使用 WITH 子句 (CTE - Common Table Expression) 定义一个基础数据集。
--- 这样做可以避免在后续的多个子查询中重复书写 FROM 和 WHERE 子句，
--- 使代码更简洁，也可能让查询规划器更好地优化。
-WITH query_activities AS (
-    SELECT *
-    FROM dist_pg_stat_activity
-    -- 排除掉后台进程、空闲的连接池连接等“噪音”。
-    WHERE global_query_id IS NOT NULL AND global_query_id != ''
-),
-
-activities_with_compound_role AS (
-    SELECT
-        *,
-        -- 使用 COALESCE 确保即使某个字段为 NULL，拼接也能正常工作
-        -- 将 role 和 backend_type 直接用 '-' 连接
-        (COALESCE(role, 'unknown_role') || '-' || COALESCE(backend_type, 'unknown_type')) 
-            AS compound_role
-    FROM
-        query_activities
-)
-
-SELECT
-    -- 这是聚合的唯一键，代表一次完整的分布式查询。
-    gid.global_query_id,
-
-    -- 通过 FILTER 子句，从角色为 'coordinator' 的记录中提取这些信息，
-    -- 因为只有协调节点才能代表查询的“源头”。
-    MAX(gid.query) FILTER (WHERE gid.role = 'coordinator') AS top_level_query,
-    MAX(gid.usename) FILTER (WHERE gid.role = 'coordinator') AS username,
-    MAX(gid.application_name) FILTER (WHERE gid.role = 'coordinator') AS application_name,
-    MAX(gid.client_addr) FILTER (WHERE gid.role = 'coordinator') AS client_address,
-
-    -- 这个查询从在协调节点上开始，到当前的总耗时。是定位慢查询最直接的指标。
-    (NOW() - MIN(gid.query_start))::interval(3) AS total_duration,
-    -- 参与本次查询的进程（Process）总数
-    COUNT(*) AS involved_processes,
-    -- 参与本次查询的独立节点（CN/DN）的总数。
-    COUNT(DISTINCT gid.nodename) AS distinct_nodes,
-    -- 整个分布式查询的最小 xmin。这个值长时间不推进，可能导致表膨胀。
-    -- 在聚合前，将 xid 类型强制转换为 bigint，先转test字符串
-    MIN((gid.backend_xmin::text)::bigint) AS cluster_xmin_horizon,
-
-    /*
-    xid (Transaction ID) 是一个PostgreSQL内部专用的、32位的无符号整数类型。
-    虽然它本质上是数字，但它有特殊的“回卷 (wraparound)”行为。
-    为了防止用户对它进行无意义的数学运算（比如求平均事务ID），
-    PostgreSQL 没有为 xid 类型预定义 MIN 或 MAX 这些聚合函数。
-    */
-
-    /*
-     * 【状态摘要】
-     * 将所有参与进程的状态进行分组统计，以 "状态名(数量){节点-进程列表}" 的格式呈现。
-     * 示例: "active(7){cn001:pid1,dn001:pid2,dn001:pid3...}"
-     */
-    (SELECT STRING_AGG(
-                state_summary.state || '(' || state_summary.count || '){' || array_to_string(state_summary.node_pids, ',') || '}',
-                ', '
-            )
-     FROM (SELECT 
-                state, 
-                COUNT(*) as count, 
-                -- 将 "nodename:pid" 拼接起来，再聚合成数组
-                ARRAY_AGG(nodename || ':' || pid ORDER BY nodename, pid) as node_pids
-           FROM query_activities
-           WHERE global_query_id = gid.global_query_id
-           GROUP BY state
-           ORDER BY state
-          ) AS state_summary
-    ) AS states_summary,
-
-    /*
-     * 将所有正在发生的等待事件进行分组统计，聚合信息中包含具体的PID，格式与状态摘要类似。
-     * 示例: "PgSleep(2){dn001:pid1,dn002:pid2}"
-     */
-    (SELECT STRING_AGG(
-                wait_summary.wait_event || '(' || wait_summary.count || '){' || array_to_string(wait_summary.node_pids, ',') || '}',
-                ', '
-            )
-     FROM (SELECT 
-                wait_event, 
-                COUNT(*) as count, 
-                -- 将 "nodename:pid" 拼接起来，再聚合成数组
-                ARRAY_AGG(nodename || ':' || pid ORDER BY nodename, pid) as node_pids
-           FROM query_activities
-           WHERE global_query_id = gid.global_query_id AND wait_event IS NOT NULL
-           GROUP BY wait_event
-           ORDER BY wait_event
-          ) AS wait_summary
-    ) AS waits_summary,
-    
-    /*
-     * 将分布式角色(role)和后端类型(backend_type)结合，提供最精确的参与者画像。
-     * 格式: "角色-类型(数量){PID列表}"
-     * 示例: "coordinator-client backend(1){123}, datanode-parallel worker(6){...}"
-     */
-    (SELECT STRING_AGG(
-                -- 直接使用我们拼接好的 compound_role 进行展示
-                role_summary.compound_role 
-                || '(' || role_summary.count || '){' || array_to_string(role_summary.pids, ',') || '}',
-                ', '
-            )
-     FROM (SELECT 
-                compound_role, 
-                COUNT(*) as count, 
-                ARRAY_AGG(pid ORDER BY pid) as pids
-           FROM activities_with_compound_role
-           WHERE global_query_id = gid.global_query_id AND compound_role IS NOT NULL
-           GROUP BY compound_role
-           ORDER BY compound_role
-          ) AS role_summary
-    ) AS backends_summary
-
-FROM
-    query_activities AS gid
-GROUP BY
-    gid.global_query_id
--- 使用 HAVING 子句，确保只显示那些（当前至少还有一个进程在 active 状态）的查询。
-HAVING
-    COUNT(*) FILTER (WHERE gid.state = 'active') > 0;
-
--- ===================================================================
--- 布式查询活动明细视图 (按 GID 排序)
--- ===================================================================
-CREATE OR REPLACE VIEW dist_pg_stat_query_details AS
-SELECT
-    -- 核心关联与身份信息
-    gid.global_query_id,
-    gid.sessionid,
-    gid.nodename,
-    gid.role,
-    gid.pid,
-    gid.usename,
-    gid.datname,
-    gid.application_name,
-    gid.client_addr,
-    gid.backend_type,
-
-    -- 状态与等待信息
-    gid.state,
-    gid.wait_event_type,
-    gid.wait_event,
-    
-    -- 事务信息
-    gid.backend_xid,
-    gid.backend_xmin,
-    
-    -- 时间戳信息
-    gid.query_start,
-    gid.xact_start,
-    gid.backend_start,
-    gid.state_change,
-    
-    -- 查询与计划文本
-    gid.query,
-    gid.planstate
-FROM
-    dist_pg_stat_activity AS gid
-WHERE
-    gid.global_query_id IS NOT NULL AND gid.global_query_id != ''
-ORDER BY
-    -- 1. 首先，按照 global_query_id 排序，把同一个查询的所有活动都聚在一起。
-    gid.global_query_id,
-    
-    -- 2. 在同一个 GID 内部，进行二次排序，让结果更有条理。
-    --    用一个 CASE 语句来给节点角色赋予一个排序优先级：
-    --    CN (1) > DN (2) > 其他。
-    CASE gid.role
-        WHEN 'coordinator' THEN 1
-        WHEN 'datanode' THEN 2
-        ELSE 3
-    END,
-
-    -- 3. 最后，按节点名排序
-    gid.nodename;
-
--- 创建一个基础的、只封装C函数的锁视图：dist_pg_locks_raw
+--
+-- View: dist_pg_locks_raw
+-- Description: Provides the raw, unmodified output from the C function,
+--              serving as a stable base for further analysis.
+--
 CREATE OR REPLACE VIEW dist_pg_locks_raw AS
   SELECT * FROM get_dist_pg_locks(false);
 
--- 【dist_pg_locks 视图
--- 它的职责是，在C函数返回的原始锁信息基础上，
--- 通过关联 dist_pg_stat_activity，为阻塞者补全其所在的节点名称。
--- 这个视图是所有更高级分析（如锁链、死锁）的、信息完备的基础。
+--
+-- View: dist_pg_locks
+-- Description: The primary distributed locks view. It enhances the raw lock data by:
+--              1. Adding the node name of the blocking process.
+--              2. Creating a human-readable 'lock_target' description.
+--              3. Filtering out redundant low-level locks for the same object
+--                 to present the most significant lock wait.
+--
 CREATE OR REPLACE VIEW dist_pg_locks AS
 WITH 
--- 第一步：创建一个“干净”的、只包含潜在阻塞者的活动信息集
 potential_blockers AS (
     SELECT
         nodename,
@@ -283,17 +133,13 @@ potential_blockers AS (
     FROM
         dist_pg_stat_activity
     WHERE
-        -- 关键的预过滤条件：
-        -- 1. 进程必须有一个有效的分布式事务ID
         gxid IS NOT NULL 
-        -- 2. 进程不能是完全空闲的，但【必须包括】idle in transaction
         AND state != 'idle'
 ),
 
--- 第二步：将原始锁信息与阻塞者地址（nodename）进行关联
 enriched_locks AS (
     SELECT
-        raw.*, -- 包含所有原始锁信息
+        raw.*,
         blockers.nodename AS blocking_node_name,
         CASE 
             WHEN raw.locktype = 'relation' THEN
@@ -315,15 +161,11 @@ enriched_locks AS (
                 'virtual transaction ' || raw.virtualxid
 
             WHEN raw.locktype = 'advisory' THEN
-                -- advisory锁的key存储在classid和objid中
                 'advisory lock [' || raw.classid::text || ',' || raw.objid::text || ']'
 
-            -- 对于 object, userlock 等，pg_describe_object 是最佳选择
-            -- 【安全检查】只有当 classid 有效时，才调用
             WHEN raw.classid != 0 THEN
                 pg_describe_object(raw.classid, raw.objid, raw.objsubid)
             
-            -- 对于所有其他未知或不需要特殊描述的类型
             ELSE
                 raw.locktype
         END AS lock_target
@@ -334,9 +176,7 @@ enriched_locks AS (
         ON raw.blocking_pid = blockers.pid AND raw.blocking_gxid = blockers.gxid
 )
 
--- 第三步：【核心】对增强后的结果进行最终的去重和选择
 SELECT DISTINCT ON (node_name, pid, granted, lock_target)
-    -- 选择所有需要的列
     node_name,
     granted,
     gxid,
@@ -360,40 +200,37 @@ SELECT DISTINCT ON (node_name, pid, granted, lock_target)
     lock_target
 FROM
     enriched_locks
--- ORDER BY 必须以 DISTINCT ON 的列开始
 ORDER BY
     node_name, pid, granted, lock_target,
-    -- 内部排序：优先保留最重要的锁模式记录
     CASE mode
         WHEN 'AccessExclusiveLock' THEN 1
         WHEN 'ExclusiveLock' THEN 2
         WHEN 'ShareRowExclusiveLock' THEN 3
         WHEN 'RowExclusiveLock' THEN 4
         WHEN 'ShareLock' THEN 5
-        -- ... (其他锁模式的优先级)
         ELSE 99
     END;
 
--- 包含所有活动信息的大而全视图
+--
+-- View: dist_pg_locks_all_info
+-- Description: A comprehensive view that joins dist_pg_locks with activity
+--              information for both the waiting and blocking processes.
+--
 CREATE OR REPLACE VIEW dist_pg_locks_all_info AS
 SELECT 
-    -- 现场信息
     l.node_name,
     l.granted,
     
-    -- 等待者信息
     l.gxid AS waiter_gxid,
     l.pid AS waiter_pid,
     act.usename AS waiter_usename,
     act.state AS waiter_state,
     act.query AS waiter_query,
     
-    -- 锁信息
     l.locktype,
     l.mode,
-    l.lock_target, -- lock_target 已经在 dist_pg_locks 中被正确创建
+    l.lock_target,
     
-    -- 阻塞者信息
     l.blocking_node_name,
     l.blocking_pid,
     l.blocking_gxid,
@@ -409,20 +246,231 @@ LEFT JOIN
     dist_pg_stat_activity AS blocker_act 
     ON l.blocking_pid = blocker_act.pid AND l.blocking_node_name = blocker_act.nodename;
 
--- ===================================================================
--- ==      Advanced Lock Analysis Views (Wait Chains & Deadlocks)   ==
--- ===================================================================
+/******************************************************************************
+ * Section 3: Advanced Analytical Views
+ ******************************************************************************/
 
--- 视图 1: 完整的分布式锁等待链
+--
+-- View: dist_pg_stat_query_summary
+-- Description: Provides a high-level summary for each active distributed query,
+--              aggregating states, wait events, and backend roles across all
+--              involved nodes. Ideal for quick performance bottleneck identification.
+--
+CREATE OR REPLACE VIEW dist_pg_stat_query_summary AS
+
+WITH query_activities AS (
+    SELECT *
+    FROM dist_pg_stat_activity
+    WHERE global_query_id IS NOT NULL AND global_query_id != ''
+),
+
+activities_with_compound_role AS (
+    SELECT
+        *,
+        (COALESCE(role, 'unknown_role') || '-' || COALESCE(backend_type, 'unknown_type')) 
+            AS compound_role
+    FROM
+        query_activities
+)
+
+SELECT
+    gid.global_query_id,
+
+    MAX(gid.query) FILTER (WHERE gid.role = 'coordinator') AS top_level_query,
+    MAX(gid.usename) FILTER (WHERE gid.role = 'coordinator') AS username,
+    MAX(gid.application_name) FILTER (WHERE gid.role = 'coordinator') AS application_name,
+    MAX(gid.client_addr) FILTER (WHERE gid.role = 'coordinator') AS client_address,
+
+    (NOW() - MIN(gid.query_start))::interval(3) AS total_duration,
+    COUNT(*) AS involved_processes,
+    COUNT(DISTINCT gid.nodename) AS distinct_nodes,
+    MIN((gid.backend_xmin::text)::bigint) AS cluster_xmin_horizon,
+
+    (SELECT STRING_AGG(
+                state_summary.state || '(' || state_summary.count || '){' || array_to_string(state_summary.node_pids, ',') || '}',
+                ', '
+            )
+     FROM (SELECT 
+                state, 
+                COUNT(*) as count, 
+                ARRAY_AGG(nodename || ':' || pid ORDER BY nodename, pid) as node_pids
+           FROM query_activities
+           WHERE global_query_id = gid.global_query_id
+           GROUP BY state
+           ORDER BY state
+          ) AS state_summary
+    ) AS states_summary,
+
+    (SELECT STRING_AGG(
+                wait_summary.wait_event || '(' || wait_summary.count || '){' || array_to_string(wait_summary.node_pids, ',') || '}',
+                ', '
+            )
+     FROM (SELECT 
+                wait_event, 
+                COUNT(*) as count, 
+                ARRAY_AGG(nodename || ':' || pid ORDER BY nodename, pid) as node_pids
+           FROM query_activities
+           WHERE global_query_id = gid.global_query_id AND wait_event IS NOT NULL
+           GROUP BY wait_event
+           ORDER BY wait_event
+          ) AS wait_summary
+    ) AS waits_summary,
+    
+    (SELECT STRING_AGG(
+                role_summary.compound_role 
+                || '(' || role_summary.count || '){' || array_to_string(role_summary.pids, ',') || '}',
+                ', '
+            )
+     FROM (SELECT 
+                compound_role, 
+                COUNT(*) as count, 
+                ARRAY_AGG(pid ORDER BY pid) as pids
+           FROM activities_with_compound_role
+           WHERE global_query_id = gid.global_query_id AND compound_role IS NOT NULL
+           GROUP BY compound_role
+           ORDER BY compound_role
+          ) AS role_summary
+    ) AS backends_summary
+
+FROM
+    query_activities AS gid
+GROUP BY
+    gid.global_query_id
+HAVING
+    COUNT(*) FILTER (WHERE gid.state = 'active') > 0;
+
+--
+-- View: dist_pg_stat_query_details
+-- Description: Presents detailed, ordered activity information for each
+--              distributed query, making it easy to trace a query's execution
+--              flow from coordinator to datanodes.
+--
+CREATE OR REPLACE VIEW dist_pg_stat_query_details AS
+SELECT
+    gid.global_query_id,
+    gid.sessionid,
+    gid.nodename,
+    gid.role,
+    gid.pid,
+    gid.usename,
+    gid.datname,
+    gid.application_name,
+    gid.client_addr,
+    gid.backend_type,
+
+    gid.state,
+    gid.wait_event_type,
+    gid.wait_event,
+
+    gid.backend_xid,
+    gid.backend_xmin,
+
+    gid.query_start,
+    gid.xact_start,
+    gid.backend_start,
+    gid.state_change,
+
+    gid.query,
+    gid.planstate
+FROM
+    dist_pg_stat_activity AS gid
+WHERE
+    gid.global_query_id IS NOT NULL AND gid.global_query_id != ''
+ORDER BY
+    gid.global_query_id,
+    
+    CASE gid.role
+        WHEN 'coordinator' THEN 1
+        WHEN 'datanode' THEN 2
+        ELSE 3
+    END,
+
+    gid.nodename;
+
+--
+-- View: dist_pg_lock_waits_summary
+-- Description: Summarizes each direct lock-waiting relationship into a single row,
+--              enriched with both "scene" (DN) and "source" (CN) information
+--              for both waiter and blocker.
+--
+CREATE OR REPLACE VIEW dist_pg_lock_waits_summary AS
+WITH 
+cn_activities AS (
+    SELECT DISTINCT ON (gxid)
+        gxid,
+        nodename,
+        usename,
+        datname,
+        application_name,
+        client_addr,
+        query AS top_level_query
+    FROM 
+        dist_pg_stat_activity
+    WHERE 
+        role = 'coordinator' AND gxid IS NOT NULL
+    ORDER BY gxid, query_start DESC
+)
+SELECT
+    lw.waiter_gxid,
+    lw.blocking_gxid,
+
+    waiter_cn.nodename AS waiter_source_node,
+    waiter_cn.usename AS waiter_user_source,
+    waiter_cn.client_addr AS waiter_client_source,
+    waiter_cn.top_level_query AS waiter_query_source,
+
+    blocker_cn.nodename AS blocker_source_node,
+    blocker_cn.usename AS blocker_user_source,
+    blocker_cn.client_addr AS blocker_client_source,
+    blocker_cn.top_level_query AS blocker_query_source,
+
+    JSONB_AGG(
+        DISTINCT jsonb_build_object(
+            'wait_happen_node', lw.node_name,
+            'waiter_pid', lw.waiter_pid,
+            'waiter_state', lw.waiter_state,
+            'blocking_node_name', lw.blocking_node_name,
+            'blocking_pid', lw.blocking_pid,
+            'blocking_state', lw.blocking_state
+        )
+    ) AS wait_scene_details,
+
+    STRING_AGG(
+        DISTINCT lw.mode || '{' || lw.lock_target || '}', 
+        ', '
+    ) AS locks_waited
+
+FROM
+    dist_pg_locks_all_info AS lw
+LEFT JOIN
+    cn_activities AS waiter_cn ON lw.waiter_gxid = waiter_cn.gxid
+LEFT JOIN
+    cn_activities AS blocker_cn ON lw.blocking_gxid = blocker_cn.gxid
+WHERE
+    NOT lw.granted
+GROUP BY
+    lw.waiter_gxid,
+    lw.blocking_gxid,
+    waiter_cn.nodename,
+    waiter_cn.usename,
+    waiter_cn.client_addr,
+    waiter_cn.top_level_query,
+    blocker_cn.nodename,
+    blocker_cn.usename,
+    blocker_cn.client_addr,
+    blocker_cn.top_level_query;
+
+--
+-- View: dist_pg_lock_wait_chains
+-- Description: Recursively reconstructs and displays the full wait chain for
+--              complex, multi-level lock contentions, directly identifying the
+--              "root blocker".
+--
 CREATE OR REPLACE VIEW dist_pg_lock_wait_chains AS
 WITH RECURSIVE 
 lock_chains_raw AS (
-    -- ==========================================================
-    -- 1. 递归的起点 (Anchor Member)
-    -- ==========================================================
     SELECT
         1 AS level,
-        -- 我们需要传递等待者和阻塞者的所有关键信息
         locks.waiter_gxid,
         locks.waiter_pid,
         locks.node_name AS waiter_node,
@@ -430,11 +478,9 @@ lock_chains_raw AS (
         locks.blocking_pid,
         locks.blocking_node_name,
         
-        -- 路径数组，用于递归和展示
         ARRAY[locks.waiter_gxid] AS gxid_path,
         ARRAY[locks.waiter_pid || ':' || locks.node_name] AS physical_path,
         
-        -- 链头的唯一标识 (就是等待者自己)
         locks.waiter_gxid AS chain_head_gxid
         
     FROM 
@@ -444,9 +490,6 @@ lock_chains_raw AS (
 
     UNION ALL
 
-    -- ==========================================================
-    -- 2. 递归的递推部分 (Recursive Member)
-    -- ==========================================================
     SELECT
         lc.level + 1,
         
@@ -464,7 +507,6 @@ lock_chains_raw AS (
         lc.chain_head_gxid
     FROM 
         lock_chains_raw lc
-    -- 【核心JOIN】使用 GXID 作为唯一的连接条件！
     JOIN 
         dist_pg_locks_all_info AS locks 
       ON lc.blocking_gxid = locks.waiter_gxid
@@ -472,7 +514,6 @@ lock_chains_raw AS (
         NOT locks.granted AND locks.blocking_gxid IS NOT NULL
       AND NOT (lc.blocking_gxid = ANY(lc.gxid_path))
 ),
--- 第二步：为每个链头，找到其最长的链
 longest_chains AS (
     SELECT DISTINCT ON (chain_head_gxid)
         chain_head_gxid,
@@ -485,7 +526,6 @@ longest_chains AS (
     FROM lock_chains_raw
     ORDER BY chain_head_gxid, level DESC
 ),
--- 第三步：准备源头信息
 cn_activities AS (
     SELECT DISTINCT ON (gxid)
         gxid, usename, client_addr, query AS top_level_query, nodename AS source_node
@@ -493,37 +533,35 @@ cn_activities AS (
     WHERE role = 'coordinator' AND gxid IS NOT NULL
     ORDER BY gxid, query_start DESC
 )
--- 第四步：最终输出，将所有信息整合
 SELECT 
     lc.chain_length,
     array_to_string(lc.gxid_path, ' -> ') || ' -> ' || lc.root_blocker_gxid AS full_wait_chain_gxid,
     array_to_string(lc.physical_path, ' -> ') || ' -> ' || (lc.root_blocker_pid || ':' || lc.root_blocker_node) AS full_wait_chain_pids,
     
-    -- 链头信息 (最初的等待者)
     head_cn.source_node AS chain_head_source_node,
     head_cn.usename AS chain_head_user,
     lc.chain_head_gxid,
     
-    -- 根源信息 (最终的阻塞者)
     root_cn.source_node AS root_blocker_source_node,
     root_cn.usename AS root_blocker_user,
     lc.root_blocker_gxid,
     
-    -- 链头和根源的顶层查询
     head_cn.top_level_query AS chain_head_query,
     root_cn.top_level_query AS root_blocker_query
 FROM
     longest_chains lc
--- 关联链头事务的“源头”信息
 LEFT JOIN
     cn_activities AS head_cn ON lc.chain_head_gxid = head_cn.gxid
--- 关联根源阻塞事务的“源头”信息
 LEFT JOIN
     cn_activities AS root_cn ON lc.root_blocker_gxid = root_cn.gxid;
 
--- 视图 2: 分布式死锁检测
+--
+-- View: dist_pg_deadlocks
+-- Description: Detects and displays circular lock dependencies (deadlocks).
+--              Serves as a powerful tool for auditing and analyzing deadlock patterns.
+--
 CREATE OR REPLACE VIEW dist_pg_deadlocks AS
-WITH RECURSIVE lock_chain ( -- 在这里显式声明所有列名
+WITH RECURSIVE lock_chain (
     waiter_gxid,
     waiter_pid,
     waiter_node,
@@ -531,9 +569,8 @@ WITH RECURSIVE lock_chain ( -- 在这里显式声明所有列名
     blocking_pid,
     blocking_node_name,
     path,
-    is_cycle -- 确保 is_cycle 在这里被声明
+    is_cycle
 ) AS (
-    -- 递归的起点 (Anchor)
     SELECT
         locks.gxid,
         locks.pid,
@@ -550,7 +587,6 @@ WITH RECURSIVE lock_chain ( -- 在这里显式声明所有列名
 
     UNION ALL
 
-    -- 递归的递推 (Recursive Step)
     SELECT
         lc.blocking_gxid,
         lc.blocking_pid,
@@ -567,7 +603,6 @@ WITH RECURSIVE lock_chain ( -- 在这里显式声明所有列名
     WHERE
         NOT locks.granted AND NOT lc.is_cycle
 )
--- 最终输出
 SELECT
     c.path || c.blocking_gxid AS deadlock_cycle_gxid,
     l.node_name, l.pid, l.gxid, l.lock_target, l.mode AS lock_mode,
@@ -585,98 +620,18 @@ LEFT JOIN
 WHERE
     c.is_cycle;
 
--- in pg_dist_stat_views--1.0.sql
-
--- ===================================================================
--- ==             Distributed Lock Waits Summary View             ==
--- ==                   (Ultimate & Corrected Edition)            ==
--- ===================================================================
--- 视图目标：将同一组“等待-阻塞”关系的所有底层锁等待信息，智能地聚合为一行，
---          并附加上事务的“源头”信息，提供一个高度浓缩的诊断快照。
--- ===================================================================
-CREATE OR REPLACE VIEW dist_pg_lock_waits_summary AS
-WITH 
--- 第一步：从 dist_pg_stat_activity 中筛选出所有 CN 的活动记录，作为“源头”信息库
-cn_activities AS (
-    SELECT DISTINCT ON (gxid)
-        gxid,
-        nodename, -- 【核心修正】添加源头节点名称
-        usename,
-        datname,
-        application_name,
-        client_addr,
-        query AS top_level_query
-    FROM 
-        dist_pg_stat_activity
-    WHERE 
-        role = 'coordinator' AND gxid IS NOT NULL
-    ORDER BY gxid, query_start DESC
-)
--- 第二步：进行最终的聚合
-SELECT
-    -- 【核心关联ID】
-    lw.waiter_gxid,
-    lw.blocking_gxid,
-
-    -- 【等待者源头信息 (完整版)】
-    waiter_cn.nodename AS waiter_source_node, -- 【核心修正】展示等待者的源头节点
-    waiter_cn.usename AS waiter_user_source,
-    waiter_cn.client_addr AS waiter_client_source,
-    waiter_cn.top_level_query AS waiter_query_source,
-
-    -- 【阻塞者源头信息 (完整版)】
-    blocker_cn.nodename AS blocker_source_node, -- 【核心修正】展示阻塞者的源头节点
-    blocker_cn.usename AS blocker_user_source,
-    blocker_cn.client_addr AS blocker_client_source,
-    blocker_cn.top_level_query AS blocker_query_source,
-
-    -- 【锁等待现场详情 (JSON格式)】
-    JSONB_AGG(
-        DISTINCT jsonb_build_object(
-            'wait_happen_node', lw.node_name,
-            'waiter_pid', lw.waiter_pid,
-            'waiter_state', lw.waiter_state,
-            'blocking_node_name', lw.blocking_node_name,
-            'blocking_pid', lw.blocking_pid,
-            'blocking_state', lw.blocking_state
-        )
-    ) AS wait_scene_details,
-
-    -- 【等待的锁 (聚合字符串)】
-    STRING_AGG(
-        DISTINCT lw.mode || '{' || lw.lock_target || '}', 
-        ', '
-    ) AS locks_waited
-
-FROM
-    dist_pg_locks_all_info AS lw
-LEFT JOIN
-    cn_activities AS waiter_cn ON lw.waiter_gxid = waiter_cn.gxid
-LEFT JOIN
-    cn_activities AS blocker_cn ON lw.blocking_gxid = blocker_cn.gxid
-WHERE
-    NOT lw.granted
-GROUP BY
-    -- 【核心修正】将源头节点名称加入GROUP BY子句
-    lw.waiter_gxid,
-    lw.blocking_gxid,
-    waiter_cn.nodename,
-    waiter_cn.usename,
-    waiter_cn.client_addr,
-    waiter_cn.top_level_query,
-    blocker_cn.nodename,
-    blocker_cn.usename,
-    blocker_cn.client_addr,
-    blocker_cn.top_level_query;
-
--- 授权
+/******************************************************************************
+ * Section 4: Grant Permissions
+ ******************************************************************************/
+ 
 GRANT SELECT ON dist_pg_stat_activity TO PUBLIC;
 GRANT SELECT ON dist_pg_stat_activity_cn TO PUBLIC;
-GRANT SELECT ON dist_pg_stat_query_summary TO PUBLIC;
-GRANT SELECT ON dist_pg_stat_query_details TO PUBLIC;
 GRANT SELECT ON dist_pg_locks_raw TO PUBLIC;
 GRANT SELECT ON dist_pg_locks TO PUBLIC;
 GRANT SELECT ON dist_pg_locks_all_info TO PUBLIC;
+
+GRANT SELECT ON dist_pg_stat_query_summary TO PUBLIC;
+GRANT SELECT ON dist_pg_stat_query_details TO PUBLIC;
+GRANT SELECT ON dist_pg_lock_waits_summary TO PUBLIC;
 GRANT SELECT ON dist_pg_lock_wait_chains TO PUBLIC;
 GRANT SELECT ON dist_pg_deadlocks TO PUBLIC;
-GRANT SELECT ON dist_pg_lock_waits_summary TO PUBLIC;

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -42,7 +42,11 @@
 
 PG_MODULE_MAGIC;
 
-#define PG_DIST_STAT_ACTIVITY_COLS 28	// 列数定义
+/*
+ * Number of columns in the result of the dist_pg_stat_get_activity() function.
+ * This must be kept in sync with the function's TuplDesc and SQL definition.
+ */
+#define PG_DIST_STAT_ACTIVITY_COLS 28
 
 /* ----------
  * Total number of backends including auxiliary
@@ -58,76 +62,87 @@ PG_MODULE_MAGIC;
 #define UINT32_ACCESS_ONCE(var)		 ((uint32)(*((volatile uint32 *)&(var))))
 
 /*
- * PgDistStatStatus is something like PgBackendStatus (see pgstat.c) but it
- * contains information that a query executed in a cluster database system.
- * Each PgDistStatStatus stands for a backend process forked by postmaster,
- * the same way PgBackendStatus does, like extended fields of PgBackendStatus.
- * We show it in view pg_stat_cluster_activity, still, one tuple for an entry.
+ * PgDistStatStatus extends the standard PgBackendStatus (see pgstat.c) with
+ * additional information specific to a distributed query's execution within
+ * the OpenTenBase cluster.
+ *
+ * Each entry in the shared DistStatArray corresponds to a backend process
+ * and stores context that is not available in the standard pgstat system,
+ * such as the global query ID and the process's role in a distributed plan.
+ * This information is collected at the start of a top-level query via hooks
+ * and is cleared upon query completion.
+ *
+ * The final view, dist_pg_stat_activity, joins this information with the
+ * real-time data from pg_stat_get_activity() to provide a complete picture.
  */
-typedef struct PgDistStatStatus	// 上面的说明记得改
+typedef struct PgDistStatStatus
 {
 	/*
 	 * To avoid locking overhead, we use the following protocol: a backend
 	 * increments changecount before modifying its entry, and again after
-	 * finishing a modification.  A would-be reader should note the value of
+	 * finishing a modification. A would-be reader should note the value of
 	 * changecount, copy the entry into private memory, then check
-	 * changecount again.  If the value hasn't changed, and if it's even,
-	 * the copy is valid; otherwise start over.  This makes updates cheap
-	 * while reads are potentially expensive, but that's the tradeoff we want.
+	 * changecount again. If the value hasn't changed, and if it's even,
+	 * the copy is valid; otherwise start over.
 	 *
-	 * The above protocol needs the memory barriers to ensure that the
-	 * apparent order of execution is as it desires. Otherwise, for example,
-	 * the CPU might rearrange the code so that changecount is incremented
-	 * twice before the modification on a machine with weak memory ordering.
-	 * This surprising result can lead to bugs.
+	 * This protocol requires memory barriers to ensure the intended order
+	 * of operations.
 	 */
-    // 持久化状态
-	int changecount;
+	int			changecount;
+
+	/*
+	 * Fields below are persistent for the backend's lifecycle.
+	 */
+	bool		valid;				/* If false, this entry is not in use. */
+	char		nodename[NAMEDATALEN];	/* Name of the node this backend runs on. */
 	
-	bool valid;                     /* don't show this entry if false */
-	char nodename[NAMEDATALEN];     /* nodename, determined after process started */
-
-	// 【核心】只存储 pgstat 没有的、我们自己扩展的信息
-	char sessionid[NAMEDATALEN];    /* global session id in a cluster, one for a session */
-    // 存储GID的哈希值，用于在C代码中进行快速、高效的比较和过滤
-    uint64 global_query_id_hash; 
-    // 存储GID的完整字符串，用于最终在视图中显示
-    char   global_query_id[256]; // 预留足够长的空间
-	// 查询级状态,在【每一个】顶层查询开始时写入，在【该查询结束】(ExecutorEnd)时就必须清理。
-	char role[NAMEDATALEN];         /* coord, datanode, producer or consumer */
-	/* portal_name or portal_name_unique */
-	char sqname[NAMEDATALEN];
-	/* true if sharequeue end, but currently change when query ends in this backend */
-	bool sqdone;
-	/* part of plantree this backend is processing, OR last processed if backend is idle */
-	char planstate[4096];
 	/*
-	 * portal name: the name of current portal, given by upper node of processing query 
-	 * cursor name: contained in planstate this backend is querying, which would be
-	 *              portal name of next layer of nodes bellow this backend
-	 *              
-	 * Note: with these two fields plus nodename, we can build a backend tree of executing query
-	 *       in whole distributed system.
+	 * Fields below are transient and specific to a single distributed query.
+	 * They are populated at the start of a top-level query (ExecutorStart hook)
+	 * and cleared at the end of that query (ExecutorEnd hook).
 	 */
-	char portal[NAMEDATALEN];
-	char cursors[NAMEDATALEN * 64];
+	char		sessionid[NAMEDATALEN];	/* Global session ID for the cluster. */
 
+	/* 
+	 * Unique identifier for a single distributed query execution.
+	 * Generated on the coordinator and propagated to all involved nodes.
+	 * This is the core key for associating activities across the cluster.
+	 */
+	uint64		global_query_id_hash;	/* Hash of the GID for faster internal comparisons. */
+	char		global_query_id[256];	/* Full string of the Global Query ID for display. */
+
+	char		role[NAMEDATALEN];		/* Role in the distributed plan (e.g., coordinator, datanode). */
+	char		sqname[NAMEDATALEN];	/* Name of the Share Queue, if any. */
+	bool		sqdone;				/* True if the Share Queue is finished. */
+	char		planstate[4096];	/* Text representation of the plan fragment being executed. */
+	
 	/*
-	// 事务级状态,【第一个】顶层查询开始时写入，直到【事务结束】(COMMIT/ROLLBACK)才清理。
-    char  gxid[NAMEDATALEN];
-    TransactionId backend_xid;
-    TransactionId backend_xmin;
-    char  application_name[NAMEDATALEN];
-    char  backend_type[NAMEDATALEN]; // backend_type 通常与进程绑定，但为保持与activity一致，也设为事务级
-	*/
+	 * portal name: The name of the current portal, typically set by an upper node.
+	 * cursors: Space-separated list of cursor names found in RemoteSubplan nodes,
+	 *          representing connections to lower-level nodes.
+	 *
+	 * Note: These fields, along with 'nodename', can be used to reconstruct
+	 *       the execution tree of a distributed query.
+	 */
+	char		portal[NAMEDATALEN];
+	char		cursors[NAMEDATALEN * 64];
 } PgDistStatStatus;
 
+/*
+ * Working status for the get_dist_pg_locks_raw() SRF.
+ *
+ * This struct is used to hold the state of the function across multiple
+ * calls. It strictly imitates the PG_Lock_Status struct used by the kernel's
+ * pg_lock_status() function to ensure safe and correct iteration over
+ * the lock data snapshots.
+ */
 typedef struct DistLockStatus
 {
-    LockData           *lockData;
-    int                 currIdx;
-    PredicateLockData  *predLockData;
-    int                 predLockIdx;
+    LockData   *lockData;        /* A safe copy of the regular lock status data from lmgr. */
+    int         currIdx;        /* Index of the current LockInstanceData being processed. */
+
+    PredicateLockData *predLockData; /* A safe copy of the predicate lock status data. */
+    int         predLockIdx;    /* Index of the current predicate lock being processed. */
 } DistLockStatus;
 
 static PgDistStatStatus *DistStatArray = NULL;
@@ -140,9 +155,9 @@ static PortalDrop_hook_type prev_PortalDrop = NULL;
 static ExecutorStart_hook_type prev_ExecutorStart = NULL;
 static ExecutorEnd_hook_type prev_ExecutorEnd = NULL;
 
-static bool pgds_enable_planstate; /* whether to show planstate in result sets */
-static int pgds_nesting_level = 0;
-static char *pgds_gid_guc_string = NULL;
+static bool pgds_enable_planstate; /* GUC variable: enable/disable planstate collection. */
+static int pgds_nesting_level = 0; /* Nesting level counter for Executor hooks, to identify top-level queries. */
+static char *pgds_gid_guc_string = NULL; /* GUC variable: propagates the Global Query ID from CN to DNs. */
 
 /*
  * Macros to load and store st_changecount with the memory barriers.
@@ -182,13 +197,11 @@ static char *pgds_gid_guc_string = NULL;
 	} while (0)
 
 Datum dist_pg_stat_get_activity(PG_FUNCTION_ARGS);
-// Datum get_dist_pg_locks_raw(PG_FUNCTION_ARGS);
 
 void _PG_init(void);
 void _PG_fini(void);
 
 PG_FUNCTION_INFO_V1(dist_pg_stat_get_activity);
-// PG_FUNCTION_INFO_V1(get_dist_pg_locks_raw);
 PG_FUNCTION_INFO_V1(get_dist_pg_locks);
 
 static ParamListInfo
@@ -345,7 +358,11 @@ pgds_entry_initialize(void)
 		MyDistStatEntry = &DistStatArray[MaxBackends + MyAuxProcType];
 	}
 	
-	// 在初始化时，清空GID信息
+	/*
+	 * Ensure the entry starts in a clean state. This is crucial for backends
+	 * that are recycled from a connection pool, preventing stale data from a
+	 * previous query from persisting.
+	 */
     MyDistStatEntry->global_query_id_hash = 0;
     MyDistStatEntry->global_query_id[0] = '\0';
 
@@ -442,24 +459,32 @@ pgds_report_query_activity(BackendState state, const char *cmd_str)
 	entry = MyDistStatEntry;
 	pgds_report_common((PgDistStatStatus *) entry);
 
-	// 只调用前任钩子
 	if (prev_pgstat_report_hook)
 		prev_pgstat_report_hook(state, cmd_str);
 }
 
-/* ----------
+/*
  * pgds_report_executor_activity
- * 
- *  Report fileds of per-query referred, hooked as ExecutorStart_hook
- *  report planstate, cursors and common fields.
- * 
- * 唯一负责写入所有与一次“顶层查询”活动相关的瞬时状态
- * ----------
+ *
+ * ExecutorStart hook to capture and record all transient, query-specific
+ * distributed status information into the backend's shared memory entry.
+ *
+ * This function is the primary mechanism for our distributed tracking. It is
+ * responsible for:
+ *  1. Identifying the start of a top-level distributed query using a
+ *     nesting-level counter.
+ *  2. Generating a Global Query ID (GID) on the coordinator node.
+ *  3. Propagating the GID to all datanodes via a GUC variable.
+ *  4. Recording the GID and other context (role, planstate, cursors) into
+ *     the shared memory slot (PgDistStatStatus).
+ *
+ * This function guarantees that all context for a distributed query is
+ * captured atomically at the beginning of its execution.
  */
 static void
 pgds_report_executor_activity(QueryDesc *desc, int eflags)
 {
-	volatile PgDistStatStatus *entry;	// volatile 告诉编译器，entry 指向的那块内存随时可能被外部改变，请不要做任何优化
+	volatile PgDistStatStatus *entry;
 	StringInfo planstate_str = NULL;
 	StringInfo cursors = NULL;
 	MemoryContext oldcxt;
@@ -471,62 +496,57 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 	else
 		standard_ExecutorStart(desc, eflags);
 	
-	pgds_nesting_level++;	// 嵌套层级就加一
+	pgds_nesting_level++;
 
 	if (!desc)
 		return;
-	// 2. 在CN端，为顶层查询生成并设置 GID
-    if (pgds_nesting_level == 1)	// 判断一个查询是否为顶层查询，即子查询不再生成新gid
+    if (pgds_nesting_level == 1)
     {
+		/* 
+		* On the coordinator, if no GID is present (i.e., this is the origin
+		* of a new distributed query), generate a new GID.
+		*/
         if (IS_PGXC_COORDINATOR && (pgds_gid_guc_string == NULL || pgds_gid_guc_string[0] == '\0'))
         {
-            // 生成 GID
             snprintf(gid_string, sizeof(gid_string), "%s-%d-%lu",
                      PGXCNodeName, MyProcPid, (unsigned long)GetCurrentTimestamp());
-
-            // 设置GUC变量，以便传播到DN
             (void)set_config_option("pg_dist_stat_views.global_query_id", gid_string,
                                     PGC_SUSET, PGC_S_SESSION, GUC_ACTION_SET, true, 0, false);
         }
-		/* 统一写入所有瞬时状态 */
 		pgds_entry_initialize();
 		entry = MyDistStatEntry;
+
+		/*
+		* On all nodes (CN and DN), atomically write all transient status
+		* information to our shared memory slot.
+		*/
 		gid_to_write = (char *)pgds_gid_guc_string;
-		// 无论CN还是DN，都在这里，把所有信息一次性写入共享内存
 		increment_changecount_before(entry);
-		// --- 在数据节点 (DN) 上，或者作为“中间人”的CN上：读取GUC并存储 --
-		// 检查绑定的C变量是否有值 (即GUC是否被传播过来)
+
 		if (gid_to_write && gid_to_write[0] != '\0')
 		{	
 			snprintf((char *)entry->global_query_id, 
 					sizeof(entry->global_query_id), 
 					"%s", 
-					gid_to_write);	// entry->global_query_id是volatile char *,就是
+					gid_to_write);
 			entry->global_query_id_hash = string_hash(gid_to_write, strlen(gid_to_write));
 
 		}
-		// 写入常规信息
 		pgds_report_common((PgDistStatStatus *) entry);
-		// 写入角色
 		pgds_report_role((PgDistStatStatus *)entry, desc);
 
-		 /* -- 采集并写入 planstate 和 cursors -- */
+		/* Collect and write planstate and cursors if applicable. */
         if (desc->already_executed)
 		{
 			entry->sqdone = true;
 		}
 		else if (desc->planstate != NULL)
 		{
-			/* 保留原始的内存管理策略 */
 			oldcxt = MemoryContextSwitchTo(desc->estate->es_query_cxt);
-			
-			/* 采集 Cursors */
 			cursors = makeStringInfo();
 			cursorCollectWalker(desc->planstate, cursors);
 			if (cursors->len > 0)
 				snprintf((char *)entry->cursors, sizeof(entry->cursors), "%s", cursors->data);
-
-			/* 采集 Planstate */
 			if (pgds_enable_planstate)
 			{
 				ExplainState es;
@@ -538,7 +558,7 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 				es.skip_remote_query = true;
 				
 				ExplainBeginOutput(&es);
-				ExplainPrintPlan(&es, desc);	// planstate_str被填充
+				ExplainPrintPlan(&es, desc);
 				ExplainEndOutput(&es);
 				
 				if (planstate_str->len > 0)
@@ -548,17 +568,13 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 			{
 				snprintf((char *)entry->planstate, sizeof(entry->planstate), "disabled");
 			}
-
-			/* 在使用完毕后，立刻释放内存 */
 			pfree(cursors->data);
 			pfree(cursors);
-			if (planstate_str) // 因为 planstate_str 可能不被创建
+			if (planstate_str)
 			{
 				pfree(planstate_str->data);
 				pfree(planstate_str);
 			}
-
-			/* 切换回原来的内存上下文 */
 			MemoryContextSwitchTo(oldcxt);
 		}
         
@@ -566,23 +582,31 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
     }
 }
 
-/* ----------
+/*
  * pgds_executor_end_hook
- * 用于在查询结束时对进程瞬时信息的清空（除了进程的基本标识信息）
- *  
- *  
- * ----------
+ *
+ * ExecutorEnd hook to clean up the transient, query-specific distributed
+ * status information from the backend's shared memory entry.
+ *
+ * This function acts as the counterpart to pgds_report_executor_activity().
+ * It is responsible for:
+ *  1. Decrementing the nesting-level counter.
+ *  2. When the top-level query finishes (nesting level returns to 0),
+ *     it clears all transient fields in the PgDistStatStatus entry.
+ *  3. On the coordinator, it also clears the GID propagation GUC variable.
+ *
+ * This cleanup is crucial to prevent stale data from a completed query
+ * being associated with a new query that reuses the same backend process.
  */
 static void
 pgds_executor_end_hook(QueryDesc *queryDesc)
 {
 	volatile PgDistStatStatus *v_entry;
 	PgDistStatStatus *entry;
-	pgds_nesting_level--;	// 嵌套层级减一
 
+	pgds_nesting_level--;
     if (pgds_nesting_level == 0)
     {
-        /* --- A. 在CN节点上，清理GUC传播信道 --- */
         if (IS_PGXC_COORDINATOR)
         {
             if (pgds_gid_guc_string && pgds_gid_guc_string[0] != '\0')
@@ -592,15 +616,12 @@ pgds_executor_end_hook(QueryDesc *queryDesc)
             }
         }
 
-        /* --- B. 在所有节点上，清理自己共享内存里的GID --- */
-        // MyDistStatEntry 在进程生命周期中，只要初始化过就不会是 NULL
         if (MyDistStatEntry)
         {
             v_entry = MyDistStatEntry;
 			entry = (PgDistStatStatus *)v_entry;
 
             increment_changecount_before(v_entry);
-            // v_entry->nodename 和 v_entry->role 被刻意保留，不作清理！
             MemSet(&entry->global_query_id_hash, 0, 
                    sizeof(PgDistStatStatus) - offsetof(PgDistStatStatus, global_query_id_hash));
             
@@ -608,22 +629,25 @@ pgds_executor_end_hook(QueryDesc *queryDesc)
 
         }
     }
-		// 调用原始的钩子链
     if (prev_ExecutorEnd)
         prev_ExecutorEnd(queryDesc);
     else
         standard_ExecutorEnd(queryDesc);
-
 }
 
-/* ----------
- * pgds_report_activity
- * 
- *  Report fileds of per-portal referred, hooked as PortalStart_hook
- *  report portal name and common fields.
- * 
- * 职责：只负责更新与 `Portal` 严格绑定的信息，比如 `portal` 名字。在 Portal 销毁时，清理掉这个名字。
- * ----------
+/*
+ * pgds_portal_hook
+ *
+ * Generic hook function for PortalStart_hook and PortalDrop_hook. It is
+ * responsible for managing portal-specific information in our shared
+ * memory entry.
+ *
+ * Its primary and ONLY responsibility is to set the portal name on portal
+ * creation (is_drop=false) and clear it on portal destruction (is_drop=true).
+ *
+ * It does NOT handle any other transient, query-specific state, as that
+ * is managed exclusively by the ExecutorStart/ExecutorEnd hooks to ensure
+ * logical consistency.
  */
 static void
 pgds_report_activity(Portal portal)
@@ -647,7 +671,6 @@ pgds_report_activity(Portal portal)
 
 	pgds_report_common((PgDistStatStatus *) entry);
 	pgds_report_role((PgDistStatStatus *) entry, desc);
-    // 如果是 PortalStart，就写入 portal 名字
     strncpy((char *)entry->portal, portal->name, NAMEDATALEN);
     
     increment_changecount_after(entry);
@@ -768,22 +791,34 @@ dist_pg_get_remote_activity(const char *sessionid, bool coordonly, Tuplestoresta
 	FreeExecutorState(estate);
 }
 
-/* ----------
+/*
  * dist_pg_stat_get_activity
- * 
- *  Internal SRF function of this extension. It accesses shared memory to find
- *  every live backend, collects their local and distributed status,
- *  and presents the information. It combines fields from both PgBackendStatus
- *  and our custom PgDistStatStatus.
  *
- *  arguments:  sessionid -- global unique id for a session, generated by CN
- *              coordonly -- only dispatch to other CNs if true.
- *              localonly -- only collect local entries' status if true.
- *              
- *  Note: since we also collect PGBackendStatus, get them first and use
- *  backend id to access a particular distributed status entry to narrow down
- *  the loop search range from all backend slots to localNumBackends (see pgstat.c)
- * ----------
+ * SQL-callable SRF (Set-Returning Function) that serves as the main entry
+ * point for the distributed activity view.
+ *
+ * This function implements a "materialized" SRF pattern. It collects activity
+ * information from all relevant nodes (both remote and local), materializes
+ * the entire result set into a Tuplestore in a single execution, and then
+ * returns the Tuplestore to the executor.
+ *
+ * The core logic involves two stages:
+ *  1. Remote data collection: If executed on a coordinator and not in
+ *     'localonly' mode, it dispatches a recursive call to all other nodes
+ *     via the dist_pg_get_remote_activity() helper.
+ *  2. Local data collection: It then iterates through the local backends,
+ *     fusing real-time status from the pgstat system (via
+ *     pgstat_fetch_stat_local_beentry) with the distributed context
+ *     (like global_query_id) stored in our custom shared memory array
+ *     (DistStatArray).
+ *
+ * Arguments:
+ *  sessionid (text, optional): Filters the result to a specific global session ID.
+ *  coordonly (bool, optional): If true, dispatches remote requests only to
+ *                              other coordinator nodes.
+ *  localonly (bool, optional): If true, skips the remote data collection stage.
+ *                              This is used by the recursive calls to prevent
+ *                              infinite loops.
  */
 Datum
 dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
@@ -1146,7 +1181,11 @@ dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
  * ===================================================================
  */
 
-static Datum
+/*
+ * Helper function to format a VirtualTransactionId into a text Datum.
+ * Copied from lockfuncs.c for self-containment.
+ */
+ static Datum
 VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
 {
     char vxidstr[32];
@@ -1155,12 +1194,16 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
 }
 
 /*
- * dist_pg_get_local_locks - 安全的本地数据采集器
+ * dist_pg_get_local_locks
  *
- * 它的职责是安全地采集本地锁信息，并将其放入一个传入的 Tuplestore。
- * 它不是SRF，只是一个普通的辅助函数。
+ * Collects all regular and predicate lock information on the local node,
+ * enhances it with distributed context (GXID), identifies the blocking
+ * process for any waiting locks, and populates the results into a Tuplestore.
+ *
+ * This function is a plain C function, not an SRF. It reads the lock manager
+ * snapshots safely and performs analysis to provide a complete picture of
+ * the local lock status.
  */
-
 
 static void
 dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
@@ -1183,14 +1226,15 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         "userlock", "advisory"
     };
 
-    // --- 1. 处理常规锁 (Regular Locks) ---
+    /*
+	 * Stage 1: Process Regular Locks
+	 */
     lockData = GetLockStatusData();
     
     for (i = 0; i < lockData->nelements; i++)
     {
         LockInstanceData *instance = &(lockData->locks[i]);
         PGPROC     *proc = BackendPidGetProc(instance->pid);
-		// 处理持有的锁
         uint32      holdMask = instance->holdMask;
         LOCKMODE    mode;
         
@@ -1264,32 +1308,27 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
             }
         }
         
-        // 处理等待的锁
+    	/* --- 1b. Report the WAITING lock mode for this instance, if any --- */
         if (instance->waitLockMode != NoLock)
         {
-			PGPROC *blocker_proc = NULL; // 声明一个用于存储阻塞者的指针
-            
-            // --- 【核心新增】在C层，安全地、精确地查找阻塞者 ---
+			PGPROC *blocker_proc = NULL;
+
             if (proc->waitStatus == STATUS_WAITING && proc->waitLock != NULL)
             {
                 LOCK *lock_obj = proc->waitLock;
                 const LockMethod lockMethodTable = GetLockTagsMethodTable(&(lock_obj->tag));
                 
-                // 再次遍历【同一个】只读快照 lockData 来寻找持有者
                 for (int j = 0; j < lockData->nelements; j++)
                 {
                     LockInstanceData *holder_instance = &(lockData->locks[j]);
                     
-                    // 检查是否是同一个锁对象 (通过比较locktag)
                     if (memcmp(&instance->locktag, &holder_instance->locktag, sizeof(LOCKTAG)) == 0)
                     {
-                        // 检查锁模式是否冲突
                         if ((holder_instance->holdMask & lockMethodTable->conflictTab[instance->waitLockMode]) != 0)
                         {
-                            // 找到了一个持有冲突锁的进程
                             blocker_proc = BackendPidGetProc(holder_instance->pid);
                             if (blocker_proc)
-                                break; // 找到第一个有效的阻塞者即可
+                                break;
                         }
                     }
                 }
@@ -1370,7 +1409,9 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         }
     }
 
-    // --- 2. 处理谓词锁 (Predicate Locks) ---
+    /*
+	 * Stage 2: Process Predicate Locks
+	 */
     predLockData = GetPredicateLockStatusData();
 
     for (i = 0; i < predLockData->nelements; i++)
@@ -1385,10 +1426,8 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         MemSet(values, 0, sizeof(values));
         MemSet(nulls, false, sizeof(nulls));
 
-        // 第1列: node_name
         values[0] = CStringGetTextDatum(PGXCNodeName);
         
-        // --- 第2-16列: 填充谓词锁信息 ---
         lockType = GET_PREDICATELOCKTARGETTAG_TYPE(*predTag);
         values[1] = CStringGetTextDatum(PredicateLockTagTypeNames[lockType]); // locktype
 
@@ -1421,7 +1460,6 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         values[14] = BoolGetDatum(true);             // granted
         values[15] = BoolGetDatum(false);            // fastpath
         
-        // 第17列: gxid
         if (proc && proc->hasGlobalXid && proc->globalXid[0] != '\0')
             values[16] = CStringGetTextDatum(proc->globalXid);
         else
@@ -1434,300 +1472,23 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
     }
 }
 
-
 /*
-Datum
-get_dist_pg_locks_raw(PG_FUNCTION_ARGS)
-{
-    FuncCallContext *funcctx;
-    DistLockStatus  *status;
-	static const char *const PredicateLockTagTypeNames[] = {"relation", "page", "tuple"};
-	// This must match enum LockTagType in lock.h!
-    const char *const LockTagTypeNames[] = {
-        "relation", "extend", "page", "tuple", "transactionid",
-        "virtualxid", "speculative token", "object",
-#ifdef _SHARDING_
-        "shard",
-#endif
-        "userlock", "advisory"
-    };
-
-    if (SRF_IS_FIRSTCALL())
-    {
-        TupleDesc       tupdesc;
-        MemoryContext   oldcontext;
-
-        funcctx = SRF_FIRSTCALL_INIT();
-        oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
-
-        // 构建返回元组的描述 (17列: node_name + 15 + gxid)
-        tupdesc = CreateTemplateTupleDesc(17, false);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 1, "node_name", TEXTOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 2, "locktype", TEXTOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 3, "database", OIDOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 4, "relation", OIDOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 5, "page", INT4OID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 6, "tuple", INT2OID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 7, "virtualxid", TEXTOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 8, "transactionid", XIDOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 9, "classid", OIDOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 10, "objid", OIDOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 11, "objsubid", INT2OID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 12, "virtualtransaction", TEXTOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 13, "pid", INT4OID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 14, "mode", TEXTOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 15, "granted", BOOLOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 16, "fastpath", BOOLOID, -1, 0);
-        TupleDescInitEntry(tupdesc, (AttrNumber) 17, "gxid", TEXTOID, -1, 0);
-        funcctx->tuple_desc = BlessTupleDesc(tupdesc);
-
-        // 创建我们自定义的状态结构体并初始化
-        status = (DistLockStatus *) palloc(sizeof(DistLockStatus));
-        status->lockData = GetLockStatusData();
-        status->currIdx = 0;
-        status->predLockData = GetPredicateLockStatusData();
-        status->predLockIdx = 0;
-        funcctx->user_fctx = status;
-
-        MemoryContextSwitchTo(oldcontext);
-    }
-
-    funcctx = SRF_PERCALL_SETUP();
-    status = (DistLockStatus *) funcctx->user_fctx;
-
-    // --- 处理常规锁 (Regular Locks) ---
-    while (status->currIdx < status->lockData->nelements)
-    {
-        LockInstanceData *instance;
-        PGPROC     *proc;
-        bool        granted;
-        LOCKMODE    mode = 0;
-        Datum       values[17];
-        bool        nulls[17];
-        HeapTuple   tuple;
-        Datum       result;
-
-        instance = &(status->lockData->locks[status->currIdx]);
-        
-        proc = BackendPidGetProc(instance->pid);
-        if (!proc)
-        {
-            status->currIdx++;
-            continue;
-        }
-
-        granted = false;
-        if (instance->holdMask)
-        {
-            for (mode = 0; mode < MAX_LOCKMODES; mode++)
-            {
-                if (instance->holdMask & LOCKBIT_ON(mode))
-                {
-                    granted = true;
-                    instance->holdMask &= LOCKBIT_OFF(mode); // 安全地修改 funcctx 中的副本
-                    break;
-                }
-            }
-        }
-
-        if (!granted)
-        {
-            if (instance->waitLockMode != NoLock)
-            {
-                mode = instance->waitLockMode;
-                status->currIdx++;
-            }
-            else
-            {
-                status->currIdx++;
-                continue;
-            }
-        }
-        
-        MemSet(values, 0, sizeof(values));
-        MemSet(nulls, false, sizeof(nulls));
-
-        // 第1列: node_name
-        values[0] = CStringGetTextDatum(PGXCNodeName);
-        
-        // 第2-16列: pg_locks 的标准15列 (索引+1)
-        if (instance->locktag.locktag_type <= LOCKTAG_LAST_TYPE)
-            values[1] = CStringGetTextDatum(LockTagTypeNames[instance->locktag.locktag_type]);
-        else
-            values[1] = CStringGetTextDatum("unknown");
-
-        switch ((LockTagType) instance->locktag.locktag_type)
-        {
-            case LOCKTAG_RELATION:
-            case LOCKTAG_RELATION_EXTEND:
-                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
-                values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
-                nulls[4] = true;
-				nulls[5] = true;
-				nulls[6] = true;
-				nulls[7] = true;
-				nulls[8] = true;
-				nulls[9] = true;
-				nulls[10] = true;
-                break;
-            case LOCKTAG_PAGE:
-                values[1] = ObjectIdGetDatum(instance->locktag.locktag_field1);
-                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field2);
-                values[3] = UInt32GetDatum(instance->locktag.locktag_field3);
-                nulls[4] = true;
-                nulls[5] = true;
-                nulls[6] = true;
-                nulls[7] = true;
-                nulls[8] = true;
-                nulls[9] = true;
-                break;
-            case LOCKTAG_TUPLE:
-                values[1] = ObjectIdGetDatum(instance->locktag.locktag_field1);
-                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field2);
-                values[3] = UInt32GetDatum(instance->locktag.locktag_field3);
-                values[4] = UInt16GetDatum(instance->locktag.locktag_field4);
-                nulls[5] = true;
-                nulls[6] = true;
-                nulls[7] = true;
-                nulls[8] = true;
-                nulls[9] = true;
-                break;
-            case LOCKTAG_TRANSACTION:
-                values[6] =
-                    TransactionIdGetDatum(instance->locktag.locktag_field1);
-                nulls[1] = true;
-                nulls[2] = true;
-                nulls[3] = true;
-                nulls[4] = true;
-                nulls[5] = true;
-                nulls[7] = true;
-                nulls[8] = true;
-                nulls[9] = true;
-                break;
-            case LOCKTAG_VIRTUALTRANSACTION:
-                values[5] = VXIDGetDatum(instance->locktag.locktag_field1,
-                                         instance->locktag.locktag_field2);
-                nulls[1] = true;
-                nulls[2] = true;
-                nulls[3] = true;
-                nulls[4] = true;
-                nulls[6] = true;
-                nulls[7] = true;
-                nulls[8] = true;
-                nulls[9] = true;
-                break;
-            case LOCKTAG_OBJECT:
-            case LOCKTAG_USERLOCK:
-            case LOCKTAG_ADVISORY:
-            default:
-                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
-                values[8] = ObjectIdGetDatum(instance->locktag.locktag_field2);
-                values[9] = ObjectIdGetDatum(instance->locktag.locktag_field3);
-                values[10] = Int16GetDatum(instance->locktag.locktag_field4);
-                nulls[3] = true;
-				nulls[4] = true;
-				nulls[5] = true;
-				nulls[6] = true;
-				nulls[7] = true;
-                break;
-        }
-        values[11] = VXIDGetDatum(instance->backend, instance->lxid);
-        values[12] = Int32GetDatum(instance->pid);
-        values[13] = CStringGetTextDatum(GetLockmodeName(instance->locktag.locktag_lockmethodid, mode));
-        values[14] = BoolGetDatum(granted);
-        values[15] = BoolGetDatum(instance->fastpath);
-
-        // 第17列: gxid
-        if (proc->hasGlobalXid && proc->globalXid[0] != '\0')
-            values[16] = CStringGetTextDatum(proc->globalXid);
-        else
-            nulls[16] = true;
-
-        tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
-        result = HeapTupleGetDatum(tuple);
-        SRF_RETURN_NEXT(funcctx, result);
-    }
-
-    // --- 处理谓词锁 (Predicate Locks) ---
-    // This must match enum PredicateLockTargetType
-
-    if (status->predLockIdx < status->predLockData->nelements)
-    {
-        PredicateLockTargetType lockType; // 【修正】定义 lockType 变量
-        PREDICATELOCKTARGETTAG *predTag = &(status->predLockData->locktags[status->predLockIdx]);
-        SERIALIZABLEXACT *xact = &(status->predLockData->xacts[status->predLockIdx]);
-        PGPROC *proc;
-        Datum       values[17];
-        bool        nulls[17];
-        HeapTuple   tuple;
-        Datum       result;
-        
-        proc = BackendPidGetProc(xact->pid);
-        
-        status->predLockIdx++;
-
-        MemSet(values, 0, sizeof(values));
-        MemSet(nulls, false, sizeof(nulls));
-
-        // 第1列: node_name
-        values[0] = CStringGetTextDatum(PGXCNodeName);
-        
-        // --- 第2-16列: 填充谓词锁信息 (严格校对索引和逻辑) ---
-        
-        // lock type
-        lockType = GET_PREDICATELOCKTARGETTAG_TYPE(*predTag); // 【修正】给 lockType 赋值
-        values[1] = CStringGetTextDatum(PredicateLockTagTypeNames[lockType]); // 索引 1 (locktype)
-
-        // lock target
-        values[2] = GET_PREDICATELOCKTARGETTAG_DB(*predTag);      // 索引 2 (database)
-        values[3] = GET_PREDICATELOCKTARGETTAG_RELATION(*predTag); // 索引 3 (relation)
-
-        if (lockType == PREDLOCKTAG_TUPLE)
-            values[5] = GET_PREDICATELOCKTARGETTAG_OFFSET(*predTag); // 索引 5 (tuple)
-        else
-            nulls[5] = true;
-
-        if (lockType == PREDLOCKTAG_TUPLE || lockType == PREDLOCKTAG_PAGE)
-            values[4] = GET_PREDICATELOCKTARGETTAG_PAGE(*predTag);   // 索引 4 (page)
-        else
-            nulls[4] = true;
-
-        // these fields are targets for other types of locks
-        nulls[6] = true;   // virtualxid
-        nulls[7] = true;   // transactionid
-        nulls[8] = true;   // classid
-        nulls[9] = true;   // objid
-        nulls[10] = true;  // objsubid
-
-        // lock holder
-        values[11] = VXIDGetDatum(xact->vxid.backendId, xact->vxid.localTransactionId); // 索引 11 (virtualtransaction)
-        if (xact->pid != 0)
-            values[12] = Int32GetDatum(xact->pid); // 索引 12 (pid)
-        else
-            nulls[12] = true;
-
-        // Lock mode
-        values[13] = CStringGetTextDatum("SIReadLock"); // 索引 13 (mode)
-        values[14] = BoolGetDatum(true);             // 索引 14 (granted)
-        values[15] = BoolGetDatum(false);            // 索引 15 (fastpath)
-        
-        // 第17列: gxid (索引 16)
-        if (proc && proc->hasGlobalXid && proc->globalXid[0] != '\0')
-            values[16] = CStringGetTextDatum(proc->globalXid);
-        else
-            nulls[16] = true;
-            
-        tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
-        result = HeapTupleGetDatum(tuple);
-        SRF_RETURN_NEXT(funcctx, result);
-    }
-
-    // 所有常规锁和谓词锁都处理完毕后，才调用 DONE
-    SRF_RETURN_DONE(funcctx);
-}
-*/
-/*
- * dist_pg_get_remote_locks - 远程执行 get_dist_pg_locks(true)
+ * dist_pg_get_remote_locks
+ *
+ * A static helper function that dispatches the get_dist_pg_locks(true) call
+ * to all remote nodes in the cluster and stores their results in the given
+ * Tuplestore.
+ *
+ * This implementation uses a SERIAL dispatch model. It iterates through each
+ * remote node one by one, executes the query, and collects the results before
+ * moving to the next node. While this approach is simpler to implement and
+ * debug, it may be slower than a parallel dispatch model for large clusters.
+ * The choice of serial dispatch is a deliberate trade-off for simplicity and
+ * robustness in this version.
+ *
+ * A parallel implementation would involve creating multiple RemoteQueryState
+ * objects and managing their connections concurrently, which significantly
+ * increases complexity.
  */
 static void
 dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
@@ -1735,9 +1496,12 @@ dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	// 串行
     List *nodelist;
     ListCell *lc;
-	Oid local_node_oid = InvalidOid; // 用于存储本地节点的OID
+	Oid local_node_oid = InvalidOid;
 
-	// --- 1. 手动、一次性地查找本地节点的OID ---
+	/*
+	 * To avoid sending a query to the local node (which is handled
+	 * separately), we must first identify the OID of the current node.
+	 */
 	{ 
 		int num_coords, num_dns;
 		Oid *coord_oids, *dn_oids;
@@ -1778,11 +1542,12 @@ dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		if (local_node_oid == InvalidOid)
 			elog(ERROR, "could not find OID for local node \"%s\"", PGXCNodeName);
 	}
-    // 1. 获取所有需要查询的远程节点列表
-    //    注意：我们不需要包含本地节点，因为它会在主函数中被单独处理。
+    /* Get a list of all coordinator and datanode OIDs. */
     nodelist = list_concat(GetAllCoordNodes(), GetAllDataNodes());
 
-    // 2. 【核心】使用 foreach 循环，对每个节点进行串行查询
+    /*
+	 * Iterate through each node and execute the remote query serially.
+	 */
     foreach(lc, nodelist)
     {
         int node_oid = lfirst_int(lc);
@@ -1793,23 +1558,26 @@ dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         TupleTableSlot *result;
         MemoryContext oldcontext;
 
-        // 跳过本地节点，因为主函数会处理它
+        /* Skip the local node; it is handled by the calling function. */
         if (node_oid == local_node_oid)
             continue;
 
-        // 准备针对单个节点的远程查询
+        /* Prepare the remote query for this specific node. */
         snprintf(query, sizeof(query), "SELECT * FROM get_dist_pg_locks(true)");
 
         plan = makeNode(RemoteQuery);
         plan->combine_type = COMBINE_TYPE_NONE;
         plan->exec_nodes = makeNode(ExecNodes);
-        plan->exec_nodes->nodeList = list_make1_int(node_oid); // 只发给当前循环的这一个节点
+        plan->exec_nodes->nodeList = list_make1_int(node_oid); /* Target only one node per loop */
         plan->exec_nodes->missing_ok = true;
-        plan->exec_type = EXEC_ON_ALL_NODES; // 明确指定节点列表
+        plan->exec_type = EXEC_ON_ALL_NODES; /* Use EXEC_ON_NODES as we provide an explicit list */
         plan->sql_statement = query;
         plan->force_autocommit = false;
 
-        // 为本次循环创建独立的执行状态
+        /*
+		 * Create a new, temporary EState for each remote query to ensure
+		 * complete isolation between dispatches.
+		 */
         estate = CreateExecutorState();
         oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
         estate->es_snapshot = GetActiveSnapshot();
@@ -1818,25 +1586,41 @@ dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         ExecAssignResultType((PlanState *) pstate, tupdesc);
         MemoryContextSwitchTo(oldcontext);
 
-        // 接收并处理这个节点的所有返回行
+        /* Fetch all results from the current remote node. */
         while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
         {
             tuplestore_puttupleslot(tupstore, result);
         }
         
-        // 清理本次循环的资源
+        /* Clean up resources for this iteration before starting the next. */
         ExecEndRemoteQuery(pstate);
         FreeExecutorState(estate);
     }
     
-    list_free(nodelist); // 释放节点列表
-
-	// 并行？
+    list_free(nodelist);
 }
 
 /*
- * get_dist_pg_locks - 最终SQL入口
- * 采用物化模式，协调远程和本地的数据采集。
+ * get_dist_pg_locks
+ *
+ * The main SQL-callable entry point for the distributed locks view. It serves
+ * as the central coordinator for data collection across the cluster.
+ *
+ * This function is implemented as a materialized Set-Returning Function (SRF).
+ * In a single execution, it performs the following steps:
+ *  1. Initializes a Tuplestore to hold the aggregated results.
+ *  2. If executed on a coordinator node (and not in 'localonly' mode), it
+ *     calls the static helper 'dist_pg_get_remote_locks' to dispatch
+ *     collection tasks to all remote nodes.
+ *  3. It then calls the static helper 'dist_pg_get_local_locks' to collect
+ *     and analyze lock information from the local node.
+ *  4. Finally, it returns the fully populated Tuplestore to the executor
+ *     for consumption.
+ *
+ * Arguments:
+ *  localonly (boolean, default false): When true, the function skips the
+ *    remote data collection stage. This is a crucial mechanism used by the
+ *    remote calls themselves to prevent infinite recursion.
  */
 Datum
 get_dist_pg_locks(PG_FUNCTION_ARGS)
@@ -1917,7 +1701,6 @@ _PG_init(void)
 	                         NULL,
 	                         NULL);
 
-	// 定义自己用于调试的GUC变量
 	DefineCustomStringVariable(
 							"pg_dist_stat_views.global_query_id",
 							"Internal GUC to propagate Global Query ID.",

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -1479,125 +1479,54 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
  * to all remote nodes in the cluster and stores their results in the given
  * Tuplestore.
  *
- * This implementation uses a SERIAL dispatch model. It iterates through each
- * remote node one by one, executes the query, and collects the results before
- * moving to the next node. While this approach is simpler to implement and
- * debug, it may be slower than a parallel dispatch model for large clusters.
- * The choice of serial dispatch is a deliberate trade-off for simplicity and
- * robustness in this version.
+ * This implementation uses a PARALLEL dispatch model. It constructs a single
+ * RemoteQuery plan targeting all remote nodes and executes it concurrently.
+ * The remote executor handles the parallel connections and fetches results
+ * as they become available from any node.
  *
- * A parallel implementation would involve creating multiple RemoteQueryState
- * objects and managing their connections concurrently, which significantly
- * increases complexity.
+ * This approach significantly reduces the data collection latency in a large
+ * cluster compared to a serial model, as the total execution time is
+ * determined by the slowest responding node, not the sum of all response times.
  */
 static void
 dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 {
-	// 串行
-    List *nodelist;
-    ListCell *lc;
-	Oid local_node_oid = InvalidOid;
+    char			 query[256];
+	RemoteQuery		*plan;
+	EState			*estate;
+	RemoteQueryState *pstate;
+	TupleTableSlot	*result;
+	MemoryContext	 oldcontext;
 
-	/*
-	 * To avoid sending a query to the local node (which is handled
-	 * separately), we must first identify the OID of the current node.
-	 */
-	{ 
-		int num_coords, num_dns;
-		Oid *coord_oids, *dn_oids;
-		int i;
-		
-		PgxcNodeGetOids(&coord_oids, &dn_oids, &num_coords, &num_dns, false);
+	snprintf(query, sizeof(query), "SELECT * FROM get_dist_pg_locks(true)");
 
-		for (i = 0; i < num_coords; i++)
-		{
-			NodeDefinition *ndef = PgxcNodeGetDefinition(coord_oids[i]);
-			if (ndef && strcmp(NameStr(ndef->nodename), PGXCNodeName) == 0)
-			{
-				local_node_oid = coord_oids[i];
-				pfree(ndef);
-				break;
-			}
-			if (ndef) pfree(ndef);
-		}
-		
-		if (local_node_oid == InvalidOid)
-		{
-			for (i = 0; i < num_dns; i++)
-			{
-				NodeDefinition *ndef = PgxcNodeGetDefinition(dn_oids[i]);
-				if (ndef && strcmp(NameStr(ndef->nodename), PGXCNodeName) == 0)
-				{
-					local_node_oid = dn_oids[i];
-					pfree(ndef);
-					break;
-				}
-				if (ndef) pfree(ndef);
-			}
-		}
-		
-		if (coord_oids) pfree(coord_oids);
-		if (dn_oids) pfree(dn_oids);
+	plan = makeNode(RemoteQuery);
+	plan->combine_type = COMBINE_TYPE_NONE;
+	plan->sql_statement = query;
+	plan->force_autocommit = false;
 
-		if (local_node_oid == InvalidOid)
-			elog(ERROR, "could not find OID for local node \"%s\"", PGXCNodeName);
+	plan->exec_type = EXEC_ON_ALL_NODES;
+
+	plan->exec_nodes = makeNode(ExecNodes);
+	plan->exec_nodes->missing_ok = true;
+
+	estate = CreateExecutorState();
+	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+
+	estate->es_snapshot = GetActiveSnapshot();
+	estate->es_param_list_info = NULL;
+	pstate = ExecInitRemoteQuery(plan, estate, 0);
+	ExecAssignResultType((PlanState *) pstate, tupdesc);
+	
+	MemoryContextSwitchTo(oldcontext);
+
+	while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
+	{
+		tuplestore_puttupleslot(tupstore, result);
 	}
-    /* Get a list of all coordinator and datanode OIDs. */
-    nodelist = list_concat(GetAllCoordNodes(), GetAllDataNodes());
-
-    /*
-	 * Iterate through each node and execute the remote query serially.
-	 */
-    foreach(lc, nodelist)
-    {
-        int node_oid = lfirst_int(lc);
-        char query[256];
-        RemoteQuery *plan;
-        EState *estate;
-        RemoteQueryState *pstate;
-        TupleTableSlot *result;
-        MemoryContext oldcontext;
-
-        /* Skip the local node; it is handled by the calling function. */
-        if (node_oid == local_node_oid)
-            continue;
-
-        /* Prepare the remote query for this specific node. */
-        snprintf(query, sizeof(query), "SELECT * FROM get_dist_pg_locks(true)");
-
-        plan = makeNode(RemoteQuery);
-        plan->combine_type = COMBINE_TYPE_NONE;
-        plan->exec_nodes = makeNode(ExecNodes);
-        plan->exec_nodes->nodeList = list_make1_int(node_oid); /* Target only one node per loop */
-        plan->exec_nodes->missing_ok = true;
-        plan->exec_type = EXEC_ON_ALL_NODES; /* Use EXEC_ON_NODES as we provide an explicit list */
-        plan->sql_statement = query;
-        plan->force_autocommit = false;
-
-        /*
-		 * Create a new, temporary EState for each remote query to ensure
-		 * complete isolation between dispatches.
-		 */
-        estate = CreateExecutorState();
-        oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
-        estate->es_snapshot = GetActiveSnapshot();
-        estate->es_param_list_info = NULL;
-        pstate = ExecInitRemoteQuery(plan, estate, 0);
-        ExecAssignResultType((PlanState *) pstate, tupdesc);
-        MemoryContextSwitchTo(oldcontext);
-
-        /* Fetch all results from the current remote node. */
-        while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
-        {
-            tuplestore_puttupleslot(tupstore, result);
-        }
-        
-        /* Clean up resources for this iteration before starting the next. */
-        ExecEndRemoteQuery(pstate);
-        FreeExecutorState(estate);
-    }
-    
-    list_free(nodelist);
+	
+	ExecEndRemoteQuery(pstate);
+	FreeExecutorState(estate);
 }
 
 /*

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -5,17 +5,22 @@
  * you may obtain a copy of the License at http://opensource.org/license/bsd-3-clause/
  */
 #include "postgres.h"
+#include "stddef.h"
 
 #include "catalog/pg_authid.h"
 #include "catalog/pg_type.h"
 #include "commands/dbcommands.h"
 #include "commands/explain.h"
 #include "common/ip.h"
+#include "executor/spi.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
+#include "nodes/plannodes.h"  // 包含 RemoteQuery, ExecNodes 等计划节点定义
+#include "nodes/execnodes.h"  // 包含 RemoteSubplanState 等执行节点定义
+#include "pgxc/nodemgr.h"      // 包含 GetAllNodes() 的声明
 #include "pgstat.h"
 #include "pgxc/execRemote.h"
 #include "pgxc/pgxc.h"
@@ -24,12 +29,18 @@
 #include "storage/ipc.h"
 #include "storage/procarray.h"
 #include "storage/shmem.h"
+#include "storage/lock.h"
+#include "storage/proc.h"
+#include "storage/lmgr.h"        // 包含 LockHeldByProc() 和 GetLockTagsMethodTable() 的声明
+#include "storage/predicate_internals.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/portal.h"
 #include "utils/snapmgr.h"
 #include "utils/timestamp.h"
 #include "utils/hsearch.h"
+#include "utils/memutils.h"
+
 
 PG_MODULE_MAGIC;
 
@@ -119,6 +130,17 @@ typedef struct PgDistStatStatus	// 上面的说明记得改
 
 } PgDistStatStatus;
 
+/*
+ * 自定义的状态结构体，用于在多次SRF调用之间保持状态
+ */
+typedef struct DistLockStatus
+{
+	LockData *lockData;	/* state data from lmgr, a safe copy*/
+	int currIdx;	/* current PROCLOCK index */
+	PredicateLockData *predLockData;    /* state data for pred locks */
+    int            predLockIdx;    /* current index for pred lock */
+}DistLockStatus;
+
 static PgDistStatStatus *DistStatArray = NULL;
 static PgDistStatStatus *MyDistStatEntry = NULL;
 
@@ -182,6 +204,7 @@ void _PG_init(void);
 void _PG_fini(void);
 
 PG_FUNCTION_INFO_V1(dist_pg_stat_get_activity);
+PG_FUNCTION_INFO_V1(get_dist_pg_locks);
 /*
 PG_FUNCTION_INFO_V1(pg_signal_session);
 PG_FUNCTION_INFO_V1(pg_terminate_session);
@@ -1195,6 +1218,364 @@ dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
 	tuplestore_donestoring(tupstore);
 	
 	return (Datum) 0;
+}
+
+/*
+ * ===================================================================
+ *                    LOCKS INFORMATION FUNCTIONS
+ * ===================================================================
+ */
+
+static Datum
+VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
+{
+    char vxidstr[32];
+    snprintf(vxidstr, sizeof(vxidstr), "%d/%u", bid, lxid);
+    return CStringGetTextDatum(vxidstr);
+}
+
+/*
+ * dist_pg_get_local_locks - 【最终版】安全的本地数据采集器
+ *
+ * 它的职责是安全地采集本地锁信息，并将其放入一个传入的 Tuplestore。
+ * 它不是SRF，只是一个普通的辅助函数。
+ */
+static void
+dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
+{
+    LockData   *lockData;
+    PredicateLockData *predLockData;
+    int         i;
+	static const char *const PredicateLockTagTypeNames[] = {"relation", "page", "tuple"};
+
+#define NUM_DIST_LOCKS_RAW_COLS 17
+    Datum       values[NUM_DIST_LOCKS_RAW_COLS];
+    bool        nulls[NUM_DIST_LOCKS_RAW_COLS];
+
+    const char *const LockTagTypeNames[] = {
+        "relation", "extend", "page", "tuple", "transactionid",
+        "virtualxid", "speculative token", "object",
+#ifdef _SHARDING_
+        "shard",
+#endif
+        "userlock", "advisory"
+    };
+
+    // --- 1. 处理常规锁 (Regular Locks) ---
+    lockData = GetLockStatusData();
+    
+    for (i = 0; i < lockData->nelements; i++)
+    {
+        LockInstanceData *instance = &(lockData->locks[i]);
+        PGPROC     *proc = BackendPidGetProc(instance->pid);
+		// 处理持有的锁
+        uint32      holdMask = instance->holdMask;
+        LOCKMODE    mode;
+        
+        if (!proc) 
+            continue;
+
+        for (mode = 0; mode < MAX_LOCKMODES; mode++)
+        {
+            if (holdMask & LOCKBIT_ON(mode))
+            {
+                MemSet(values, 0, sizeof(values));
+                MemSet(nulls, false, sizeof(nulls));
+                
+                values[0] = CStringGetTextDatum(PGXCNodeName);
+                if (instance->locktag.locktag_type <= LOCKTAG_LAST_TYPE)
+                    values[1] = CStringGetTextDatum(LockTagTypeNames[instance->locktag.locktag_type]);
+                else
+                    values[1] = CStringGetTextDatum("unknown");
+                switch ((LockTagType) instance->locktag.locktag_type)
+                {
+                    case LOCKTAG_RELATION:
+                    case LOCKTAG_RELATION_EXTEND:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        nulls[4]=nulls[5]=nulls[6]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_PAGE:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        values[4] = UInt32GetDatum(instance->locktag.locktag_field3);
+                        nulls[5]=nulls[6]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_TUPLE:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        values[4] = UInt32GetDatum(instance->locktag.locktag_field3);
+                        values[5] = UInt16GetDatum(instance->locktag.locktag_field4);
+                        nulls[6]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_TRANSACTION:
+                        values[7] = TransactionIdGetDatum(instance->locktag.locktag_field1);
+                        nulls[2]=nulls[3]=nulls[4]=nulls[5]=nulls[6]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_VIRTUALTRANSACTION:
+                        values[6] = VXIDGetDatum(instance->locktag.locktag_field1, instance->locktag.locktag_field2);
+                        nulls[2]=nulls[3]=nulls[4]=nulls[5]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_OBJECT:
+                    case LOCKTAG_USERLOCK:
+                    case LOCKTAG_ADVISORY:
+                    default:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[8] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        values[9] = ObjectIdGetDatum(instance->locktag.locktag_field3);
+                        values[10] = Int16GetDatum(instance->locktag.locktag_field4);
+                        nulls[3]=nulls[4]=nulls[5]=nulls[6]=nulls[7]=true;
+                        break;
+                }
+                values[11] = VXIDGetDatum(instance->backend, instance->lxid);
+                values[12] = Int32GetDatum(instance->pid);
+                values[13] = CStringGetTextDatum(GetLockmodeName(instance->locktag.locktag_lockmethodid, mode));
+                values[14] = BoolGetDatum(true);
+                values[15] = BoolGetDatum(instance->fastpath);
+                if (proc->hasGlobalXid && proc->globalXid[0] != '\0')
+                    values[16] = CStringGetTextDatum(proc->globalXid);
+                else
+                    nulls[16] = true;
+                tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+            }
+        }
+        
+        // 处理等待的锁
+        if (instance->waitLockMode != NoLock)
+        {
+            MemSet(values, 0, sizeof(values));
+            MemSet(nulls, false, sizeof(nulls));
+            
+            values[0] = CStringGetTextDatum(PGXCNodeName);
+            if (instance->locktag.locktag_type <= LOCKTAG_LAST_TYPE)
+                values[1] = CStringGetTextDatum(LockTagTypeNames[instance->locktag.locktag_type]);
+            else
+                values[1] = CStringGetTextDatum("unknown");
+            switch ((LockTagType) instance->locktag.locktag_type)
+            {
+                    case LOCKTAG_RELATION:
+                    case LOCKTAG_RELATION_EXTEND:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        nulls[4]=nulls[5]=nulls[6]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_PAGE:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        values[4] = UInt32GetDatum(instance->locktag.locktag_field3);
+                        nulls[5]=nulls[6]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_TUPLE:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        values[4] = UInt32GetDatum(instance->locktag.locktag_field3);
+                        values[5] = UInt16GetDatum(instance->locktag.locktag_field4);
+                        nulls[6]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_TRANSACTION:
+                        values[7] = TransactionIdGetDatum(instance->locktag.locktag_field1);
+                        nulls[2]=nulls[3]=nulls[4]=nulls[5]=nulls[6]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_VIRTUALTRANSACTION:
+                        values[6] = VXIDGetDatum(instance->locktag.locktag_field1, instance->locktag.locktag_field2);
+                        nulls[2]=nulls[3]=nulls[4]=nulls[5]=nulls[7]=nulls[8]=nulls[9]=nulls[10]=true;
+                        break;
+                    case LOCKTAG_OBJECT:
+                    case LOCKTAG_USERLOCK:
+                    case LOCKTAG_ADVISORY:
+                    default:
+                        values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                        values[8] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                        values[9] = ObjectIdGetDatum(instance->locktag.locktag_field3);
+                        values[10] = Int16GetDatum(instance->locktag.locktag_field4);
+                        nulls[3]=nulls[4]=nulls[5]=nulls[6]=nulls[7]=true;
+                        break;
+            }
+            values[11] = VXIDGetDatum(instance->backend, instance->lxid);
+            values[12] = Int32GetDatum(instance->pid);
+            values[13] = CStringGetTextDatum(GetLockmodeName(instance->locktag.locktag_lockmethodid, instance->waitLockMode));
+            values[14] = BoolGetDatum(false);
+            values[15] = BoolGetDatum(instance->fastpath);
+            if (proc->hasGlobalXid && proc->globalXid[0] != '\0')
+                values[16] = CStringGetTextDatum(proc->globalXid);
+            else
+                nulls[16] = true;
+            tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+        }
+    }
+
+    // --- 2. 处理谓词锁 (Predicate Locks) ---
+    predLockData = GetPredicateLockStatusData();
+
+    for (i = 0; i < predLockData->nelements; i++)
+    {
+        PredicateLockTargetType lockType;
+        PREDICATELOCKTARGETTAG *predTag = &(predLockData->locktags[i]);
+        SERIALIZABLEXACT *xact = &(predLockData->xacts[i]);
+        PGPROC *proc;
+
+        proc = BackendPidGetProc(xact->pid);
+
+        MemSet(values, 0, sizeof(values));
+        MemSet(nulls, false, sizeof(nulls));
+
+        // 第1列: node_name
+        values[0] = CStringGetTextDatum(PGXCNodeName);
+        
+        // --- 第2-16列: 填充谓词锁信息 (严格校对) ---
+        lockType = GET_PREDICATELOCKTARGETTAG_TYPE(*predTag);
+        values[1] = CStringGetTextDatum(PredicateLockTagTypeNames[lockType]); // locktype
+
+        values[2] = GET_PREDICATELOCKTARGETTAG_DB(*predTag);      // database
+        values[3] = GET_PREDICATELOCKTARGETTAG_RELATION(*predTag); // relation
+
+        if (lockType == PREDLOCKTAG_TUPLE)
+            values[5] = GET_PREDICATELOCKTARGETTAG_OFFSET(*predTag); // tuple
+        else
+            nulls[5] = true;
+
+        if (lockType == PREDLOCKTAG_TUPLE || lockType == PREDLOCKTAG_PAGE)
+            values[4] = GET_PREDICATELOCKTARGETTAG_PAGE(*predTag);   // page
+        else
+            nulls[4] = true;
+            
+        nulls[6] = true;   // virtualxid
+        nulls[7] = true;   // transactionid
+        nulls[8] = true;   // classid
+        nulls[9] = true;   // objid
+        nulls[10] = true;  // objsubid
+
+        values[11] = VXIDGetDatum(xact->vxid.backendId, xact->vxid.localTransactionId); // virtualtransaction
+        if (xact->pid != 0)
+            values[12] = Int32GetDatum(xact->pid); // pid
+        else
+            nulls[12] = true;
+
+        values[13] = CStringGetTextDatum("SIReadLock"); // mode
+        values[14] = BoolGetDatum(true);             // granted
+        values[15] = BoolGetDatum(false);            // fastpath
+        
+        // 第17列: gxid
+        if (proc && proc->hasGlobalXid && proc->globalXid[0] != '\0')
+            values[16] = CStringGetTextDatum(proc->globalXid);
+        else
+            nulls[16] = true;
+
+        tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+    }
+}
+
+/*
+ * dist_pg_get_remote_locks - 【最终权威版】
+ * 采用串行方式，逐个节点地执行远程查询，以避免连接池风暴。
+ */
+static void
+dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
+{
+    List *nodelist;
+    ListCell *lc;
+	Oid local_node_oid; // 用于存储本地节点的OID
+
+	local_node_oid = get_pgxc_node_oid(PGXCNodeName);
+    // 1. 获取所有需要查询的远程节点列表
+    //    注意：我们不需要包含本地节点，因为它会在主函数中被单独处理。
+    nodelist = list_concat(GetAllCoordNodes(), GetAllDataNodes());
+
+    // 2. 【核心】使用 foreach 循环，对每个节点进行串行查询
+    foreach(lc, nodelist)
+    {
+        int node_oid = lfirst_int(lc);
+        char query[256];
+        RemoteQuery *plan;
+        EState *estate;
+        RemoteQueryState *pstate;
+        TupleTableSlot *result;
+        MemoryContext oldcontext;
+
+        // 跳过本地节点，因为主函数会处理它
+        if (node_oid == local_node_oid)
+            continue;
+
+        // 准备针对单个节点的远程查询
+        snprintf(query, sizeof(query), "SELECT * FROM @extschema@.get_dist_pg_locks(true)");
+
+        plan = makeNode(RemoteQuery);
+        plan->combine_type = COMBINE_TYPE_NONE;
+        plan->exec_nodes = makeNode(ExecNodes);
+        plan->exec_nodes->nodeList = list_make1_int(node_oid); // 只发给当前循环的这一个节点
+        plan->exec_nodes->missing_ok = true;
+        plan->exec_type = EXEC_ON_ALL_NODES; // 明确指定节点列表
+        plan->sql_statement = query;
+        plan->force_autocommit = false;
+
+        // 为本次循环创建独立的执行状态
+        estate = CreateExecutorState();
+        oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+        estate->es_snapshot = GetActiveSnapshot();
+        estate->es_param_list_info = NULL;
+        pstate = ExecInitRemoteQuery(plan, estate, 0);
+        ExecAssignResultType((PlanState *) pstate, tupdesc);
+        MemoryContextSwitchTo(oldcontext);
+
+        // 接收并处理这个节点的所有返回行
+        while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
+        {
+            tuplestore_puttupleslot(tupstore, result);
+        }
+        
+        // 清理本次循环的资源
+        ExecEndRemoteQuery(pstate);
+        FreeExecutorState(estate);
+    }
+    
+    list_free_deep(nodelist); // 释放节点列表
+}
+
+/*
+ * get_dist_pg_locks - 【总指挥 & 最终SQL入口】
+ * 采用物化模式，协调远程和本地的数据采集。
+ */
+Datum
+get_dist_pg_locks(PG_FUNCTION_ARGS)
+{
+    bool localonly = PG_GETARG_BOOL(0);
+    ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+    TupleDesc tupdesc;
+    Tuplestorestate *tupstore;
+    MemoryContext per_query_ctx, oldcontext;
+    
+    // 检查调用上下文是否支持返回集合
+    if (!IsA(rsinfo, ReturnSetInfo) || !(rsinfo->allowedModes & SFRM_Materialize))
+        ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                        errmsg("set-valued function called in context that cannot accept a set")));
+
+    // 获取期望返回的元组描述 (TupleDesc)
+    if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+        elog(ERROR, "return type must be a row type");
+
+    // 切换到查询级别的内存上下文，以确保Tuplestore的生命周期正确
+    per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+    oldcontext = MemoryContextSwitchTo(per_query_ctx);
+
+    // 创建 Tuplestore
+    tupstore = tuplestore_begin_heap(true, false, work_mem);
+
+    // 【核心】告诉PostgreSQL执行器，我们将使用物化模式返回结果
+    rsinfo->returnMode = SFRM_Materialize;
+    rsinfo->setResult = tupstore; // 将 tupstore 挂在返回结果上
+    rsinfo->setDesc = tupdesc;      // 将 tupdesc 挂在返回结果上
+
+	// 1. 如果是CN，且非localonly，则进行远程数据采集
+    if (!localonly && IS_PGXC_COORDINATOR)
+        dist_pg_get_remote_locks(tupstore, tupdesc);
+
+    // 2. 然后采集本地节点的数据 (直接、简洁地调用我们的普通辅助函数)
+    dist_pg_get_local_locks(tupstore, tupdesc);
+    
+    tuplestore_donestoring(tupstore);
+    MemoryContextSwitchTo(oldcontext);
+
+    return (Datum) 0;
 }
 
 static bool

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -7,6 +7,7 @@
 #include "postgres.h"
 #include "stddef.h"
 
+#include "access/htup_details.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_type.h"
 #include "commands/dbcommands.h"
@@ -18,6 +19,7 @@
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
+#include "pgxc/nodemgr.h"
 #include "pgstat.h"
 #include "pgxc/execRemote.h"
 #include "pgxc/pgxc.h"
@@ -40,7 +42,7 @@
 
 PG_MODULE_MAGIC;
 
-#define PG_DIST_STAT_ACTIVITY_COLS 27	// 列数定义
+#define PG_DIST_STAT_ACTIVITY_COLS 28	// 列数定义
 
 /* ----------
  * Total number of backends including auxiliary
@@ -116,8 +118,17 @@ typedef struct PgDistStatStatus	// 上面的说明记得改
     TransactionId backend_xid;
     TransactionId backend_xmin;
     char backend_type[NAMEDATALEN];
+	char gxid[NAMEDATALEN];
 
 } PgDistStatStatus;
+
+typedef struct DistLockStatus
+{
+    LockData           *lockData;
+    int                 currIdx;
+    PredicateLockData  *predLockData;
+    int                 predLockIdx;
+} DistLockStatus;
 
 static PgDistStatStatus *DistStatArray = NULL;
 static PgDistStatStatus *MyDistStatEntry = NULL;
@@ -171,11 +182,13 @@ static char *pgds_gid_guc_string = NULL;
 	} while (0)
 
 Datum dist_pg_stat_get_activity(PG_FUNCTION_ARGS);
+// Datum get_dist_pg_locks_raw(PG_FUNCTION_ARGS);
 
 void _PG_init(void);
 void _PG_fini(void);
 
 PG_FUNCTION_INFO_V1(dist_pg_stat_get_activity);
+// PG_FUNCTION_INFO_V1(get_dist_pg_locks_raw);
 PG_FUNCTION_INFO_V1(get_dist_pg_locks);
 
 static ParamListInfo
@@ -528,6 +541,15 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
             entry->backend_xid = local_beentry->backend_xid;
             entry->backend_xmin = local_beentry->backend_xmin;
         }
+
+		if (MyProc && MyProc->hasGlobalXid && MyProc->globalXid[0] != '\0')
+		{
+			snprintf((char *)entry->gxid, NAMEDATALEN, "%s", MyProc->globalXid);
+		}
+		else
+		{
+			entry->gxid[0] = '\0';
+		}
 
 		 /* -- 采集并写入 planstate 和 cursors -- */
         if (desc->already_executed)
@@ -1145,6 +1167,11 @@ dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
 				values[26] = CStringGetTextDatum(local_dsentry->global_query_id);
 			else
 				nulls[26] = true;
+
+			if (local_dsentry->gxid[0] != '\0')
+				values[27] = CStringGetTextDatum(local_dsentry->gxid);
+			else
+				nulls[27] = true;
 		}
 		else
 		{
@@ -1203,6 +1230,8 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
  * 它的职责是安全地采集本地锁信息，并将其放入一个传入的 Tuplestore。
  * 它不是SRF，只是一个普通的辅助函数。
  */
+
+
 static void
 dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 {
@@ -1211,7 +1240,7 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
     int         i;
 	static const char *const PredicateLockTagTypeNames[] = {"relation", "page", "tuple"};
 
-#define NUM_DIST_LOCKS_RAW_COLS 17
+#define NUM_DIST_LOCKS_RAW_COLS 19
     Datum       values[NUM_DIST_LOCKS_RAW_COLS];
     bool        nulls[NUM_DIST_LOCKS_RAW_COLS];
 
@@ -1299,6 +1328,8 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
                     values[16] = CStringGetTextDatum(proc->globalXid);
                 else
                     nulls[16] = true;
+				nulls[17] = true; // blocking_pid
+                nulls[18] = true; // blocking_gxid
                 tuplestore_putvalues(tupstore, tupdesc, values, nulls);
             }
         }
@@ -1306,6 +1337,34 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         // 处理等待的锁
         if (instance->waitLockMode != NoLock)
         {
+			PGPROC *blocker_proc = NULL; // 声明一个用于存储阻塞者的指针
+            
+            // --- 【核心新增】在C层，安全地、精确地查找阻塞者 ---
+            if (proc->waitStatus == STATUS_WAITING && proc->waitLock != NULL)
+            {
+                LOCK *lock_obj = proc->waitLock;
+                const LockMethod lockMethodTable = GetLockTagsMethodTable(&(lock_obj->tag));
+                
+                // 再次遍历【同一个】只读快照 lockData 来寻找持有者
+                for (int j = 0; j < lockData->nelements; j++)
+                {
+                    LockInstanceData *holder_instance = &(lockData->locks[j]);
+                    
+                    // 检查是否是同一个锁对象 (通过比较locktag)
+                    if (memcmp(&instance->locktag, &holder_instance->locktag, sizeof(LOCKTAG)) == 0)
+                    {
+                        // 检查锁模式是否冲突
+                        if ((holder_instance->holdMask & lockMethodTable->conflictTab[instance->waitLockMode]) != 0)
+                        {
+                            // 找到了一个持有冲突锁的进程
+                            blocker_proc = BackendPidGetProc(holder_instance->pid);
+                            if (blocker_proc)
+                                break; // 找到第一个有效的阻塞者即可
+                        }
+                    }
+                }
+            }
+
             MemSet(values, 0, sizeof(values));
             MemSet(nulls, false, sizeof(nulls));
             
@@ -1363,6 +1422,20 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
                 values[16] = CStringGetTextDatum(proc->globalXid);
             else
                 nulls[16] = true;
+
+			if (blocker_proc)
+            {
+                values[17] = Int32GetDatum(blocker_proc->pid);
+                if (blocker_proc->hasGlobalXid && blocker_proc->globalXid[0] != '\0')
+                    values[18] = CStringGetTextDatum(blocker_proc->globalXid);
+                else
+                    nulls[18] = true;
+            }
+            else
+            {
+                nulls[17] = true;
+                nulls[18] = true;
+            }
             tuplestore_putvalues(tupstore, tupdesc, values, nulls);
         }
     }
@@ -1424,51 +1497,408 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         else
             nulls[16] = true;
 
+		nulls[17] = true; // blocking_pid
+        nulls[18] = true; // blocking_gxid
+
         tuplestore_putvalues(tupstore, tupdesc, values, nulls);
     }
 }
 
+
+/*
+Datum
+get_dist_pg_locks_raw(PG_FUNCTION_ARGS)
+{
+    FuncCallContext *funcctx;
+    DistLockStatus  *status;
+	static const char *const PredicateLockTagTypeNames[] = {"relation", "page", "tuple"};
+	// This must match enum LockTagType in lock.h!
+    const char *const LockTagTypeNames[] = {
+        "relation", "extend", "page", "tuple", "transactionid",
+        "virtualxid", "speculative token", "object",
+#ifdef _SHARDING_
+        "shard",
+#endif
+        "userlock", "advisory"
+    };
+
+    if (SRF_IS_FIRSTCALL())
+    {
+        TupleDesc       tupdesc;
+        MemoryContext   oldcontext;
+
+        funcctx = SRF_FIRSTCALL_INIT();
+        oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+        // 构建返回元组的描述 (17列: node_name + 15 + gxid)
+        tupdesc = CreateTemplateTupleDesc(17, false);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 1, "node_name", TEXTOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 2, "locktype", TEXTOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 3, "database", OIDOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 4, "relation", OIDOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 5, "page", INT4OID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 6, "tuple", INT2OID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 7, "virtualxid", TEXTOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 8, "transactionid", XIDOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 9, "classid", OIDOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 10, "objid", OIDOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 11, "objsubid", INT2OID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 12, "virtualtransaction", TEXTOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 13, "pid", INT4OID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 14, "mode", TEXTOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 15, "granted", BOOLOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 16, "fastpath", BOOLOID, -1, 0);
+        TupleDescInitEntry(tupdesc, (AttrNumber) 17, "gxid", TEXTOID, -1, 0);
+        funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+        // 创建我们自定义的状态结构体并初始化
+        status = (DistLockStatus *) palloc(sizeof(DistLockStatus));
+        status->lockData = GetLockStatusData();
+        status->currIdx = 0;
+        status->predLockData = GetPredicateLockStatusData();
+        status->predLockIdx = 0;
+        funcctx->user_fctx = status;
+
+        MemoryContextSwitchTo(oldcontext);
+    }
+
+    funcctx = SRF_PERCALL_SETUP();
+    status = (DistLockStatus *) funcctx->user_fctx;
+
+    // --- 处理常规锁 (Regular Locks) ---
+    while (status->currIdx < status->lockData->nelements)
+    {
+        LockInstanceData *instance;
+        PGPROC     *proc;
+        bool        granted;
+        LOCKMODE    mode = 0;
+        Datum       values[17];
+        bool        nulls[17];
+        HeapTuple   tuple;
+        Datum       result;
+
+        instance = &(status->lockData->locks[status->currIdx]);
+        
+        proc = BackendPidGetProc(instance->pid);
+        if (!proc)
+        {
+            status->currIdx++;
+            continue;
+        }
+
+        granted = false;
+        if (instance->holdMask)
+        {
+            for (mode = 0; mode < MAX_LOCKMODES; mode++)
+            {
+                if (instance->holdMask & LOCKBIT_ON(mode))
+                {
+                    granted = true;
+                    instance->holdMask &= LOCKBIT_OFF(mode); // 安全地修改 funcctx 中的副本
+                    break;
+                }
+            }
+        }
+
+        if (!granted)
+        {
+            if (instance->waitLockMode != NoLock)
+            {
+                mode = instance->waitLockMode;
+                status->currIdx++;
+            }
+            else
+            {
+                status->currIdx++;
+                continue;
+            }
+        }
+        
+        MemSet(values, 0, sizeof(values));
+        MemSet(nulls, false, sizeof(nulls));
+
+        // 第1列: node_name
+        values[0] = CStringGetTextDatum(PGXCNodeName);
+        
+        // 第2-16列: pg_locks 的标准15列 (索引+1)
+        if (instance->locktag.locktag_type <= LOCKTAG_LAST_TYPE)
+            values[1] = CStringGetTextDatum(LockTagTypeNames[instance->locktag.locktag_type]);
+        else
+            values[1] = CStringGetTextDatum("unknown");
+
+        switch ((LockTagType) instance->locktag.locktag_type)
+        {
+            case LOCKTAG_RELATION:
+            case LOCKTAG_RELATION_EXTEND:
+                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                values[3] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                nulls[4] = true;
+				nulls[5] = true;
+				nulls[6] = true;
+				nulls[7] = true;
+				nulls[8] = true;
+				nulls[9] = true;
+				nulls[10] = true;
+                break;
+            case LOCKTAG_PAGE:
+                values[1] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                values[3] = UInt32GetDatum(instance->locktag.locktag_field3);
+                nulls[4] = true;
+                nulls[5] = true;
+                nulls[6] = true;
+                nulls[7] = true;
+                nulls[8] = true;
+                nulls[9] = true;
+                break;
+            case LOCKTAG_TUPLE:
+                values[1] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                values[3] = UInt32GetDatum(instance->locktag.locktag_field3);
+                values[4] = UInt16GetDatum(instance->locktag.locktag_field4);
+                nulls[5] = true;
+                nulls[6] = true;
+                nulls[7] = true;
+                nulls[8] = true;
+                nulls[9] = true;
+                break;
+            case LOCKTAG_TRANSACTION:
+                values[6] =
+                    TransactionIdGetDatum(instance->locktag.locktag_field1);
+                nulls[1] = true;
+                nulls[2] = true;
+                nulls[3] = true;
+                nulls[4] = true;
+                nulls[5] = true;
+                nulls[7] = true;
+                nulls[8] = true;
+                nulls[9] = true;
+                break;
+            case LOCKTAG_VIRTUALTRANSACTION:
+                values[5] = VXIDGetDatum(instance->locktag.locktag_field1,
+                                         instance->locktag.locktag_field2);
+                nulls[1] = true;
+                nulls[2] = true;
+                nulls[3] = true;
+                nulls[4] = true;
+                nulls[6] = true;
+                nulls[7] = true;
+                nulls[8] = true;
+                nulls[9] = true;
+                break;
+            case LOCKTAG_OBJECT:
+            case LOCKTAG_USERLOCK:
+            case LOCKTAG_ADVISORY:
+            default:
+                values[2] = ObjectIdGetDatum(instance->locktag.locktag_field1);
+                values[8] = ObjectIdGetDatum(instance->locktag.locktag_field2);
+                values[9] = ObjectIdGetDatum(instance->locktag.locktag_field3);
+                values[10] = Int16GetDatum(instance->locktag.locktag_field4);
+                nulls[3] = true;
+				nulls[4] = true;
+				nulls[5] = true;
+				nulls[6] = true;
+				nulls[7] = true;
+                break;
+        }
+        values[11] = VXIDGetDatum(instance->backend, instance->lxid);
+        values[12] = Int32GetDatum(instance->pid);
+        values[13] = CStringGetTextDatum(GetLockmodeName(instance->locktag.locktag_lockmethodid, mode));
+        values[14] = BoolGetDatum(granted);
+        values[15] = BoolGetDatum(instance->fastpath);
+
+        // 第17列: gxid
+        if (proc->hasGlobalXid && proc->globalXid[0] != '\0')
+            values[16] = CStringGetTextDatum(proc->globalXid);
+        else
+            nulls[16] = true;
+
+        tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+        result = HeapTupleGetDatum(tuple);
+        SRF_RETURN_NEXT(funcctx, result);
+    }
+
+    // --- 处理谓词锁 (Predicate Locks) ---
+    // This must match enum PredicateLockTargetType
+
+    if (status->predLockIdx < status->predLockData->nelements)
+    {
+        PredicateLockTargetType lockType; // 【修正】定义 lockType 变量
+        PREDICATELOCKTARGETTAG *predTag = &(status->predLockData->locktags[status->predLockIdx]);
+        SERIALIZABLEXACT *xact = &(status->predLockData->xacts[status->predLockIdx]);
+        PGPROC *proc;
+        Datum       values[17];
+        bool        nulls[17];
+        HeapTuple   tuple;
+        Datum       result;
+        
+        proc = BackendPidGetProc(xact->pid);
+        
+        status->predLockIdx++;
+
+        MemSet(values, 0, sizeof(values));
+        MemSet(nulls, false, sizeof(nulls));
+
+        // 第1列: node_name
+        values[0] = CStringGetTextDatum(PGXCNodeName);
+        
+        // --- 第2-16列: 填充谓词锁信息 (严格校对索引和逻辑) ---
+        
+        // lock type
+        lockType = GET_PREDICATELOCKTARGETTAG_TYPE(*predTag); // 【修正】给 lockType 赋值
+        values[1] = CStringGetTextDatum(PredicateLockTagTypeNames[lockType]); // 索引 1 (locktype)
+
+        // lock target
+        values[2] = GET_PREDICATELOCKTARGETTAG_DB(*predTag);      // 索引 2 (database)
+        values[3] = GET_PREDICATELOCKTARGETTAG_RELATION(*predTag); // 索引 3 (relation)
+
+        if (lockType == PREDLOCKTAG_TUPLE)
+            values[5] = GET_PREDICATELOCKTARGETTAG_OFFSET(*predTag); // 索引 5 (tuple)
+        else
+            nulls[5] = true;
+
+        if (lockType == PREDLOCKTAG_TUPLE || lockType == PREDLOCKTAG_PAGE)
+            values[4] = GET_PREDICATELOCKTARGETTAG_PAGE(*predTag);   // 索引 4 (page)
+        else
+            nulls[4] = true;
+
+        // these fields are targets for other types of locks
+        nulls[6] = true;   // virtualxid
+        nulls[7] = true;   // transactionid
+        nulls[8] = true;   // classid
+        nulls[9] = true;   // objid
+        nulls[10] = true;  // objsubid
+
+        // lock holder
+        values[11] = VXIDGetDatum(xact->vxid.backendId, xact->vxid.localTransactionId); // 索引 11 (virtualtransaction)
+        if (xact->pid != 0)
+            values[12] = Int32GetDatum(xact->pid); // 索引 12 (pid)
+        else
+            nulls[12] = true;
+
+        // Lock mode
+        values[13] = CStringGetTextDatum("SIReadLock"); // 索引 13 (mode)
+        values[14] = BoolGetDatum(true);             // 索引 14 (granted)
+        values[15] = BoolGetDatum(false);            // 索引 15 (fastpath)
+        
+        // 第17列: gxid (索引 16)
+        if (proc && proc->hasGlobalXid && proc->globalXid[0] != '\0')
+            values[16] = CStringGetTextDatum(proc->globalXid);
+        else
+            nulls[16] = true;
+            
+        tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+        result = HeapTupleGetDatum(tuple);
+        SRF_RETURN_NEXT(funcctx, result);
+    }
+
+    // 所有常规锁和谓词锁都处理完毕后，才调用 DONE
+    SRF_RETURN_DONE(funcctx);
+}
+*/
 /*
  * dist_pg_get_remote_locks - 远程执行 get_dist_pg_locks(true)
  */
 static void
 dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 {
-	char    query[256];
-	EState *estate;
-	RemoteQuery *plan;
-	RemoteQueryState *pstate;
-	TupleTableSlot *result = NULL;
-	MemoryContext oldcontext;
+    List *nodelist;
+    ListCell *lc;
+	Oid local_node_oid = InvalidOid; // 用于存储本地节点的OID
 
-	snprintf(query, sizeof(query), "SELECT * FROM @extschema@.get_dist_pg_locks(true)");
+	// --- 1. 手动、一次性地查找本地节点的OID ---
+	{ 
+		int num_coords, num_dns;
+		Oid *coord_oids, *dn_oids;
+		int i;
+		
+		PgxcNodeGetOids(&coord_oids, &dn_oids, &num_coords, &num_dns, false);
 
-	plan = makeNode(RemoteQuery);
-	plan->combine_type = COMBINE_TYPE_NONE;
-	
-	plan->exec_nodes = makeNode(ExecNodes);
-	plan->exec_nodes->nodeList = list_concat(GetAllCoordNodes(), GetAllDataNodes());
-	plan->exec_nodes->missing_ok = true;
-	plan->exec_type = EXEC_ON_ALL_NODES;
+		for (i = 0; i < num_coords; i++)
+		{
+			NodeDefinition *ndef = PgxcNodeGetDefinition(coord_oids[i]);
+			if (ndef && strcmp(NameStr(ndef->nodename), PGXCNodeName) == 0)
+			{
+				local_node_oid = coord_oids[i];
+				pfree(ndef);
+				break;
+			}
+			if (ndef) pfree(ndef);
+		}
+		
+		if (local_node_oid == InvalidOid)
+		{
+			for (i = 0; i < num_dns; i++)
+			{
+				NodeDefinition *ndef = PgxcNodeGetDefinition(dn_oids[i]);
+				if (ndef && strcmp(NameStr(ndef->nodename), PGXCNodeName) == 0)
+				{
+					local_node_oid = dn_oids[i];
+					pfree(ndef);
+					break;
+				}
+				if (ndef) pfree(ndef);
+			}
+		}
+		
+		if (coord_oids) pfree(coord_oids);
+		if (dn_oids) pfree(dn_oids);
 
-	plan->sql_statement = query;
-	plan->force_autocommit = false;
-
-	estate = CreateExecutorState();
-	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
-	estate->es_snapshot = GetActiveSnapshot();
-	estate->es_param_list_info = NULL;
-	pstate = ExecInitRemoteQuery(plan, estate, 0);
-	ExecAssignResultType((PlanState *) pstate, tupdesc);
-	MemoryContextSwitchTo(oldcontext);
-
-	while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
-	{
-		tuplestore_puttupleslot(tupstore, result);
+		if (local_node_oid == InvalidOid)
+			elog(ERROR, "could not find OID for local node \"%s\"", PGXCNodeName);
 	}
+    // 1. 获取所有需要查询的远程节点列表
+    //    注意：我们不需要包含本地节点，因为它会在主函数中被单独处理。
+    nodelist = list_concat(GetAllCoordNodes(), GetAllDataNodes());
 
-	ExecEndRemoteQuery(pstate);
-	FreeExecutorState(estate);
+    // 2. 【核心】使用 foreach 循环，对每个节点进行串行查询
+    foreach(lc, nodelist)
+    {
+        int node_oid = lfirst_int(lc);
+        char query[256];
+        RemoteQuery *plan;
+        EState *estate;
+        RemoteQueryState *pstate;
+        TupleTableSlot *result;
+        MemoryContext oldcontext;
+
+        // 跳过本地节点，因为主函数会处理它
+        if (node_oid == local_node_oid)
+            continue;
+
+        // 准备针对单个节点的远程查询
+        snprintf(query, sizeof(query), "SELECT * FROM get_dist_pg_locks(true)");
+
+        plan = makeNode(RemoteQuery);
+        plan->combine_type = COMBINE_TYPE_NONE;
+        plan->exec_nodes = makeNode(ExecNodes);
+        plan->exec_nodes->nodeList = list_make1_int(node_oid); // 只发给当前循环的这一个节点
+        plan->exec_nodes->missing_ok = true;
+        plan->exec_type = EXEC_ON_ALL_NODES; // 明确指定节点列表
+        plan->sql_statement = query;
+        plan->force_autocommit = false;
+
+        // 为本次循环创建独立的执行状态
+        estate = CreateExecutorState();
+        oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+        estate->es_snapshot = GetActiveSnapshot();
+        estate->es_param_list_info = NULL;
+        pstate = ExecInitRemoteQuery(plan, estate, 0);
+        ExecAssignResultType((PlanState *) pstate, tupdesc);
+        MemoryContextSwitchTo(oldcontext);
+
+        // 接收并处理这个节点的所有返回行
+        while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
+        {
+            tuplestore_puttupleslot(tupstore, result);
+        }
+        
+        // 清理本次循环的资源
+        ExecEndRemoteQuery(pstate);
+        FreeExecutorState(estate);
+    }
+    
+    list_free(nodelist); // 释放节点列表
 }
 
 /*
@@ -1483,33 +1913,25 @@ get_dist_pg_locks(PG_FUNCTION_ARGS)
     TupleDesc tupdesc;
     Tuplestorestate *tupstore;
     MemoryContext per_query_ctx, oldcontext;
-    
-    // 检查调用上下文是否支持返回集合
+
     if (!IsA(rsinfo, ReturnSetInfo) || !(rsinfo->allowedModes & SFRM_Materialize))
         ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                         errmsg("set-valued function called in context that cannot accept a set")));
 
-    // 获取期望返回的元组描述 (TupleDesc)
     if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
         elog(ERROR, "return type must be a row type");
 
-    // 切换到查询级别的内存上下文，以确保Tuplestore的生命周期正确
     per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
     oldcontext = MemoryContextSwitchTo(per_query_ctx);
 
-    // 创建 Tuplestore
     tupstore = tuplestore_begin_heap(true, false, work_mem);
-
-    // 告诉PostgreSQL执行器，我们将使用物化模式返回结果
     rsinfo->returnMode = SFRM_Materialize;
-    rsinfo->setResult = tupstore; // 将 tupstore 挂在返回结果上
-    rsinfo->setDesc = tupdesc;      // 将 tupdesc 挂在返回结果上
+    rsinfo->setResult = tupstore;
+    rsinfo->setDesc = tupdesc;
 
-	// 1. 如果是CN，且非localonly，则进行远程数据采集
     if (!localonly && IS_PGXC_COORDINATOR)
         dist_pg_get_remote_locks(tupstore, tupdesc);
 
-    // 2. 然后采集本地节点的数据
     dist_pg_get_local_locks(tupstore, tupdesc);
     
     tuplestore_donestoring(tupstore);

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -86,18 +86,21 @@ typedef struct PgDistStatStatus	// 上面的说明记得改
 	
 	bool valid;                     /* don't show this entry if false */
 	char nodename[NAMEDATALEN];     /* nodename, determined after process started */
-	char role[NAMEDATALEN];         /* coord, datanode, producer or consumer */
 
-    // 临时状态
+	// 【核心】只存储 pgstat 没有的、我们自己扩展的信息
 	char sessionid[NAMEDATALEN];    /* global session id in a cluster, one for a session */
-	
+    // 存储GID的哈希值，用于在C代码中进行快速、高效的比较和过滤
+    uint64 global_query_id_hash; 
+    // 存储GID的完整字符串，用于最终在视图中显示
+    char   global_query_id[256]; // 预留足够长的空间
+	// 查询级状态,在【每一个】顶层查询开始时写入，在【该查询结束】(ExecutorEnd)时就必须清理。
+	char role[NAMEDATALEN];         /* coord, datanode, producer or consumer */
 	/* portal_name or portal_name_unique */
 	char sqname[NAMEDATALEN];
 	/* true if sharequeue end, but currently change when query ends in this backend */
 	bool sqdone;
 	/* part of plantree this backend is processing, OR last processed if backend is idle */
 	char planstate[4096];
-	
 	/*
 	 * portal name: the name of current portal, given by upper node of processing query 
 	 * cursor name: contained in planstate this backend is querying, which would be
@@ -109,17 +112,14 @@ typedef struct PgDistStatStatus	// 上面的说明记得改
 	char portal[NAMEDATALEN];
 	char cursors[NAMEDATALEN * 64];
 
-	// 新增字段
-    // 存储GID的哈希值，用于在C代码中进行快速、高效的比较和过滤
-    uint64 global_query_id_hash; 
-    // 存储GID的完整字符串，用于最终在视图中显示
-    char   global_query_id[256]; // 预留足够长的空间
-    char application_name[NAMEDATALEN];
+	/*
+	// 事务级状态,【第一个】顶层查询开始时写入，直到【事务结束】(COMMIT/ROLLBACK)才清理。
+    char  gxid[NAMEDATALEN];
     TransactionId backend_xid;
     TransactionId backend_xmin;
-    char backend_type[NAMEDATALEN];
-	char gxid[NAMEDATALEN];
-
+    char  application_name[NAMEDATALEN];
+    char  backend_type[NAMEDATALEN]; // backend_type 通常与进程绑定，但为保持与activity一致，也设为事务级
+	*/
 } PgDistStatStatus;
 
 typedef struct DistLockStatus
@@ -295,9 +295,6 @@ pgds_shutdown_hook(int code, Datum arg)
 	increment_changecount_before(entry);
 	
 	entry->valid = false;	/* mark invalid to hide this entry */
-	
-	entry->global_query_id_hash = 0; // 新增
-    entry->global_query_id[0] = '\0'; // 新增
 
 	increment_changecount_after(entry);
 }
@@ -440,28 +437,14 @@ static void
 pgds_report_query_activity(BackendState state, const char *cmd_str)
 {
 	volatile PgDistStatStatus *entry;
-	LocalPgBackendStatus *local_beentry;
-	PgBackendStatus *beentry;
 	
+	pgds_entry_initialize();
+	entry = MyDistStatEntry;
+	pgds_report_common((PgDistStatStatus *) entry);
+
 	// 只调用前任钩子
 	if (prev_pgstat_report_hook)
 		prev_pgstat_report_hook(state, cmd_str);
-
-    if (MyDistStatEntry && MyDistStatEntry->global_query_id_hash != 0)
-    {
-        entry = MyDistStatEntry;
-        
-        // 获取实时的 beentry 来更新动态信息
-        local_beentry = pgstat_fetch_stat_local_beentry(MyBackendId);
-        if (local_beentry)
-        {
-             // 更新 backend_type
-             beentry = &local_beentry->backendStatus;
-             increment_changecount_before(entry);
-             snprintf((char *)entry->backend_type, NAMEDATALEN, "%s", pgstat_get_backend_desc(beentry->st_backendType));
-             increment_changecount_after(entry);
-        }
-    }
 }
 
 /* ----------
@@ -482,8 +465,6 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 	MemoryContext oldcxt;
 	char gid_string[256];
 	char *gid_to_write;
-	LocalPgBackendStatus *local_beentry;
-	PgBackendStatus *beentry;
 	
 	if (prev_ExecutorStart)
 		prev_ExecutorStart(desc, eflags);
@@ -513,9 +494,6 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 		gid_to_write = (char *)pgds_gid_guc_string;
 		// 无论CN还是DN，都在这里，把所有信息一次性写入共享内存
 		increment_changecount_before(entry);
-		// 写入通用信息
-		pgds_report_common((PgDistStatStatus *) entry);
-
 		// --- 在数据节点 (DN) 上，或者作为“中间人”的CN上：读取GUC并存储 --
 		// 检查绑定的C变量是否有值 (即GUC是否被传播过来)
 		if (gid_to_write && gid_to_write[0] != '\0')
@@ -527,29 +505,10 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 			entry->global_query_id_hash = string_hash(gid_to_write, strlen(gid_to_write));
 
 		}
+		// 写入常规信息
+		pgds_report_common((PgDistStatStatus *) entry);
 		// 写入角色
 		pgds_report_role((PgDistStatStatus *)entry, desc);
-
-		// 新增的采集逻辑，连接名称和后台进程相关信息
-		local_beentry = pgstat_fetch_stat_local_beentry(MyBackendId);
-		if (local_beentry)
-        {
-            beentry = &local_beentry->backendStatus;
-            if (beentry->st_appname)
-                snprintf((char *)entry->application_name, NAMEDATALEN, "%s", beentry->st_appname);
-            snprintf((char *)entry->backend_type, NAMEDATALEN, "%s", pgstat_get_backend_desc(beentry->st_backendType));
-            entry->backend_xid = local_beentry->backend_xid;
-            entry->backend_xmin = local_beentry->backend_xmin;
-        }
-
-		if (MyProc && MyProc->hasGlobalXid && MyProc->globalXid[0] != '\0')
-		{
-			snprintf((char *)entry->gxid, NAMEDATALEN, "%s", MyProc->globalXid);
-		}
-		else
-		{
-			entry->gxid[0] = '\0';
-		}
 
 		 /* -- 采集并写入 planstate 和 cursors -- */
         if (desc->already_executed)
@@ -642,8 +601,8 @@ pgds_executor_end_hook(QueryDesc *queryDesc)
 
             increment_changecount_before(v_entry);
             // v_entry->nodename 和 v_entry->role 被刻意保留，不作清理！
-            MemSet(&entry->sessionid, 0, 
-                   sizeof(PgDistStatStatus) - offsetof(PgDistStatStatus, sessionid));
+            MemSet(&entry->global_query_id_hash, 0, 
+                   sizeof(PgDistStatStatus) - offsetof(PgDistStatStatus, global_query_id_hash));
             
             increment_changecount_after(v_entry);
 
@@ -667,60 +626,31 @@ pgds_executor_end_hook(QueryDesc *queryDesc)
  * ----------
  */
 static void
-pgds_report_activity(Portal portal, bool is_drop)	// 新增一个参数区分是Portal Start 还是 Drop
+pgds_report_activity(Portal portal)
 {
 	volatile PgDistStatStatus *entry;
+	QueryDesc *desc = portal->queryDesc;
 	
-	if (is_drop)
-	{
-		if (prev_PortalDrop)
-			prev_PortalDrop(portal);
-	}
-	else
-	{
-		if (prev_PortalStart)
-			prev_PortalStart(portal);
-	}
-
 	pgds_entry_initialize();
 	entry = MyDistStatEntry;
 	
 	/* if query already done, just report sqdone and return */
-	// if (desc != NULL && desc->already_executed)
-	// {
-	// 	increment_changecount_before(entry);
-	// 	entry->sqdone = true;
-	// 	increment_changecount_after(entry);
-	// 	return;
-	// }
+	if (desc != NULL && desc->already_executed)
+	{
+		increment_changecount_before(entry);
+		entry->sqdone = true;
+		increment_changecount_after(entry);
+		return;
+	}
 	
 	increment_changecount_before(entry);
 
-    if (is_drop)
-    {
-        // 如果是 PortalDrop，就清空 portal 名字
-        entry->portal[0] = '\0';
-    }
-    else
-    {
-        // 如果是 PortalStart，就写入 portal 名字
-        strncpy((char *)entry->portal, portal->name, NAMEDATALEN);
-    }
+	pgds_report_common((PgDistStatStatus *) entry);
+	pgds_report_role((PgDistStatStatus *) entry, desc);
+    // 如果是 PortalStart，就写入 portal 名字
+    strncpy((char *)entry->portal, portal->name, NAMEDATALEN);
     
     increment_changecount_after(entry);
-}
-
-// 为了适配钩子函数的不同签名，我们需要两个“包装”函数
-static void
-pgds_portal_start_hook(Portal portal)
-{
-    pgds_report_activity(portal, false);
-}
-
-static void
-pgds_portal_drop_hook(Portal portal)
-{
-    pgds_report_activity(portal, true);
 }
 
 /* ----------
@@ -1143,23 +1073,23 @@ dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
 			else
 				nulls[21] = true;
 
-			if (local_dsentry->application_name[0] != '\0')
-				values[22] = CStringGetTextDatum(local_dsentry->application_name);
+			if (beentry->st_appname)
+				values[22] = CStringGetTextDatum(beentry->st_appname);
 			else
 				nulls[22] = true;
 			
-			if (TransactionIdIsValid(local_dsentry->backend_xid))
-				values[23] = TransactionIdGetDatum(local_dsentry->backend_xid);
+			if (TransactionIdIsValid(local_beentry->backend_xid))
+				values[23] = TransactionIdGetDatum(local_beentry->backend_xid);
 			else
 				nulls[23] = true;
 
-			if (TransactionIdIsValid(local_dsentry->backend_xmin))
-				values[24] = TransactionIdGetDatum(local_dsentry->backend_xmin);
+			if (TransactionIdIsValid(local_beentry->backend_xmin))
+				values[24] = TransactionIdGetDatum(local_beentry->backend_xmin);
 			else
 				nulls[24] = true;
 
-			if (local_dsentry->backend_type[0] != '\0')
-				values[25] = CStringGetTextDatum(local_dsentry->backend_type);
+			if (beentry->st_backendType)
+				values[25] = CStringGetTextDatum(pgstat_get_backend_desc(beentry->st_backendType));
 			else
 				nulls[25] = true;
 
@@ -1168,8 +1098,8 @@ dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
 			else
 				nulls[26] = true;
 
-			if (local_dsentry->gxid[0] != '\0')
-				values[27] = CStringGetTextDatum(local_dsentry->gxid);
+			if (proc->hasGlobalXid && proc->globalXid[0] != '\0')
+				values[27] = CStringGetTextDatum(proc->globalXid);
 			else
 				nulls[27] = true;
 		}
@@ -2013,9 +1943,9 @@ _PG_init(void)
 	prev_pgstat_report_hook = pgstat_report_hook;
 	pgstat_report_hook = pgds_report_query_activity;
 	prev_PortalStart = PortalStart_hook;
-	PortalStart_hook = pgds_portal_start_hook;
+	PortalStart_hook = pgds_report_activity;
 	prev_PortalDrop = PortalDrop_hook;
-	PortalDrop_hook = pgds_portal_drop_hook;
+	PortalDrop_hook = pgds_report_activity;
 	prev_ExecutorStart = ExecutorStart_hook;
 	ExecutorStart_hook = pgds_report_executor_activity;
 	prev_ExecutorEnd = ExecutorEnd_hook;
@@ -2031,8 +1961,8 @@ _PG_fini(void)
 	/* Uninstall hooks. */
 	shmem_startup_hook = prev_shmem_startup_hook;
 	pgstat_report_hook = prev_pgstat_report_hook;
-	PortalStart_hook = pgds_portal_start_hook;
-	PortalDrop_hook = pgds_portal_drop_hook;
+	PortalStart_hook = prev_PortalStart;
+	PortalDrop_hook = prev_PortalDrop;
 	ExecutorStart_hook = prev_ExecutorStart;
 	ExecutorEnd_hook = prev_ExecutorEnd;
 }

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -1732,6 +1732,7 @@ get_dist_pg_locks_raw(PG_FUNCTION_ARGS)
 static void
 dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 {
+	// 串行
     List *nodelist;
     ListCell *lc;
 	Oid local_node_oid = InvalidOid; // 用于存储本地节点的OID
@@ -1829,6 +1830,8 @@ dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
     }
     
     list_free(nodelist); // 释放节点列表
+
+	// 并行？
 }
 
 /*

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -18,9 +18,6 @@
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
-#include "nodes/plannodes.h"  // 包含 RemoteQuery, ExecNodes 等计划节点定义
-#include "nodes/execnodes.h"  // 包含 RemoteSubplanState 等执行节点定义
-#include "pgxc/nodemgr.h"      // 包含 GetAllNodes() 的声明
 #include "pgstat.h"
 #include "pgxc/execRemote.h"
 #include "pgxc/pgxc.h"
@@ -31,7 +28,6 @@
 #include "storage/shmem.h"
 #include "storage/lock.h"
 #include "storage/proc.h"
-#include "storage/lmgr.h"        // 包含 LockHeldByProc() 和 GetLockTagsMethodTable() 的声明
 #include "storage/predicate_internals.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
@@ -44,7 +40,7 @@
 
 PG_MODULE_MAGIC;
 
-#define PG_DIST_STAT_ACTIVITY_COLS 27	// 列数定义，如果你要增删列，记得在这里更新
+#define PG_DIST_STAT_ACTIVITY_COLS 27	// 列数定义
 
 /* ----------
  * Total number of backends including auxiliary
@@ -83,19 +79,14 @@ typedef struct PgDistStatStatus	// 上面的说明记得改
 	 * twice before the modification on a machine with weak memory ordering.
 	 * This surprising result can lead to bugs.
 	 */
-	/* ================================================= */
-    /* ==   持久化状态 (整个进程生命周期内不变)   == */
-    /* ================================================= */
+    // 持久化状态
 	int changecount;
 	
 	bool valid;                     /* don't show this entry if false */
 	char nodename[NAMEDATALEN];     /* nodename, determined after process started */
 	char role[NAMEDATALEN];         /* coord, datanode, producer or consumer */
 
-	/* ================================================= */
-    /* ==    临时状态 (每次查询后都应被清理)      == */
-    /* ================================================= */
-	/* fields that will be shown in pg_stat_cluster_activity */
+    // 临时状态
 	char sessionid[NAMEDATALEN];    /* global session id in a cluster, one for a session */
 	
 	/* portal_name or portal_name_unique */
@@ -116,30 +107,17 @@ typedef struct PgDistStatStatus	// 上面的说明记得改
 	char portal[NAMEDATALEN];
 	char cursors[NAMEDATALEN * 64];
 
-	// --- 【新增字段】 ---
+	// 新增字段
     // 存储GID的哈希值，用于在C代码中进行快速、高效的比较和过滤
     uint64 global_query_id_hash; 
     // 存储GID的完整字符串，用于最终在视图中显示
     char   global_query_id[256]; // 预留足够长的空间
-
-	/* --- 【新增的兼容性字段】 --- */
     char application_name[NAMEDATALEN];
     TransactionId backend_xid;
     TransactionId backend_xmin;
     char backend_type[NAMEDATALEN];
 
 } PgDistStatStatus;
-
-/*
- * 自定义的状态结构体，用于在多次SRF调用之间保持状态
- */
-typedef struct DistLockStatus
-{
-	LockData *lockData;	/* state data from lmgr, a safe copy*/
-	int currIdx;	/* current PROCLOCK index */
-	PredicateLockData *predLockData;    /* state data for pred locks */
-    int            predLockIdx;    /* current index for pred lock */
-}DistLockStatus;
 
 static PgDistStatStatus *DistStatArray = NULL;
 static PgDistStatStatus *MyDistStatEntry = NULL;
@@ -193,23 +171,12 @@ static char *pgds_gid_guc_string = NULL;
 	} while (0)
 
 Datum dist_pg_stat_get_activity(PG_FUNCTION_ARGS);
-// ... 其他辅助函数，如果你暂时不用可以注释掉 ...
-/*
-Datum pg_signal_session(PG_FUNCTION_ARGS);
-Datum pg_terminate_session(PG_FUNCTION_ARGS);
-Datum pg_cancel_session(PG_FUNCTION_ARGS);
-*/
 
 void _PG_init(void);
 void _PG_fini(void);
 
 PG_FUNCTION_INFO_V1(dist_pg_stat_get_activity);
 PG_FUNCTION_INFO_V1(get_dist_pg_locks);
-/*
-PG_FUNCTION_INFO_V1(pg_signal_session);
-PG_FUNCTION_INFO_V1(pg_terminate_session);
-PG_FUNCTION_INFO_V1(pg_cancel_session);
-*/
 
 static ParamListInfo
 EvaluateSessionIDParam(const char *sessionid)
@@ -316,8 +283,8 @@ pgds_shutdown_hook(int code, Datum arg)
 	
 	entry->valid = false;	/* mark invalid to hide this entry */
 	
-	entry->global_query_id_hash = 0; // 【新增】
-    entry->global_query_id[0] = '\0'; // 【新增】
+	entry->global_query_id_hash = 0; // 新增
+    entry->global_query_id[0] = '\0'; // 新增
 
 	increment_changecount_after(entry);
 }
@@ -365,10 +332,10 @@ pgds_entry_initialize(void)
 		 * MaxBackends + AuxBackendType + 1 as the index of the slot for an
 		 * auxiliary process.
 		 */
-		MyDistStatEntry = &DistStatArray[MaxBackends + MyAuxProcType];	// 上面的说明记得改
+		MyDistStatEntry = &DistStatArray[MaxBackends + MyAuxProcType];
 	}
 	
-	// 【新增】在初始化时，清空GID信息
+	// 在初始化时，清空GID信息
     MyDistStatEntry->global_query_id_hash = 0;
     MyDistStatEntry->global_query_id[0] = '\0';
 
@@ -463,26 +430,22 @@ pgds_report_query_activity(BackendState state, const char *cmd_str)
 	LocalPgBackendStatus *local_beentry;
 	PgBackendStatus *beentry;
 	
-	// 只调用前任钩子，确保像 pg_stat_statements 这样的其他模块能正常工作。
+	// 只调用前任钩子
 	if (prev_pgstat_report_hook)
 		prev_pgstat_report_hook(state, cmd_str);
 
-	// 只有当这个进程已经被我们的 ExecutorStart 钩子“激活”过
-    // (即它有一个 GID)，我们才为它更新动态信息。
     if (MyDistStatEntry && MyDistStatEntry->global_query_id_hash != 0)
     {
         entry = MyDistStatEntry;
         
-        // 【获取实时的 beentry 来更新动态信息】
+        // 获取实时的 beentry 来更新动态信息
         local_beentry = pgstat_fetch_stat_local_beentry(MyBackendId);
         if (local_beentry)
         {
-             // 注意：这里可能需要一个新的 QueryDesc，或者从其他地方获取
-             // 为了简化，我们暂时只更新 backend_type
+             // 更新 backend_type
              beentry = &local_beentry->backendStatus;
              increment_changecount_before(entry);
              snprintf((char *)entry->backend_type, NAMEDATALEN, "%s", pgstat_get_backend_desc(beentry->st_backendType));
-             // 在这里更新 role 也是一个好主意
              increment_changecount_after(entry);
         }
     }
@@ -494,7 +457,7 @@ pgds_report_query_activity(BackendState state, const char *cmd_str)
  *  Report fileds of per-query referred, hooked as ExecutorStart_hook
  *  report planstate, cursors and common fields.
  * 
- * 唯一负责写入所有与一次“顶层查询”活动相关的瞬时状态。这是整个模块的“大脑”。
+ * 唯一负责写入所有与一次“顶层查询”活动相关的瞬时状态
  * ----------
  */
 static void
@@ -527,7 +490,7 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
             snprintf(gid_string, sizeof(gid_string), "%s-%d-%lu",
                      PGXCNodeName, MyProcPid, (unsigned long)GetCurrentTimestamp());
 
-            // 【传递】设置GUC变量，以便传播到DN
+            // 设置GUC变量，以便传播到DN
             (void)set_config_option("pg_dist_stat_views.global_query_id", gid_string,
                                     PGC_SUSET, PGC_S_SESSION, GUC_ACTION_SET, true, 0, false);
         }
@@ -573,7 +536,7 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 		}
 		else if (desc->planstate != NULL)
 		{
-			/* 【修正】保留原始的内存管理策略 */
+			/* 保留原始的内存管理策略 */
 			oldcxt = MemoryContextSwitchTo(desc->estate->es_query_cxt);
 			
 			/* 采集 Cursors */
@@ -605,7 +568,7 @@ pgds_report_executor_activity(QueryDesc *desc, int eflags)
 				snprintf((char *)entry->planstate, sizeof(entry->planstate), "disabled");
 			}
 
-			/* 【新增】在使用完毕后，立刻释放内存 */
+			/* 在使用完毕后，立刻释放内存 */
 			pfree(cursors->data);
 			pfree(cursors);
 			if (planstate_str) // 因为 planstate_str 可能不被创建
@@ -648,7 +611,7 @@ pgds_executor_end_hook(QueryDesc *queryDesc)
             }
         }
 
-        /* --- B. 【新增的关键逻辑】在所有节点上，清理自己共享内存里的GID --- */
+        /* --- B. 在所有节点上，清理自己共享内存里的GID --- */
         // MyDistStatEntry 在进程生命周期中，只要初始化过就不会是 NULL
         if (MyDistStatEntry)
         {
@@ -656,7 +619,7 @@ pgds_executor_end_hook(QueryDesc *queryDesc)
 			entry = (PgDistStatStatus *)v_entry;
 
             increment_changecount_before(v_entry);
-            // 【重要】v_entry->nodename 和 v_entry->role 被刻意保留，不作清理！
+            // v_entry->nodename 和 v_entry->role 被刻意保留，不作清理！
             MemSet(&entry->sessionid, 0, 
                    sizeof(PgDistStatStatus) - offsetof(PgDistStatStatus, sessionid));
             
@@ -1235,7 +1198,7 @@ VXIDGetDatum(BackendId bid, LocalTransactionId lxid)
 }
 
 /*
- * dist_pg_get_local_locks - 【最终版】安全的本地数据采集器
+ * dist_pg_get_local_locks - 安全的本地数据采集器
  *
  * 它的职责是安全地采集本地锁信息，并将其放入一个传入的 Tuplestore。
  * 它不是SRF，只是一个普通的辅助函数。
@@ -1422,7 +1385,7 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
         // 第1列: node_name
         values[0] = CStringGetTextDatum(PGXCNodeName);
         
-        // --- 第2-16列: 填充谓词锁信息 (严格校对) ---
+        // --- 第2-16列: 填充谓词锁信息 ---
         lockType = GET_PREDICATELOCKTARGETTAG_TYPE(*predTag);
         values[1] = CStringGetTextDatum(PredicateLockTagTypeNames[lockType]); // locktype
 
@@ -1466,73 +1429,50 @@ dist_pg_get_local_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 }
 
 /*
- * dist_pg_get_remote_locks - 【最终权威版】
- * 采用串行方式，逐个节点地执行远程查询，以避免连接池风暴。
+ * dist_pg_get_remote_locks - 远程执行 get_dist_pg_locks(true)
  */
 static void
 dist_pg_get_remote_locks(Tuplestorestate *tupstore, TupleDesc tupdesc)
 {
-    List *nodelist;
-    ListCell *lc;
-	Oid local_node_oid; // 用于存储本地节点的OID
+	char    query[256];
+	EState *estate;
+	RemoteQuery *plan;
+	RemoteQueryState *pstate;
+	TupleTableSlot *result = NULL;
+	MemoryContext oldcontext;
 
-	local_node_oid = get_pgxc_node_oid(PGXCNodeName);
-    // 1. 获取所有需要查询的远程节点列表
-    //    注意：我们不需要包含本地节点，因为它会在主函数中被单独处理。
-    nodelist = list_concat(GetAllCoordNodes(), GetAllDataNodes());
+	snprintf(query, sizeof(query), "SELECT * FROM @extschema@.get_dist_pg_locks(true)");
 
-    // 2. 【核心】使用 foreach 循环，对每个节点进行串行查询
-    foreach(lc, nodelist)
-    {
-        int node_oid = lfirst_int(lc);
-        char query[256];
-        RemoteQuery *plan;
-        EState *estate;
-        RemoteQueryState *pstate;
-        TupleTableSlot *result;
-        MemoryContext oldcontext;
+	plan = makeNode(RemoteQuery);
+	plan->combine_type = COMBINE_TYPE_NONE;
+	
+	plan->exec_nodes = makeNode(ExecNodes);
+	plan->exec_nodes->nodeList = list_concat(GetAllCoordNodes(), GetAllDataNodes());
+	plan->exec_nodes->missing_ok = true;
+	plan->exec_type = EXEC_ON_ALL_NODES;
 
-        // 跳过本地节点，因为主函数会处理它
-        if (node_oid == local_node_oid)
-            continue;
+	plan->sql_statement = query;
+	plan->force_autocommit = false;
 
-        // 准备针对单个节点的远程查询
-        snprintf(query, sizeof(query), "SELECT * FROM @extschema@.get_dist_pg_locks(true)");
+	estate = CreateExecutorState();
+	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+	estate->es_snapshot = GetActiveSnapshot();
+	estate->es_param_list_info = NULL;
+	pstate = ExecInitRemoteQuery(plan, estate, 0);
+	ExecAssignResultType((PlanState *) pstate, tupdesc);
+	MemoryContextSwitchTo(oldcontext);
 
-        plan = makeNode(RemoteQuery);
-        plan->combine_type = COMBINE_TYPE_NONE;
-        plan->exec_nodes = makeNode(ExecNodes);
-        plan->exec_nodes->nodeList = list_make1_int(node_oid); // 只发给当前循环的这一个节点
-        plan->exec_nodes->missing_ok = true;
-        plan->exec_type = EXEC_ON_ALL_NODES; // 明确指定节点列表
-        plan->sql_statement = query;
-        plan->force_autocommit = false;
+	while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
+	{
+		tuplestore_puttupleslot(tupstore, result);
+	}
 
-        // 为本次循环创建独立的执行状态
-        estate = CreateExecutorState();
-        oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
-        estate->es_snapshot = GetActiveSnapshot();
-        estate->es_param_list_info = NULL;
-        pstate = ExecInitRemoteQuery(plan, estate, 0);
-        ExecAssignResultType((PlanState *) pstate, tupdesc);
-        MemoryContextSwitchTo(oldcontext);
-
-        // 接收并处理这个节点的所有返回行
-        while ((result = ExecRemoteQuery((PlanState *) pstate)) != NULL && !TupIsNull(result))
-        {
-            tuplestore_puttupleslot(tupstore, result);
-        }
-        
-        // 清理本次循环的资源
-        ExecEndRemoteQuery(pstate);
-        FreeExecutorState(estate);
-    }
-    
-    list_free_deep(nodelist); // 释放节点列表
+	ExecEndRemoteQuery(pstate);
+	FreeExecutorState(estate);
 }
 
 /*
- * get_dist_pg_locks - 【总指挥 & 最终SQL入口】
+ * get_dist_pg_locks - 最终SQL入口
  * 采用物化模式，协调远程和本地的数据采集。
  */
 Datum
@@ -1560,7 +1500,7 @@ get_dist_pg_locks(PG_FUNCTION_ARGS)
     // 创建 Tuplestore
     tupstore = tuplestore_begin_heap(true, false, work_mem);
 
-    // 【核心】告诉PostgreSQL执行器，我们将使用物化模式返回结果
+    // 告诉PostgreSQL执行器，我们将使用物化模式返回结果
     rsinfo->returnMode = SFRM_Materialize;
     rsinfo->setResult = tupstore; // 将 tupstore 挂在返回结果上
     rsinfo->setDesc = tupdesc;      // 将 tupdesc 挂在返回结果上
@@ -1569,7 +1509,7 @@ get_dist_pg_locks(PG_FUNCTION_ARGS)
     if (!localonly && IS_PGXC_COORDINATOR)
         dist_pg_get_remote_locks(tupstore, tupdesc);
 
-    // 2. 然后采集本地节点的数据 (直接、简洁地调用我们的普通辅助函数)
+    // 2. 然后采集本地节点的数据
     dist_pg_get_local_locks(tupstore, tupdesc);
     
     tuplestore_donestoring(tupstore);
@@ -1577,129 +1517,6 @@ get_dist_pg_locks(PG_FUNCTION_ARGS)
 
     return (Datum) 0;
 }
-
-static bool
-pgds_signal_session_remote(const char *sessionid, int signal)
-{
-#define QUERY_LEN 1024
-	char    query[QUERY_LEN];
-	EState              *estate;
-	MemoryContext		oldcontext;
-	RemoteQuery 		*plan;
-	RemoteQueryState    *pstate;
-	Var 				*dummy;
-	TupleTableSlot		*result = NULL;
-	
-	snprintf(query, QUERY_LEN, "select pg_signal_session($1, %d, true)", signal);
-	
-	plan = makeNode(RemoteQuery);
-	plan->combine_type = COMBINE_TYPE_NONE;
-	/*
-	 * set exec_nodes to NULL makes ExecRemoteQuery send query to all nodes
-	 * (local CN nodes won't recieved query again).
-	 */
-	plan->exec_nodes = NULL;
-	plan->exec_type = EXEC_ON_ALL_NODES;
-	plan->sql_statement = (char *) query;
-	plan->force_autocommit = false;
-	
-	/*
-	 * We only need the target entry to determine result data type.
-	 * So create dummy even if real expression is a function.
-	 */
-	dummy = makeVar(1, 1, TEXTOID, 0, InvalidOid, 0);
-	plan->scan.plan.targetlist = lappend(plan->scan.plan.targetlist,
-	                                     makeTargetEntry((Expr *) dummy, 1, NULL, false));
-	
-	/* prepare to execute */
-	estate = CreateExecutorState();
-	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
-	estate->es_snapshot = GetActiveSnapshot();
-	estate->es_param_list_info = EvaluateSessionIDParam(sessionid);
-	pstate = ExecInitRemoteQuery(plan, estate, 0);
-	MemoryContextSwitchTo(oldcontext);
-	
-	result = ExecRemoteQuery((PlanState *) pstate);
-	ExecEndRemoteQuery(pstate);
-	if (TupIsNull(result))
-	{
-		elog(ERROR, "result of pg_signal_session executed remotely is NULL");
-		return false;
-	}
-	
-	FreeExecutorState(estate);
-	return true;
-}
-
-static bool
-pgds_signal_session(const char *sessionid, int signal)
-{
-	int         num_backends = pgstat_fetch_stat_numbackends();
-	int         curr_backend;
-	const char *funcname;
-	LocalPgBackendStatus *local_beentry;
-	PgDistStatStatus      *local_dsentry;
-	PgBackendStatus      *beentry;
-	
-	if (signal == SIGTERM)
-		funcname = "pg_terminate_backend";
-	else if (signal == SIGINT)
-		funcname = "pg_cancel_backend";
-	else
-		elog(ERROR, "pgds_signal_session only support SIGTERM and SIGINT, not %d", signal);
-	
-	/* 1-based index */
-	for (curr_backend = 1; curr_backend <= num_backends; curr_backend++)
-	{
-		/* Get the next one in the list */
-		local_beentry = pgstat_fetch_stat_local_beentry(curr_backend);
-		local_dsentry = pgstat_fetch_stat_local_dsentry(local_beentry->backend_id);
-		
-		if (local_dsentry->valid && strcmp(local_dsentry->sessionid, sessionid) == 0)
-		{
-			beentry = &local_beentry->backendStatus;
-			OidFunctionCall1(fmgr_internal_function(funcname),
-			                 Int32GetDatum(beentry->st_procpid));
-		}
-	}
-	
-	return true;
-}
-
-/*
-Datum
-pg_signal_session(PG_FUNCTION_ARGS)
-{
-	const char *sessionid = text_to_cstring(PG_GETARG_TEXT_P(0));
-	int         signal = PG_GETARG_INT32(1);
-	bool        localonly = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
-	bool        result;
-	
-	result = pgds_signal_session(sessionid, signal);
-	if (result && !localonly)
-		result = pgds_signal_session_remote(sessionid, signal);
-	
-	return BoolGetDatum(result);
-}
-
-Datum
-pg_terminate_session(PG_FUNCTION_ARGS)
-{
-	return DirectFunctionCall3(pg_signal_session,
-	                           PG_GETARG_DATUM(0),
-	                           Int32GetDatum(SIGTERM),
-	                           BoolGetDatum(false));
-}
-
-Datum
-pg_cancel_session(PG_FUNCTION_ARGS)
-{
-	return DirectFunctionCall3(pg_signal_session,
-	                           PG_GETARG_DATUM(0),
-	                           Int32GetDatum(SIGINT),
-	                           BoolGetDatum(false));
-}
-*/
 
 /*
  * Hooked as shmem_startup_hook
@@ -1745,7 +1562,7 @@ _PG_init(void)
 	                         NULL,
 	                         NULL);
 
-	// 【新增】定义自己用于调试的GUC变量
+	// 定义自己用于调试的GUC变量
 	DefineCustomStringVariable(
 							"pg_dist_stat_views.global_query_id",
 							"Internal GUC to propagate Global Query ID.",

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -885,7 +885,7 @@ dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
 		MemSet(values, 0, sizeof(values));
 		MemSet(nulls, 0, sizeof(nulls));
 		
-		/* Get the next one in the list */	// ????
+		/* Get the next one in the list */
 		local_beentry = pgstat_fetch_stat_local_beentry(curr_backend);
 		local_dsentry = pgstat_fetch_stat_local_dsentry(local_beentry->backend_id);
 		if (!local_beentry || !local_dsentry)

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.c
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.c
@@ -1,0 +1,1418 @@
+/*
+ * Copyright (c) 2023 THL A29 Limited, a Tencent company.
+ *
+ * This source code file is licensed under the BSD 3-Clause License,
+ * you may obtain a copy of the License at http://opensource.org/license/bsd-3-clause/
+ */
+#include "postgres.h"
+
+#include "catalog/pg_authid.h"
+#include "catalog/pg_type.h"
+#include "commands/dbcommands.h"
+#include "commands/explain.h"
+#include "common/ip.h"
+#include "fmgr.h"
+#include "funcapi.h"
+#include "miscadmin.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
+#include "pgstat.h"
+#include "pgxc/execRemote.h"
+#include "pgxc/pgxc.h"
+#include "pgxc/squeue.h"
+#include "port/atomics.h"
+#include "storage/ipc.h"
+#include "storage/procarray.h"
+#include "storage/shmem.h"
+#include "utils/builtins.h"
+#include "utils/guc.h"
+#include "utils/portal.h"
+#include "utils/snapmgr.h"
+#include "utils/timestamp.h"
+#include "utils/hsearch.h"
+
+PG_MODULE_MAGIC;
+
+#define PG_DIST_STAT_ACTIVITY_COLS 27	// 列数定义，如果你要增删列，记得在这里更新
+
+/* ----------
+ * Total number of backends including auxiliary
+ *
+ * We reserve a slot for each possible BackendId, plus one for each
+ * possible auxiliary process type.  (This scheme assumes there is not
+ * more than one of any auxiliary process type at a time.) MaxBackends
+ * includes autovacuum workers and background workers as well.
+ * ----------
+ */
+#define NumBackendStatSlots (MaxBackends + NUM_AUXPROCTYPES)
+
+#define UINT32_ACCESS_ONCE(var)		 ((uint32)(*((volatile uint32 *)&(var))))
+
+/*
+ * PgDistStatStatus is something like PgBackendStatus (see pgstat.c) but it
+ * contains information that a query executed in a cluster database system.
+ * Each PgDistStatStatus stands for a backend process forked by postmaster,
+ * the same way PgBackendStatus does, like extended fields of PgBackendStatus.
+ * We show it in view pg_stat_cluster_activity, still, one tuple for an entry.
+ */
+typedef struct PgDistStatStatus	// 上面的说明记得改
+{
+	/*
+	 * To avoid locking overhead, we use the following protocol: a backend
+	 * increments changecount before modifying its entry, and again after
+	 * finishing a modification.  A would-be reader should note the value of
+	 * changecount, copy the entry into private memory, then check
+	 * changecount again.  If the value hasn't changed, and if it's even,
+	 * the copy is valid; otherwise start over.  This makes updates cheap
+	 * while reads are potentially expensive, but that's the tradeoff we want.
+	 *
+	 * The above protocol needs the memory barriers to ensure that the
+	 * apparent order of execution is as it desires. Otherwise, for example,
+	 * the CPU might rearrange the code so that changecount is incremented
+	 * twice before the modification on a machine with weak memory ordering.
+	 * This surprising result can lead to bugs.
+	 */
+	/* ================================================= */
+    /* ==   持久化状态 (整个进程生命周期内不变)   == */
+    /* ================================================= */
+	int changecount;
+	
+	bool valid;                     /* don't show this entry if false */
+	char nodename[NAMEDATALEN];     /* nodename, determined after process started */
+	char role[NAMEDATALEN];         /* coord, datanode, producer or consumer */
+
+	/* ================================================= */
+    /* ==    临时状态 (每次查询后都应被清理)      == */
+    /* ================================================= */
+	/* fields that will be shown in pg_stat_cluster_activity */
+	char sessionid[NAMEDATALEN];    /* global session id in a cluster, one for a session */
+	
+	/* portal_name or portal_name_unique */
+	char sqname[NAMEDATALEN];
+	/* true if sharequeue end, but currently change when query ends in this backend */
+	bool sqdone;
+	/* part of plantree this backend is processing, OR last processed if backend is idle */
+	char planstate[4096];
+	
+	/*
+	 * portal name: the name of current portal, given by upper node of processing query 
+	 * cursor name: contained in planstate this backend is querying, which would be
+	 *              portal name of next layer of nodes bellow this backend
+	 *              
+	 * Note: with these two fields plus nodename, we can build a backend tree of executing query
+	 *       in whole distributed system.
+	 */
+	char portal[NAMEDATALEN];
+	char cursors[NAMEDATALEN * 64];
+
+	// --- 【新增字段】 ---
+    // 存储GID的哈希值，用于在C代码中进行快速、高效的比较和过滤
+    uint64 global_query_id_hash; 
+    // 存储GID的完整字符串，用于最终在视图中显示
+    char   global_query_id[256]; // 预留足够长的空间
+
+	/* --- 【新增的兼容性字段】 --- */
+    char application_name[NAMEDATALEN];
+    TransactionId backend_xid;
+    TransactionId backend_xmin;
+    char backend_type[NAMEDATALEN];
+
+} PgDistStatStatus;
+
+static PgDistStatStatus *DistStatArray = NULL;
+static PgDistStatStatus *MyDistStatEntry = NULL;
+
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
+static pgstat_report_hook_type prev_pgstat_report_hook = NULL;
+static PortalStart_hook_type prev_PortalStart = NULL;
+static PortalDrop_hook_type prev_PortalDrop = NULL;
+static ExecutorStart_hook_type prev_ExecutorStart = NULL;
+static ExecutorEnd_hook_type prev_ExecutorEnd = NULL;
+
+static bool pgds_enable_planstate; /* whether to show planstate in result sets */
+static int pgds_nesting_level = 0;
+static char *pgds_gid_guc_string = NULL;
+
+/*
+ * Macros to load and store st_changecount with the memory barriers.
+ *
+ * increment_changecount_before() and
+ * increment_changecount_after() need to be called before and after
+ * entries are modified, respectively. This makes sure that st_changecount
+ * is incremented around the modification.
+ *
+ * Also save_changecount_before() and save_changecount_after()
+ * need to be called before and after entries are copied into private memory
+ * respectively.
+ */
+#define increment_changecount_before(status)	\
+	do {	\
+		status->changecount++;	\
+		pg_write_barrier(); \
+	} while (0)
+
+#define increment_changecount_after(status) \
+	do {	\
+		pg_write_barrier(); \
+		status->changecount++;	\
+		Assert((status->changecount & 1) == 0); \
+	} while (0)
+
+#define save_changecount_before(status, save_changecount)	\
+	do {	\
+		save_changecount = status->changecount; \
+		pg_read_barrier();	\
+	} while (0)
+
+#define save_changecount_after(status, save_changecount)	\
+	do {	\
+		pg_read_barrier();	\
+		save_changecount = status->changecount; \
+	} while (0)
+
+Datum dist_pg_stat_get_activity(PG_FUNCTION_ARGS);
+// ... 其他辅助函数，如果你暂时不用可以注释掉 ...
+/*
+Datum pg_signal_session(PG_FUNCTION_ARGS);
+Datum pg_terminate_session(PG_FUNCTION_ARGS);
+Datum pg_cancel_session(PG_FUNCTION_ARGS);
+*/
+
+void _PG_init(void);
+void _PG_fini(void);
+
+PG_FUNCTION_INFO_V1(dist_pg_stat_get_activity);
+/*
+PG_FUNCTION_INFO_V1(pg_signal_session);
+PG_FUNCTION_INFO_V1(pg_terminate_session);
+PG_FUNCTION_INFO_V1(pg_cancel_session);
+*/
+
+static ParamListInfo
+EvaluateSessionIDParam(const char *sessionid)
+{
+	int num_params = 1;
+	ParamListInfo paramLI = (ParamListInfo)
+		palloc0(offsetof(ParamListInfoData, params) +
+		        num_params * sizeof(ParamExternData));
+	
+	ParamExternData *prm;
+	
+	/* we have static list of params, so no hooks needed */
+	paramLI->paramFetch = NULL;
+	paramLI->paramFetchArg = NULL;
+	paramLI->parserSetup = NULL;
+	paramLI->parserSetupArg = NULL;
+	paramLI->numParams = num_params;
+	paramLI->paramMask = NULL;
+	
+	prm = &paramLI->params[0];
+	prm->ptype = TEXTOID;
+	prm->pflags = PARAM_FLAG_CONST;
+	if (sessionid != NULL)
+	{
+		prm->value = CStringGetTextDatum(sessionid);
+		prm->isnull = false;
+	}
+	else
+	{
+		prm->isnull = true;
+	}
+	
+	return paramLI;
+}
+
+/*
+ * walk through planstate tree and gets cursors it contains in
+ * RemoteSubplan node, formed as a single string delimited each
+ * cursor by a space (one cursor stands for a RemoteSubplan node).
+ */
+static bool
+cursorCollectWalker(PlanState *planstate, StringInfo str)
+{
+	if (IsA(planstate, RemoteSubplanState))
+	{
+		RemoteSubplan *plan = (RemoteSubplan *) planstate->plan;
+		if (plan->cursor != NULL)
+		{
+			appendStringInfoString(str, plan->cursor);
+			if (plan->unique)
+				appendStringInfo(str, "_"INT64_FORMAT, plan->unique);
+			/* add a space as delimiter */
+			appendStringInfoString(str, " ");
+		}
+	}
+	
+	return planstate_tree_walker(planstate, cursorCollectWalker, str);
+}
+
+/*
+ * Initialize the shared status array and several string buffers
+ * during postmaster startup.
+ */
+static void
+CreateSharedDistStatus(void)
+{
+	Size		size;
+	bool        found;
+	
+	/* Create or attach to the shared array */
+	size = mul_size(sizeof(PgDistStatStatus), NumBackendStatSlots);
+	DistStatArray = (PgDistStatStatus *)
+		ShmemInitStruct("Distributed Status Array", size, &found);
+	
+	if (!found)
+	{
+		/*
+		 * We're the first - initialize.
+		 */
+		MemSet(DistStatArray, 0, size);
+	}
+}
+
+/*
+ * Shut down a single backend's statistics reporting at process exit.
+ *
+ * Flush any remaining statistics counts out to the collector.
+ * Without this, operations triggered during backend exit (such as
+ * temp table deletions) won't be counted.
+ *
+ * Lastly, clear out our entry in the PgBackendStatus array.
+ */
+static void
+pgds_shutdown_hook(int code, Datum arg)
+{
+	volatile PgDistStatStatus *entry = MyDistStatEntry;
+	
+	/*
+	 * Clear my status entry, following the protocol of bumping st_changecount
+	 * before and after.  We use a volatile pointer here to ensure the
+	 * compiler doesn't try to get cute.
+	 */
+	increment_changecount_before(entry);
+	
+	entry->valid = false;	/* mark invalid to hide this entry */
+	
+	entry->global_query_id_hash = 0; // 【新增】
+    entry->global_query_id[0] = '\0'; // 【新增】
+
+	increment_changecount_after(entry);
+}
+
+/* ----------
+ * pgds_entry_initialize() -
+ *
+ *	Initialize my cluster status entry, and set up our on-proc-exit hook.
+ *	as an extension but we don't have hook during process startup, so called
+ *	each time the backend try to report something.
+ * ----------
+ */
+static void
+pgds_entry_initialize(void)
+{
+	/* already initialized */
+	if (MyDistStatEntry != NULL)
+		return;
+
+	if (DistStatArray == NULL)
+	{
+		ereport(ERROR,
+		        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			        errmsg("shared memory for pg_dist_stat_view is not prepared"),
+			        errhint("maybe you need to set shared_preload_libraries in postgresql.conf file")));
+		return;
+	}
+	
+	/* Initialize MyCSEntry */
+	if (MyBackendId != InvalidBackendId)
+	{
+		Assert(MyBackendId >= 1 && MyBackendId <= MaxBackends);
+		MyDistStatEntry = &DistStatArray[MyBackendId - 1];
+	}
+	else
+	{
+		/* Must be an auxiliary process */
+		Assert(MyAuxProcType != NotAnAuxProcess);
+		
+		/*
+		 * Assign the MyDistStatEntry for an auxiliary process. Since it doesn't
+		 * have a BackendId, the slot is statically allocated based on the
+		 * auxiliary process type (MyAuxProcType).  Backends use slots indexed
+		 * in the range from 1 to MaxBackends (inclusive), so we use
+		 * MaxBackends + AuxBackendType + 1 as the index of the slot for an
+		 * auxiliary process.
+		 */
+		MyDistStatEntry = &DistStatArray[MaxBackends + MyAuxProcType];	// 上面的说明记得改
+	}
+	
+	// 【新增】在初始化时，清空GID信息
+    MyDistStatEntry->global_query_id_hash = 0;
+    MyDistStatEntry->global_query_id[0] = '\0';
+
+	/* also set nodename here, it won't change anyway */
+	memcpy(MyDistStatEntry->nodename, PGXCNodeName, strlen(PGXCNodeName) + 1);
+	
+	/* Set up a process-exit hook to clean up */
+	on_shmem_exit(pgds_shutdown_hook, 0);
+}
+
+/* ----------
+ * pgds_report_common
+ * 
+ *  Report common fileds of cluster backend status activity,
+ *  called by pgds_report_query_activity and pgds_report_activity.
+ * ----------
+ */
+static void
+pgds_report_common(PgDistStatStatus *entry)
+{
+	strncpy((char *) entry->sessionid, PGXCSessionId, NAMEDATALEN);
+	
+	entry->sqdone = false;
+	entry->valid = true;
+}
+
+/* ----------
+ * pgds_report_role
+ * 
+ *  Report role, sqname, also if this backend become consumer, remove
+ *  previous planstate and cursor.
+ * ----------
+ */
+static void
+pgds_report_role(PgDistStatStatus *entry, QueryDesc *desc)
+{
+	/* fields need queryDesc */
+	if (IS_PGXC_DATANODE)
+	{
+		if (desc != NULL && desc->squeue)
+		{
+			strncpy((char *) entry->sqname, SqueueName(desc->squeue), NAMEDATALEN);
+			if (IsSqueueProducer())
+			{
+				strncpy((char *) entry->role, "producer", NAMEDATALEN);
+			}
+			else if (IsSqueueConsumer())
+			{
+				strncpy((char *) entry->role, "consumer", NAMEDATALEN);
+				/* consumer does not know of planstate */
+				entry->planstate[0] = '\0';
+				entry->cursors[0] = '\0';
+			}
+			else
+			{
+				/* do not support */
+				entry->role[0] = '\0';
+			}
+		}
+		else if (IsParallelWorker())
+		{
+			strncpy((char *) entry->role, "parallel worker", NAMEDATALEN);
+		}
+		else
+		{
+			strncpy((char *) entry->role, "datanode", NAMEDATALEN);
+		}
+	}
+	else if (IS_PGXC_COORDINATOR)
+	{
+		strncpy((char *) entry->role, "coordinator", NAMEDATALEN);
+	}
+	else
+	{
+		/* do not support */
+		entry->role[0] = '\0';
+	}
+}
+
+/* ----------
+ * pgds_report_query_activity
+ *
+ *  Do nothing but set common field, just enable this cluster entry
+ *  to make it visible in the same time as pg_stat_activity. Hooked
+ *  in pgstat_report_activity, args are redundant.
+ * 	
+ */
+static void
+pgds_report_query_activity(BackendState state, const char *cmd_str)
+{
+	volatile PgDistStatStatus *entry;
+	LocalPgBackendStatus *local_beentry;
+	PgBackendStatus *beentry;
+	
+	// 只调用前任钩子，确保像 pg_stat_statements 这样的其他模块能正常工作。
+	if (prev_pgstat_report_hook)
+		prev_pgstat_report_hook(state, cmd_str);
+
+	// 只有当这个进程已经被我们的 ExecutorStart 钩子“激活”过
+    // (即它有一个 GID)，我们才为它更新动态信息。
+    if (MyDistStatEntry && MyDistStatEntry->global_query_id_hash != 0)
+    {
+        entry = MyDistStatEntry;
+        
+        // 【获取实时的 beentry 来更新动态信息】
+        local_beentry = pgstat_fetch_stat_local_beentry(MyBackendId);
+        if (local_beentry)
+        {
+             // 注意：这里可能需要一个新的 QueryDesc，或者从其他地方获取
+             // 为了简化，我们暂时只更新 backend_type
+             beentry = &local_beentry->backendStatus;
+             increment_changecount_before(entry);
+             snprintf((char *)entry->backend_type, NAMEDATALEN, "%s", pgstat_get_backend_desc(beentry->st_backendType));
+             // 在这里更新 role 也是一个好主意
+             increment_changecount_after(entry);
+        }
+    }
+}
+
+/* ----------
+ * pgds_report_executor_activity
+ * 
+ *  Report fileds of per-query referred, hooked as ExecutorStart_hook
+ *  report planstate, cursors and common fields.
+ * 
+ * 唯一负责写入所有与一次“顶层查询”活动相关的瞬时状态。这是整个模块的“大脑”。
+ * ----------
+ */
+static void
+pgds_report_executor_activity(QueryDesc *desc, int eflags)
+{
+	volatile PgDistStatStatus *entry;	// volatile 告诉编译器，entry 指向的那块内存随时可能被外部改变，请不要做任何优化
+	StringInfo planstate_str = NULL;
+	StringInfo cursors = NULL;
+	MemoryContext oldcxt;
+	char gid_string[256];
+	char *gid_to_write;
+	LocalPgBackendStatus *local_beentry;
+	PgBackendStatus *beentry;
+	
+	if (prev_ExecutorStart)
+		prev_ExecutorStart(desc, eflags);
+	else
+		standard_ExecutorStart(desc, eflags);
+	
+	pgds_nesting_level++;	// 嵌套层级就加一
+
+	if (!desc)
+		return;
+	// 2. 在CN端，为顶层查询生成并设置 GID
+    if (pgds_nesting_level == 1)	// 判断一个查询是否为顶层查询，即子查询不再生成新gid
+    {
+        if (IS_PGXC_COORDINATOR && (pgds_gid_guc_string == NULL || pgds_gid_guc_string[0] == '\0'))
+        {
+            // 生成 GID
+            snprintf(gid_string, sizeof(gid_string), "%s-%d-%lu",
+                     PGXCNodeName, MyProcPid, (unsigned long)GetCurrentTimestamp());
+
+            // 【传递】设置GUC变量，以便传播到DN
+            (void)set_config_option("pg_dist_stat_views.global_query_id", gid_string,
+                                    PGC_SUSET, PGC_S_SESSION, GUC_ACTION_SET, true, 0, false);
+        }
+		/* 统一写入所有瞬时状态 */
+		pgds_entry_initialize();
+		entry = MyDistStatEntry;
+		gid_to_write = (char *)pgds_gid_guc_string;
+		// 无论CN还是DN，都在这里，把所有信息一次性写入共享内存
+		increment_changecount_before(entry);
+		// 写入通用信息
+		pgds_report_common((PgDistStatStatus *) entry);
+
+		// --- 在数据节点 (DN) 上，或者作为“中间人”的CN上：读取GUC并存储 --
+		// 检查绑定的C变量是否有值 (即GUC是否被传播过来)
+		if (gid_to_write && gid_to_write[0] != '\0')
+		{	
+			snprintf((char *)entry->global_query_id, 
+					sizeof(entry->global_query_id), 
+					"%s", 
+					gid_to_write);	// entry->global_query_id是volatile char *,就是
+			entry->global_query_id_hash = string_hash(gid_to_write, strlen(gid_to_write));
+
+		}
+		// 写入角色
+		pgds_report_role((PgDistStatStatus *)entry, desc);
+
+		// 新增的采集逻辑，连接名称和后台进程相关信息
+		local_beentry = pgstat_fetch_stat_local_beentry(MyBackendId);
+		if (local_beentry)
+        {
+            beentry = &local_beentry->backendStatus;
+            if (beentry->st_appname)
+                snprintf((char *)entry->application_name, NAMEDATALEN, "%s", beentry->st_appname);
+            snprintf((char *)entry->backend_type, NAMEDATALEN, "%s", pgstat_get_backend_desc(beentry->st_backendType));
+            entry->backend_xid = local_beentry->backend_xid;
+            entry->backend_xmin = local_beentry->backend_xmin;
+        }
+
+		 /* -- 采集并写入 planstate 和 cursors -- */
+        if (desc->already_executed)
+		{
+			entry->sqdone = true;
+		}
+		else if (desc->planstate != NULL)
+		{
+			/* 【修正】保留原始的内存管理策略 */
+			oldcxt = MemoryContextSwitchTo(desc->estate->es_query_cxt);
+			
+			/* 采集 Cursors */
+			cursors = makeStringInfo();
+			cursorCollectWalker(desc->planstate, cursors);
+			if (cursors->len > 0)
+				snprintf((char *)entry->cursors, sizeof(entry->cursors), "%s", cursors->data);
+
+			/* 采集 Planstate */
+			if (pgds_enable_planstate)
+			{
+				ExplainState es;
+				planstate_str = makeStringInfo();
+				
+				memset(&es, 0, sizeof(es));
+				es.str = planstate_str;
+				es.costs = false;
+				es.skip_remote_query = true;
+				
+				ExplainBeginOutput(&es);
+				ExplainPrintPlan(&es, desc);	// planstate_str被填充
+				ExplainEndOutput(&es);
+				
+				if (planstate_str->len > 0)
+					snprintf((char *)entry->planstate, sizeof(entry->planstate), "%s", planstate_str->data);
+			}
+			else
+			{
+				snprintf((char *)entry->planstate, sizeof(entry->planstate), "disabled");
+			}
+
+			/* 【新增】在使用完毕后，立刻释放内存 */
+			pfree(cursors->data);
+			pfree(cursors);
+			if (planstate_str) // 因为 planstate_str 可能不被创建
+			{
+				pfree(planstate_str->data);
+				pfree(planstate_str);
+			}
+
+			/* 切换回原来的内存上下文 */
+			MemoryContextSwitchTo(oldcxt);
+		}
+        
+		increment_changecount_after(entry);
+    }
+}
+
+/* ----------
+ * pgds_executor_end_hook
+ * 用于在查询结束时对进程瞬时信息的清空（除了进程的基本标识信息）
+ *  
+ *  
+ * ----------
+ */
+static void
+pgds_executor_end_hook(QueryDesc *queryDesc)
+{
+	volatile PgDistStatStatus *v_entry;
+	PgDistStatStatus *entry;
+	pgds_nesting_level--;	// 嵌套层级减一
+
+    if (pgds_nesting_level == 0)
+    {
+        /* --- A. 在CN节点上，清理GUC传播信道 --- */
+        if (IS_PGXC_COORDINATOR)
+        {
+            if (pgds_gid_guc_string && pgds_gid_guc_string[0] != '\0')
+            {
+                (void)set_config_option("pg_dist_stat_views.global_query_id", "",
+                                        PGC_SUSET, PGC_S_SESSION, GUC_ACTION_SET, true, 0, false);
+            }
+        }
+
+        /* --- B. 【新增的关键逻辑】在所有节点上，清理自己共享内存里的GID --- */
+        // MyDistStatEntry 在进程生命周期中，只要初始化过就不会是 NULL
+        if (MyDistStatEntry)
+        {
+            v_entry = MyDistStatEntry;
+			entry = (PgDistStatStatus *)v_entry;
+
+            increment_changecount_before(v_entry);
+            // 【重要】v_entry->nodename 和 v_entry->role 被刻意保留，不作清理！
+            MemSet(&entry->sessionid, 0, 
+                   sizeof(PgDistStatStatus) - offsetof(PgDistStatStatus, sessionid));
+            
+            increment_changecount_after(v_entry);
+
+        }
+    }
+		// 调用原始的钩子链
+    if (prev_ExecutorEnd)
+        prev_ExecutorEnd(queryDesc);
+    else
+        standard_ExecutorEnd(queryDesc);
+
+}
+
+/* ----------
+ * pgds_report_activity
+ * 
+ *  Report fileds of per-portal referred, hooked as PortalStart_hook
+ *  report portal name and common fields.
+ * 
+ * 职责：只负责更新与 `Portal` 严格绑定的信息，比如 `portal` 名字。在 Portal 销毁时，清理掉这个名字。
+ * ----------
+ */
+static void
+pgds_report_activity(Portal portal, bool is_drop)	// 新增一个参数区分是Portal Start 还是 Drop
+{
+	volatile PgDistStatStatus *entry;
+	
+	if (is_drop)
+	{
+		if (prev_PortalDrop)
+			prev_PortalDrop(portal);
+	}
+	else
+	{
+		if (prev_PortalStart)
+			prev_PortalStart(portal);
+	}
+
+	pgds_entry_initialize();
+	entry = MyDistStatEntry;
+	
+	/* if query already done, just report sqdone and return */
+	// if (desc != NULL && desc->already_executed)
+	// {
+	// 	increment_changecount_before(entry);
+	// 	entry->sqdone = true;
+	// 	increment_changecount_after(entry);
+	// 	return;
+	// }
+	
+	increment_changecount_before(entry);
+
+    if (is_drop)
+    {
+        // 如果是 PortalDrop，就清空 portal 名字
+        entry->portal[0] = '\0';
+    }
+    else
+    {
+        // 如果是 PortalStart，就写入 portal 名字
+        strncpy((char *)entry->portal, portal->name, NAMEDATALEN);
+    }
+    
+    increment_changecount_after(entry);
+}
+
+// 为了适配钩子函数的不同签名，我们需要两个“包装”函数
+static void
+pgds_portal_start_hook(Portal portal)
+{
+    pgds_report_activity(portal, false);
+}
+
+static void
+pgds_portal_drop_hook(Portal portal)
+{
+    pgds_report_activity(portal, true);
+}
+
+/* ----------
+ * pgstat_fetch_stat_local_csentry
+ * 
+ *  Given a backend id, find particular cluster status entry, copy valid
+ *  entry into local memory, loop around changecount to ensure concurrency.
+ * ----------
+ */
+static PgDistStatStatus *
+pgstat_fetch_stat_local_dsentry(int beid)
+{
+	PgDistStatStatus *dsentry;
+	PgDistStatStatus *local = palloc(sizeof(PgDistStatStatus));
+	local->valid = false;
+	
+	if (DistStatArray == NULL)
+	{
+		ereport(ERROR,
+		        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			        errmsg("shared memory for pg_stat_cluster_activity is not prepared"),
+			        errhint("maybe you need to set shared_preload_libraries in postgresql.conf")));
+		return NULL;
+	}
+	
+	if (beid < 1)
+		return NULL;
+	
+	dsentry = &DistStatArray[beid - 1];
+	
+	for (;;)
+	{
+		int			before_changecount;
+		int			after_changecount;
+		
+		save_changecount_before(dsentry, before_changecount);
+		if (dsentry->valid)
+		{
+			memcpy(local, dsentry, sizeof(PgDistStatStatus));
+		}
+		save_changecount_after(dsentry, after_changecount);
+		if (before_changecount == after_changecount &&
+		    (before_changecount & 1) == 0)
+			break;
+		
+		/* Make sure we can break out of loop if stuck... */
+		CHECK_FOR_INTERRUPTS();
+	}
+	
+	return local;
+}
+
+/* ----------
+ * dist_pg_get_remote_activity
+ * 
+ *  Execute dist_pg_stat_get_activity query remotely and save
+ *  results in the given tuplestore.
+ */
+static void
+dist_pg_get_remote_activity(const char *sessionid, bool coordonly, Tuplestorestate *tupstore, TupleDesc tupdesc)
+{
+#define QUERY_LEN 1024
+	char    query[QUERY_LEN];
+	EState              *estate;
+	MemoryContext		oldcontext;
+	RemoteQuery 		*plan;
+	RemoteQueryState    *pstate;
+	TupleTableSlot		*result = NULL;
+	
+	/*
+	* Here we call dist_pg_stat_get_activity remotely with args:
+	* coordonly = false, localonly = true, to prevent recursive calls on remote nodes.
+	*/
+	snprintf(query, QUERY_LEN, "select * from dist_pg_stat_get_activity($1, false, true)");
+	
+	plan = makeNode(RemoteQuery);
+	plan->combine_type = COMBINE_TYPE_NONE;
+	/*
+	 * set exec_nodes to NULL makes ExecRemoteQuery send query to all nodes
+	 * (local CN nodes won't recieved query again).
+	 */
+	plan->exec_nodes = NULL;
+	plan->exec_type = EXEC_ON_ALL_NODES;
+	plan->sql_statement = (char *) query;
+	plan->force_autocommit = false;
+	plan->exec_nodes = makeNode(ExecNodes);
+	plan->exec_nodes->missing_ok = true;
+	
+	if (coordonly)
+	{
+		plan->exec_nodes->nodeList = GetAllCoordNodes();
+		plan->exec_type = EXEC_ON_COORDS;
+	}
+	
+	/* prepare to execute */
+	estate = CreateExecutorState();
+	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+	estate->es_snapshot = GetActiveSnapshot();
+	estate->es_param_list_info = EvaluateSessionIDParam(sessionid);
+	pstate = ExecInitRemoteQuery(plan, estate, 0);
+	ExecAssignResultType((PlanState *) pstate, tupdesc);
+	MemoryContextSwitchTo(oldcontext);
+	
+	result = ExecRemoteQuery((PlanState *) pstate);
+	
+	while (result != NULL && !TupIsNull(result))
+	{
+		slot_getallattrs(result);
+		
+		tuplestore_puttupleslot(tupstore, result);
+		result = ExecRemoteQuery((PlanState *) pstate);
+	}
+	
+	ExecEndRemoteQuery(pstate);
+	FreeExecutorState(estate);
+}
+
+/* ----------
+ * dist_pg_stat_get_activity
+ * 
+ *  Internal SRF function of this extension. It accesses shared memory to find
+ *  every live backend, collects their local and distributed status,
+ *  and presents the information. It combines fields from both PgBackendStatus
+ *  and our custom PgDistStatStatus.
+ *
+ *  arguments:  sessionid -- global unique id for a session, generated by CN
+ *              coordonly -- only dispatch to other CNs if true.
+ *              localonly -- only collect local entries' status if true.
+ *              
+ *  Note: since we also collect PGBackendStatus, get them first and use
+ *  backend id to access a particular distributed status entry to narrow down
+ *  the loop search range from all backend slots to localNumBackends (see pgstat.c)
+ * ----------
+ */
+Datum
+dist_pg_stat_get_activity(PG_FUNCTION_ARGS)
+{
+	int              num_backends = pgstat_fetch_stat_numbackends();
+	int			     curr_backend;
+	bool             with_sessionid = !PG_ARGISNULL(0);
+	bool             coordonly = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
+	bool             localonly = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
+	const char      *sessionid = with_sessionid ? text_to_cstring(PG_GETARG_TEXT_P(0)) : NULL;
+	ReturnSetInfo   *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	TupleDesc	     tupdesc;
+	Tuplestorestate *tupstore;
+	MemoryContext    per_query_ctx;
+	MemoryContext    oldcontext;
+	
+	/* check to see if caller supports us returning a tuplestore */
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
+		ereport(ERROR,
+		        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			        errmsg("set-valued function called in context that cannot accept a set")));
+	if (!(rsinfo->allowedModes & SFRM_Materialize))
+		ereport(ERROR,
+		        (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			        errmsg("materialize mode required, but it is not " \
+						"allowed in this context")));
+	
+	/* Build a tuple descriptor for our result type */
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		elog(ERROR, "return type must be a row type");
+	
+	/* switch to query's memory context to save results during execution */
+	per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+	oldcontext = MemoryContextSwitchTo(per_query_ctx);
+	
+	tupstore = tuplestore_begin_heap(true, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = tupstore;
+	rsinfo->setDesc = tupdesc;
+	
+	MemoryContextSwitchTo(oldcontext);
+	
+	/* dispatch query to remote if needed */
+	if (!localonly && IS_PGXC_COORDINATOR)
+		dist_pg_get_remote_activity(sessionid, coordonly, tupstore, tupdesc);
+	
+	/* 1-based index */
+	for (curr_backend = 1; curr_backend <= num_backends; curr_backend++)
+	{
+		/* for each row */
+		Datum		values[PG_DIST_STAT_ACTIVITY_COLS];
+		bool		nulls[PG_DIST_STAT_ACTIVITY_COLS];
+		
+		/* same as pg_stat_get_activity */
+		LocalPgBackendStatus *local_beentry;
+		PgBackendStatus *beentry;
+		PGPROC	   *proc;
+		const char *wait_event_type = NULL;
+		const char *wait_event = NULL;
+		
+		/* cluster information */
+		PgDistStatStatus *local_dsentry;
+		
+		MemSet(values, 0, sizeof(values));
+		MemSet(nulls, 0, sizeof(nulls));
+		
+		/* Get the next one in the list */	// ????
+		local_beentry = pgstat_fetch_stat_local_beentry(curr_backend);
+		local_dsentry = pgstat_fetch_stat_local_dsentry(local_beentry->backend_id);
+		if (!local_beentry || !local_dsentry)
+		{
+			int			i;
+			
+			/* Ignore missing entries if looking for specific sessionid */
+			if (with_sessionid)
+				continue;
+			
+			for (i = 0; i < lengthof(nulls); i++)
+				nulls[i] = true;
+			
+			nulls[13] = false;
+			values[13] = CStringGetTextDatum("<backend information not available>");
+			
+			tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+			continue;
+		}
+		
+		if (!local_dsentry->valid)
+			continue;
+		
+		beentry = &local_beentry->backendStatus;
+		/* If looking for specific sessionid, ignore all the others */
+		if (with_sessionid && strcmp(sessionid, local_dsentry->sessionid) != 0)
+			continue;
+		
+		/* Values available to all callers */
+		values[0] = CStringGetTextDatum(local_dsentry->sessionid);
+		values[1] = Int32GetDatum(beentry->st_procpid);
+		
+		if (beentry->st_databaseid != InvalidOid)
+		{
+			char *dbname = get_database_name(beentry->st_databaseid);
+			if (dbname != NULL)
+				values[7] = CStringGetTextDatum(dbname);
+			else
+				nulls[7] = true;
+		}
+		else
+			nulls[7] = true;
+		
+		if (beentry->st_userid != InvalidOid)
+		{
+			char *usename = GetUserNameFromId(beentry->st_userid, true);
+			if (usename != NULL)
+				values[8] = CStringGetTextDatum(usename);
+			else
+				nulls[8] = true;
+		}
+		else
+			nulls[8] = true;
+		
+		/* Values only available to owner or superuser or pg_read_all_stats */
+		if (has_privs_of_role(GetUserId(), beentry->st_userid) ||
+		    is_member_of_role(GetUserId(), DEFAULT_ROLE_READ_ALL_STATS))
+		{
+			SockAddr	zero_clientaddr;
+			
+			/* A zeroed client addr means we don't know */
+			memset(&zero_clientaddr, 0, sizeof(zero_clientaddr));
+			if (memcmp(&(beentry->st_clientaddr), &zero_clientaddr,
+			           sizeof(zero_clientaddr)) == 0)
+			{
+				nulls[2] = true;
+				nulls[3] = true;
+				nulls[4] = true;
+			}
+			else
+			{
+				if (beentry->st_clientaddr.addr.ss_family == AF_INET
+#ifdef HAVE_IPV6
+				    || beentry->st_clientaddr.addr.ss_family == AF_INET6
+#endif
+					)
+				{
+					char		remote_host[NI_MAXHOST];
+					char		remote_port[NI_MAXSERV];
+					int			ret;
+					
+					remote_host[0] = '\0';
+					remote_port[0] = '\0';
+					ret = pg_getnameinfo_all(&beentry->st_clientaddr.addr,
+					                         beentry->st_clientaddr.salen,
+					                         remote_host, sizeof(remote_host),
+					                         remote_port, sizeof(remote_port),
+					                         NI_NUMERICHOST | NI_NUMERICSERV);
+					if (ret == 0)
+					{
+						clean_ipv6_addr(beentry->st_clientaddr.addr.ss_family, remote_host);
+						values[2] = DirectFunctionCall1(inet_in,
+						                                CStringGetDatum(remote_host));
+						if (beentry->st_clienthostname &&
+						    beentry->st_clienthostname[0])
+							values[3] = CStringGetTextDatum(beentry->st_clienthostname);
+						else
+							nulls[3] = true;
+						values[4] = Int32GetDatum(atoi(remote_port));
+					}
+					else
+					{
+						nulls[2] = true;
+						nulls[3] = true;
+						nulls[4] = true;
+					}
+				}
+				else if (beentry->st_clientaddr.addr.ss_family == AF_UNIX)
+				{
+					/*
+					 * Unix sockets always reports NULL for host and -1 for
+					 * port, so it's possible to tell the difference to
+					 * connections we have no permissions to view, or with
+					 * errors.
+					 */
+					nulls[2] = true;
+					nulls[3] = true;
+					values[4] = DatumGetInt32(-1);
+				}
+				else
+				{
+					/* Unknown address type, should never happen */
+					nulls[2] = true;
+					nulls[3] = true;
+					nulls[4] = true;
+				}
+			}
+			
+			values[5] = CStringGetTextDatum(local_dsentry->nodename);
+			values[6] = CStringGetTextDatum(local_dsentry->role);
+			
+			proc = BackendPidGetProc(beentry->st_procpid);
+			if (proc != NULL)
+			{
+				uint32		raw_wait_event;
+				
+				raw_wait_event = UINT32_ACCESS_ONCE(proc->wait_event_info);
+				wait_event_type = pgstat_get_wait_event_type(raw_wait_event);
+				wait_event = pgstat_get_wait_event(raw_wait_event);
+			}
+			else if (beentry->st_backendType != B_BACKEND)
+			{
+				/*
+				 * For an auxiliary process, retrieve process info from
+				 * AuxiliaryProcs stored in shared-memory.
+				 */
+				proc = AuxiliaryPidGetProc(beentry->st_procpid);
+				
+				if (proc != NULL)
+				{
+					uint32		raw_wait_event;
+					
+					raw_wait_event =
+						UINT32_ACCESS_ONCE(proc->wait_event_info);
+					wait_event_type =
+						pgstat_get_wait_event_type(raw_wait_event);
+					wait_event = pgstat_get_wait_event(raw_wait_event);
+				}
+			}
+			
+			if (wait_event_type)
+				values[9] = CStringGetTextDatum(wait_event_type);
+			else
+				nulls[9] = true;
+			
+			if (wait_event)
+				values[10] = CStringGetTextDatum(wait_event);
+			else
+				nulls[10] = true;
+			
+			switch (beentry->st_state)
+			{
+				case STATE_IDLE:
+					values[11] = CStringGetTextDatum("idle");
+					break;
+				case STATE_RUNNING:
+					values[11] = CStringGetTextDatum("active");
+					break;
+				case STATE_IDLEINTRANSACTION:
+					values[11] = CStringGetTextDatum("idle in transaction");
+					break;
+				case STATE_FASTPATH:
+					values[11] = CStringGetTextDatum("fastpath function call");
+					break;
+				case STATE_IDLEINTRANSACTION_ABORTED:
+					values[11] = CStringGetTextDatum("idle in transaction (aborted)");
+					break;
+				case STATE_DISABLED:
+					values[11] = CStringGetTextDatum("disabled");
+					break;
+				case STATE_UNDEFINED:
+					nulls[11] = true;
+					break;
+			}
+			
+			values[12] = CStringGetTextDatum(local_dsentry->sqname);
+			values[13] = BoolGetDatum(local_dsentry->sqdone);
+			values[14] = CStringGetTextDatum(beentry->st_activity);
+			values[15] = CStringGetTextDatum(local_dsentry->planstate);
+			values[16] = CStringGetTextDatum(local_dsentry->portal);
+			values[17] = CStringGetTextDatum(local_dsentry->cursors);
+			
+			if (beentry->st_proc_start_timestamp != 0)
+				values[18] = TimestampTzGetDatum(beentry->st_proc_start_timestamp);
+			else
+				nulls[18] = true;
+			
+			if (beentry->st_xact_start_timestamp != 0)
+				values[19] = TimestampTzGetDatum(beentry->st_xact_start_timestamp);
+			else
+				nulls[19] = true;
+			
+			if (beentry->st_activity_start_timestamp != 0)
+				values[20] = TimestampTzGetDatum(beentry->st_activity_start_timestamp);
+			else
+				nulls[20] = true;
+			
+			if (beentry->st_state_start_timestamp != 0)
+				values[21] = TimestampTzGetDatum(beentry->st_state_start_timestamp);
+			else
+				nulls[21] = true;
+
+			if (local_dsentry->application_name[0] != '\0')
+				values[22] = CStringGetTextDatum(local_dsentry->application_name);
+			else
+				nulls[22] = true;
+			
+			if (TransactionIdIsValid(local_dsentry->backend_xid))
+				values[23] = TransactionIdGetDatum(local_dsentry->backend_xid);
+			else
+				nulls[23] = true;
+
+			if (TransactionIdIsValid(local_dsentry->backend_xmin))
+				values[24] = TransactionIdGetDatum(local_dsentry->backend_xmin);
+			else
+				nulls[24] = true;
+
+			if (local_dsentry->backend_type[0] != '\0')
+				values[25] = CStringGetTextDatum(local_dsentry->backend_type);
+			else
+				nulls[25] = true;
+
+			if (local_dsentry->global_query_id[0] != '\0')
+				values[26] = CStringGetTextDatum(local_dsentry->global_query_id);
+			else
+				nulls[26] = true;
+		}
+		else
+		{
+			values[14] = CStringGetTextDatum("<insufficient privilege>");
+			nulls[2] = true;
+			nulls[3] = true;
+			nulls[4] = true;
+			nulls[5] = true;
+			nulls[6] = true;
+			nulls[9] = true;
+			nulls[10] = true;
+			nulls[11] = true;
+			nulls[12] = true;
+			nulls[13] = true;
+			nulls[15] = true;
+			nulls[16] = true;
+			nulls[17] = true;
+			nulls[18] = true;
+			nulls[19] = true;
+			nulls[20] = true;
+			nulls[21] = true;
+			nulls[22] = true;
+			nulls[23] = true;
+			nulls[24] = true;
+			nulls[25] = true;
+			nulls[26] = true;
+			nulls[27] = true;
+		}
+		
+		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+	}
+	
+	/* clean up and return the tuplestore */
+	tuplestore_donestoring(tupstore);
+	
+	return (Datum) 0;
+}
+
+static bool
+pgds_signal_session_remote(const char *sessionid, int signal)
+{
+#define QUERY_LEN 1024
+	char    query[QUERY_LEN];
+	EState              *estate;
+	MemoryContext		oldcontext;
+	RemoteQuery 		*plan;
+	RemoteQueryState    *pstate;
+	Var 				*dummy;
+	TupleTableSlot		*result = NULL;
+	
+	snprintf(query, QUERY_LEN, "select pg_signal_session($1, %d, true)", signal);
+	
+	plan = makeNode(RemoteQuery);
+	plan->combine_type = COMBINE_TYPE_NONE;
+	/*
+	 * set exec_nodes to NULL makes ExecRemoteQuery send query to all nodes
+	 * (local CN nodes won't recieved query again).
+	 */
+	plan->exec_nodes = NULL;
+	plan->exec_type = EXEC_ON_ALL_NODES;
+	plan->sql_statement = (char *) query;
+	plan->force_autocommit = false;
+	
+	/*
+	 * We only need the target entry to determine result data type.
+	 * So create dummy even if real expression is a function.
+	 */
+	dummy = makeVar(1, 1, TEXTOID, 0, InvalidOid, 0);
+	plan->scan.plan.targetlist = lappend(plan->scan.plan.targetlist,
+	                                     makeTargetEntry((Expr *) dummy, 1, NULL, false));
+	
+	/* prepare to execute */
+	estate = CreateExecutorState();
+	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
+	estate->es_snapshot = GetActiveSnapshot();
+	estate->es_param_list_info = EvaluateSessionIDParam(sessionid);
+	pstate = ExecInitRemoteQuery(plan, estate, 0);
+	MemoryContextSwitchTo(oldcontext);
+	
+	result = ExecRemoteQuery((PlanState *) pstate);
+	ExecEndRemoteQuery(pstate);
+	if (TupIsNull(result))
+	{
+		elog(ERROR, "result of pg_signal_session executed remotely is NULL");
+		return false;
+	}
+	
+	FreeExecutorState(estate);
+	return true;
+}
+
+static bool
+pgds_signal_session(const char *sessionid, int signal)
+{
+	int         num_backends = pgstat_fetch_stat_numbackends();
+	int         curr_backend;
+	const char *funcname;
+	LocalPgBackendStatus *local_beentry;
+	PgDistStatStatus      *local_dsentry;
+	PgBackendStatus      *beentry;
+	
+	if (signal == SIGTERM)
+		funcname = "pg_terminate_backend";
+	else if (signal == SIGINT)
+		funcname = "pg_cancel_backend";
+	else
+		elog(ERROR, "pgds_signal_session only support SIGTERM and SIGINT, not %d", signal);
+	
+	/* 1-based index */
+	for (curr_backend = 1; curr_backend <= num_backends; curr_backend++)
+	{
+		/* Get the next one in the list */
+		local_beentry = pgstat_fetch_stat_local_beentry(curr_backend);
+		local_dsentry = pgstat_fetch_stat_local_dsentry(local_beentry->backend_id);
+		
+		if (local_dsentry->valid && strcmp(local_dsentry->sessionid, sessionid) == 0)
+		{
+			beentry = &local_beentry->backendStatus;
+			OidFunctionCall1(fmgr_internal_function(funcname),
+			                 Int32GetDatum(beentry->st_procpid));
+		}
+	}
+	
+	return true;
+}
+
+/*
+Datum
+pg_signal_session(PG_FUNCTION_ARGS)
+{
+	const char *sessionid = text_to_cstring(PG_GETARG_TEXT_P(0));
+	int         signal = PG_GETARG_INT32(1);
+	bool        localonly = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
+	bool        result;
+	
+	result = pgds_signal_session(sessionid, signal);
+	if (result && !localonly)
+		result = pgds_signal_session_remote(sessionid, signal);
+	
+	return BoolGetDatum(result);
+}
+
+Datum
+pg_terminate_session(PG_FUNCTION_ARGS)
+{
+	return DirectFunctionCall3(pg_signal_session,
+	                           PG_GETARG_DATUM(0),
+	                           Int32GetDatum(SIGTERM),
+	                           BoolGetDatum(false));
+}
+
+Datum
+pg_cancel_session(PG_FUNCTION_ARGS)
+{
+	return DirectFunctionCall3(pg_signal_session,
+	                           PG_GETARG_DATUM(0),
+	                           Int32GetDatum(SIGINT),
+	                           BoolGetDatum(false));
+}
+*/
+
+/*
+ * Hooked as shmem_startup_hook
+ */
+static void
+pgds_shmem_startup(void)
+{
+	if (prev_shmem_startup_hook)
+		prev_shmem_startup_hook();
+	
+	CreateSharedDistStatus();
+}
+
+/*
+ * Estimate shared memory space needed.
+ */
+static Size
+pgds_memsize(void)
+{
+	return mul_size(sizeof(PgDistStatStatus), NumBackendStatSlots);
+}
+
+/*
+ * Module load callback
+ */
+void
+_PG_init(void)
+{
+	if (!process_shared_preload_libraries_in_progress)
+		return;
+	
+	/*
+	 * Define (or redefine) custom GUC variables.
+	 */
+	DefineCustomBoolVariable("pg_dist_stat_views.enable_planstate",
+	                         "whether to show planstate in result sets.",
+	                         NULL,
+	                         &pgds_enable_planstate,
+	                         true,
+	                         PGC_SUSET,
+	                         0,
+	                         NULL,
+	                         NULL,
+	                         NULL);
+
+	// 【新增】定义自己用于调试的GUC变量
+	DefineCustomStringVariable(
+							"pg_dist_stat_views.global_query_id",
+							"Internal GUC to propagate Global Query ID.",
+							NULL,
+							&pgds_gid_guc_string,
+							"",
+							PGC_SUSET,
+							0,
+							NULL,
+							NULL,
+							NULL
+	);
+	
+	/*
+	 * Request additional shared resources.  (These are no-ops if we're not in
+	 * the postmaster process.)  We'll allocate or attach to the shared
+	 * resources in pgds_shmem_startup().
+	 */
+	RequestAddinShmemSpace(pgds_memsize());
+	
+	/*
+	 * Install hooks.
+	 */
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = pgds_shmem_startup;
+	prev_pgstat_report_hook = pgstat_report_hook;
+	pgstat_report_hook = pgds_report_query_activity;
+	prev_PortalStart = PortalStart_hook;
+	PortalStart_hook = pgds_portal_start_hook;
+	prev_PortalDrop = PortalDrop_hook;
+	PortalDrop_hook = pgds_portal_drop_hook;
+	prev_ExecutorStart = ExecutorStart_hook;
+	ExecutorStart_hook = pgds_report_executor_activity;
+	prev_ExecutorEnd = ExecutorEnd_hook;
+	ExecutorEnd_hook = pgds_executor_end_hook;
+}
+
+/*
+ * Module unload callback
+ */
+void
+_PG_fini(void)
+{
+	/* Uninstall hooks. */
+	shmem_startup_hook = prev_shmem_startup_hook;
+	pgstat_report_hook = prev_pgstat_report_hook;
+	PortalStart_hook = pgds_portal_start_hook;
+	PortalDrop_hook = pgds_portal_drop_hook;
+	ExecutorStart_hook = prev_ExecutorStart;
+	ExecutorEnd_hook = prev_ExecutorEnd;
+}

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.conf
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.conf
@@ -1,0 +1,5 @@
+#
+# This source code file contains modifications made by THL A29 Limited ("Tencent Modifications").
+# All Tencent Modifications are Copyright (C) 2023 THL A29 Limited.
+#
+shared_preload_libraries = 'pg_dist_stat_views'

--- a/contrib/pg_dist_stat_views/pg_dist_stat_views.control
+++ b/contrib/pg_dist_stat_views/pg_dist_stat_views.control
@@ -1,0 +1,9 @@
+# pg_stat_cluster_activity extension
+#
+# This source code file contains modifications made by THL A29 Limited ("Tencent Modifications").
+# All Tencent Modifications are Copyright (C) 2023 THL A29 Limited.
+#
+comment = 'distributed statistics views for activities and locks'
+default_version = '1.0'
+module_pathname = '$libdir/pg_dist_stat_views'
+relocatable = true

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -2601,7 +2601,7 @@ pgstat_fetch_stat_local_beentry(int beid)
     if (beid < 1 || beid > localNumBackends)
         return NULL;
 
-    return &localBackendStatusTable[beid - 1];
+    return &localBackendStatusTable[beid - 1];  // 缓存表
 }
 
 

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -541,10 +541,10 @@ Datum
 pg_stat_get_activity(PG_FUNCTION_ARGS)
 {// #lizard forgives
 #define PG_STAT_GET_ACTIVITY_COLS    24
-    int            num_backends = pgstat_fetch_stat_numbackends();
+    int            num_backends = pgstat_fetch_stat_numbackends();  // 当前后端进程总数
     int            curr_backend;
     int            pid = PG_ARGISNULL(0) ? -1 : PG_GETARG_INT32(0);
-    ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+    ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;   // 获取返回集信息，它包含了调用者期望如何接收结果的上下文。
     TupleDesc    tupdesc;
     Tuplestorestate *tupstore;
     MemoryContext per_query_ctx;
@@ -567,8 +567,8 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 
     per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
     oldcontext = MemoryContextSwitchTo(per_query_ctx);
-
     tupstore = tuplestore_begin_heap(true, false, work_mem);
+    
     rsinfo->returnMode = SFRM_Materialize;
     rsinfo->setResult = tupstore;
     rsinfo->setDesc = tupdesc;
@@ -591,7 +591,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
         MemSet(nulls, 0, sizeof(nulls));
 
         /* Get the next one in the list */
-        local_beentry = pgstat_fetch_stat_local_beentry(curr_backend);
+        local_beentry = pgstat_fetch_stat_local_beentry(curr_backend);  // 从统计信息收集器（stats collector）的共享内存中，获取编号为 curr_backend 的那个进程的状态快照
         if (!local_beentry)
         {
             int            i;
@@ -610,7 +610,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
             continue;
         }
 
-        beentry = &local_beentry->backendStatus;
+        beentry = &local_beentry->backendStatus;    // 获得
 
         /* If looking for specific PID, ignore all the others */
         if (pid != -1 && beentry->st_procpid != pid)
@@ -618,11 +618,11 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 
         /* Values available to all callers */
         if (beentry->st_databaseid != InvalidOid)
-            values[0] = ObjectIdGetDatum(beentry->st_databaseid);
+            values[0] = ObjectIdGetDatum(beentry->st_databaseid);       //数据库ID
         else
             nulls[0] = true;
 
-        values[1] = Int32GetDatum(beentry->st_procpid);
+        values[1] = Int32GetDatum(beentry->st_procpid);     // 进程ID
 
         if (beentry->st_userid != InvalidOid)
             values[2] = ObjectIdGetDatum(beentry->st_userid);
@@ -692,6 +692,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
 
             values[5] = CStringGetTextDatum(beentry->st_activity);
 
+            // 直接调用 BackendPidGetProc()，通过进程ID去共享内存的 ProcArray 里找到了那个进程对应的 PGPROC 结构体，并直接读取了 wait_event_info 字段
             proc = BackendPidGetProc(beentry->st_procpid);
             if (proc != NULL)
             {
@@ -840,6 +841,7 @@ pg_stat_get_activity(PG_FUNCTION_ARGS)
             nulls[17] = true;
         }
 
+        // 把填充好的 values 和 nulls 数组，正式变成一行数据，存入我们一开始创建的那个内存临时表 tupstore 中
         tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 
         /* If only a single backend was requested, and we found it, break. */


### PR DESCRIPTION
本次 Pull Request 旨在为 OpenTenBase 引入一个全新的 PostgreSQL 扩展模块 pg_dist_stat_views，以提供全面、跨集群的状态监控能力。本项目解决了在分布式环境下，使用 pg_stat_activity 和 pg_locks 等单节点视图进行问题诊断时，存在的信息孤岛和人工关联复杂的核心痛点。
本模块的核心价值在于显著降低分布式环境下的故障排查成本和时间。它通过智能地将同一个分布式查询或事务在所有协调节点（CN）和数据节点（DN）上的状态信息进行关联和聚合，实现了这一目标。
这项工作直接回应了社区对于提升系统可观测性的需求，特别是针对会话关联、锁等待链分析、分布式死锁追溯等关键运维场景，提供了完整的解决方案。