### PR TITLE
Fix ProjectSet remote parameter type discovery

### DIFF
--- a/src/backend/pgxc/pool/execRemote.c
+++ b/src/backend/pgxc/pool/execRemote.c
@@ -9915,6 +9915,7 @@ determine_param_types(Plan *plan,  struct find_params_context *context)
 		case T_Unique:
 		case T_SetOp:
 		case T_Group:
+		case T_ProjectSet:
 		case T_MergeQualProj:
 		case T_ConnectBy:
 		case T_PartIterator:


### PR DESCRIPTION
## Pull Request Overview

This PR fixes remote parameter type discovery for plans containing `ProjectSet` nodes, which are produced by set-returning functions in the target list. `determine_param_types()` now recognizes `T_ProjectSet` instead of falling through to `elog(ERROR, "unrecognized node type: %d", ...)`.

## Changes

- Add `T_ProjectSet` handling to the `determine_param_types()` plan-node switch in `execRemote.c`.
- Prevent remote subplans containing SRF/ProjectSet plans from failing during parameter type discovery.

## Test Plan

- `git diff --check`
- Ubuntu 20.04 container: configured and built `src/backend/pgxc/pool/execRemote.o`
- Ubuntu 20.04 container: full build and install into `/opt/opentenbase`
- Ubuntu 20.04 container distributed smoke: coordinator/datanode `ProjectSet` `PREPARE`/`EXECUTE` queries passed
- Ubuntu 20.04 container distributed smoke: `EXECUTE DIRECT` SRF queries passed on both datanodes
- Grepped node logs for `unrecognized node type`; none found

## Notes

- Writable distributed-table SRF smoke was not run because the local container cluster reports license read-only. The smoke test used read-only SRF queries and `EXECUTE DIRECT` against both datanodes.
