### PR TITLE
fix: preserve FORWARD port in opentenbase_ctl node DDL

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -186,10 +186,10 @@ std::string build_create_pgxz_node_cmd(NodeInfo *node, OpentenbaseConfig* config
         {
             // 本节点默认会生成一个IP为 localhost/端口为5432 的记录，需要修改一下节点路由的IP/Port
             // ALTER NODE cn001 with(HOST='172.16.16.49',PORT=11000);
-            create_sql += "ALTER NODE " + config->nodes[i].name + " WITH (HOST='"+ config->nodes[i].ip +"', PORT=" + std::to_string(config->nodes[i].port) +");";
+            create_sql += "ALTER NODE " + config->nodes[i].name + " WITH (HOST='"+ config->nodes[i].ip +"', PORT=" + std::to_string(config->nodes[i].port) + ", FORWARD=" + std::to_string(config->nodes[i].forward_port) + ");";
         } else {
             // CREATE NODE cn001 WITH (TYPE='coordinator', HOST='172.16.16.49', PORT=11000);
-            create_sql += "CREATE NODE " + config->nodes[i].name + " WITH (TYPE='"+ node_type +"', HOST='"+ config->nodes[i].ip +"', PORT=" + std::to_string(config->nodes[i].port) +");";
+            create_sql += "CREATE NODE " + config->nodes[i].name + " WITH (TYPE='"+ node_type +"', HOST='"+ config->nodes[i].ip +"', PORT=" + std::to_string(config->nodes[i].port) + ", FORWARD=" + std::to_string(config->nodes[i].forward_port) + ");";
         }
     }
 


### PR DESCRIPTION
## Summary

Fix `opentenbase_ctl` node DDL generation so that the configured forward port is preserved.

`build_create_pgxz_node_cmd()` previously generated `CREATE NODE` and `ALTER NODE` statements with `HOST` and `PORT` only. As a result, the configured `forward_port` was omitted and the catalog value could remain unset.

This change adds `FORWARD=<node.forward_port>` to both generated statements.

## Validation

* Verified that both `ALTER NODE` and `CREATE NODE` generation paths include `FORWARD` from `config->nodes[i].forward_port`.
* Ran `git diff --check` successfully.

Fixes #194.
