### PR TITLE
test: add regress coverage for FORWARD in node DDL

### DIFF
--- a/src/test/regress/expected/forward_node.out
+++ b/src/test/regress/expected/forward_node.out
@@ -1,0 +1,20 @@
+-- Verify that FORWARD is stored by CREATE NODE and updated by ALTER NODE.
+CREATE NODE regress_forward_node
+WITH (TYPE = 'datanode', HOST = 'forward_host_1', PORT = 6546, FORWARD = 6548);
+COPY (
+    SELECT node_forward_port
+      FROM pgxc_node
+     WHERE node_name = 'regress_forward_node'
+) TO STDOUT;
+6548
+ALTER NODE regress_forward_node WITH (FORWARD = 6550);
+COPY (
+    SELECT node_forward_port
+      FROM pgxc_node
+     WHERE node_name = 'regress_forward_node'
+) TO STDOUT;
+6550
+-- Avoid a non-deterministic cleanup warning in the expected output.
+SET client_min_messages = error;
+DROP NODE regress_forward_node;
+RESET client_min_messages;

--- a/src/test/regress/serial_schedule
+++ b/src/test/regress/serial_schedule
@@ -225,6 +225,7 @@ test: xc_having
 test: xc_temp
 test: xc_remote
 test: xc_node
+test: forward_node
 test: xc_FQS
 test: xc_FQS_join
 test: xc_misc

--- a/src/test/regress/sql/forward_node.sql
+++ b/src/test/regress/sql/forward_node.sql
@@ -1,0 +1,22 @@
+-- Verify that FORWARD is stored by CREATE NODE and updated by ALTER NODE.
+CREATE NODE regress_forward_node
+WITH (TYPE = 'datanode', HOST = 'forward_host_1', PORT = 6546, FORWARD = 6548);
+
+COPY (
+    SELECT node_forward_port
+      FROM pgxc_node
+     WHERE node_name = 'regress_forward_node'
+) TO STDOUT;
+
+ALTER NODE regress_forward_node WITH (FORWARD = 6550);
+
+COPY (
+    SELECT node_forward_port
+      FROM pgxc_node
+     WHERE node_name = 'regress_forward_node'
+) TO STDOUT;
+
+-- Avoid a non-deterministic cleanup warning in the expected output.
+SET client_min_messages = error;
+DROP NODE regress_forward_node;
+RESET client_min_messages;


### PR DESCRIPTION
## Summary

Add a serial regression test for the `FORWARD` option in node DDL.

The test verifies that:

* `CREATE NODE ... FORWARD = 6548` stores the configured value in `pgxc_node.node_forward_port`.
* `ALTER NODE ... FORWARD = 6550` updates `pgxc_node.node_forward_port`.
* Cleanup output is kept stable by suppressing the non-deterministic node-id warning.

## Test

```text
test forward_node ... ok
All 1 tests passed.
```

## Files changed

* `src/test/regress/sql/forward_node.sql`
* `src/test/regress/expected/forward_node.out`
* `src/test/regress/serial_schedule`

Related to #194: adds regression coverage for CREATE/ALTER NODE FORWARD handling.