### PR TITLE
Fix variable redeclaration in cluster.cpp

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -1392,13 +1392,13 @@ int status_command(OpentenbaseConfig *install) {
 
         if (is_Centralized_instance(install->instance.instance_type) && is_master_dn(install->nodes[i].type))
         {
-            std::string port = get_node_port(&install->nodes[i], install);
+            std::string node_port = get_node_port(&install->nodes[i], install);
             std::cout << " ------- Master DN Connection Info -------  " << std::endl;
             std::string export_cmd = "export LD_LIBRARY_PATH=" + install->nodes[i].install_path + "/lib  && export PATH=" + install->nodes[i].install_path + "/bin:${PATH} ";
             std::cout << "Environment variable: " << export_cmd << std::endl;
 
-            std::string port = get_node_port(&install->nodes[i], install);
-            std::cout << "PSQL connection: psql -h " << install->nodes[i].ip << " -p " + port + " -U opentenbase postgres \n" << std::endl;
+            std::string data_port = get_node_port(&install->nodes[i], install);
+            std::cout << "PSQL connection: psql -h " << install->nodes[i].ip << " -p " + data_port + " -U opentenbase postgres \n" << std::endl;
             break;
 
         } else if (is_master_cn(install->nodes[i].type))


### PR DESCRIPTION
Resolves compile error due to duplicate 'port' variable in status_command
- Renamed first variable to node_port
- Renamed second variable to data_port
- Maintained original logic and functionality"