### PR TITLE
Fix WindowAgg remote parameter discovery

### DIFF
--- a/src/backend/pgxc/pool/execRemote.c
+++ b/src/backend/pgxc/pool/execRemote.c
@@ -9902,9 +9902,11 @@ determine_param_types(Plan *plan,  struct find_params_context *context)
 			if (expression_tree_walker((Node *) ((WindowAgg *) plan)->startOffset,
 									   determine_param_types_walker,
 									   (void *) context))
+				return true;
 			if (expression_tree_walker((Node *) ((WindowAgg *) plan)->endOffset,
 									   determine_param_types_walker,
 									   (void *) context))
+				return true;
 			break;
 
 		case T_Gather:


### PR DESCRIPTION
## Pull Request Overview

This PR fixes `WindowAgg` handling in `determine_param_types()` for remote parameter type discovery. The existing `T_WindowAgg` branch walks `startOffset` and `endOffset`, but ignores a successful walker result. It should return immediately when either offset walker finds all required parameters, matching the pattern used by nearby plan-node branches and the generic plan walker.

Closes #217.

## Changes

- Add missing `return true;` after walking `WindowAgg.startOffset`.
- Add missing `return true;` after walking `WindowAgg.endOffset`.

## Test Plan

- `git diff --check`
- Ubuntu 20.04 container:
  - `./configure --prefix=/tmp/opentenbase-windowagg-217-install --enable-user-switch --with-openssl --with-ossp-uuid CFLAGS=-g`
  - `make -C src/backend generated-headers`
  - `make -C src/backend/pgxc/pool execRemote.o`

## Notes

- Runtime WindowAgg remote-parameter query was not run because this environment does not have a writable distributed regression harness for this specific plan shape.
