### PR TITLE
fix: update PACKAGE_XC_VERSION from 10.0 to 11.0

### DIFF
--- a/configure
+++ b/configure
@@ -596,13 +596,13 @@ fi
 # Identity of this package.
 PACKAGE_NAME='OpenTenBase'
 PACKAGE_TARNAME='OpenTenBase'
-PACKAGE_XC_VERSION='10.0'
+PACKAGE_XC_VERSION='11.0'
 OPENTENBASE_VERSION='5.0'
 # used in opentenbase_version()
 PACKAGE_STRING="OpenTenBase V$OPENTENBASE_VERSION"
 PACKAGE_BUGREPORT='bugs@postgres-xl.org'
 PACKAGE_URL=''
-PACKAGE_VERSION="10.0 @ OpenTenBase_v$OPENTENBASE_VERSION $GIT_TAG `date -d today +\"%Y-%m-%d %H:%M:%S\"`"
+PACKAGE_VERSION="11.0 @ OpenTenBase_v$OPENTENBASE_VERSION $GIT_TAG `date -d today +\"%Y-%m-%d %H:%M:%S\"`"
 
 ac_unique_file="src/backend/access/common/heaptuple.c"
 ac_default_prefix=/usr/local/pgsql


### PR DESCRIPTION
## Summary

- Fix `PACKAGE_XC_VERSION` from `'10.0'` to `'11.0'` in the `configure` file
- This resolves version mismatch that causes pgAdmin/Navicat to query wrong system catalog columns (`proisagg` instead of `prokind`)

## Problem

OpenTenBase v5.0 is based on PG11+ and uses the `prokind` column in `pg_proc` (46 files), but reports itself as PostgreSQL 10.0 via `PACKAGE_XC_VERSION`. External tools check the server version string to decide which catalog columns to query:

- PG < 11: uses `proisagg` (boolean)
- PG >= 11: uses `prokind` (char: 'f', 'a', 'w', 'p')

When OpenTenBase reports version 10.0, tools like pgAdmin query `proisagg` which doesn't exist, causing errors.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `configure` | 599 | `PACKAGE_XC_VERSION='10.0'` | `PACKAGE_XC_VERSION='11.0'` |
| `configure` | 605 | `PACKAGE_VERSION="10.0 @ ..."` | `PACKAGE_VERSION="11.0 @ ..."` |

**Effect:** `PG_VERSION_NUM` changes from `100000` to `110000`.

## Safety Analysis

Verified that the change is safe:

- **`prokind` usage:** 46 files use `prokind` (PG11+ style)
- **`proisagg` usage:** Only 1 file (`src/bin/psql/describe.c`) uses `proisagg`
- **`PG_VERSION_NUM >= 110000` check:** 0 results in codebase — no code branches on this threshold
- **`PG_VERSION_NUM >= 100000` check:** 9 files — all still satisfied with 110000
- **`XLVERSION` (PACKAGE_XC_VERSION):** Only used in `GNUmakefile.in` and `doc/src/sgml/Makefile` for display purposes, not conditional compilation

## Test Plan

- [ ] `./configure` correctly sets `PACKAGE_XC_VERSION='11.0'`
- [ ] `make` completes without errors
- [ ] `SELECT version()` reports PostgreSQL 11.0
- [ ] pgAdmin/Navicat can browse functions without `proisagg` errors
- [ ] No regressions in `PG_VERSION_NUM`-dependent code paths

Closes #179