### PR TITLE
Fix concurrent pre-install thread reuse

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -507,6 +507,7 @@ int pre_install_command_concurrency(OpentenbaseConfig *config) {
     for (auto& thread : threads) {
         thread.join();
     }
+    threads.clear();
     for (int result : results) {
         if (result != 0) {
             LOG_ERROR_FMT("Failed to create directory for nodes");


### PR DESCRIPTION
## Summary

This PR fixes a latent crash in `pre_install_command_concurrency()` when running the concurrent pre-install path in `opentenbase_ctl`.

Step 1 joins all directory-creation threads, but the same `threads` vector was reused for Step 2 package transfer threads. Step 2 then iterated the entire vector again, including already-joined `std::thread` objects. Calling `join()` on those non-joinable objects can throw `std::system_error` and abort the process.

The fix clears the vector after Step 1 joins complete, so Step 2 only owns and joins the transfer threads it creates.

## Changes

- Add `threads.clear()` after the Step 1 join loop in `pre_install_command_concurrency()`.

## Validation

- `git diff --check`
- Ubuntu container build:
  - `./configure --without-readline --without-zlib`
  - `make -C src/port`
  - `make -C src/common`
  - `make -C contrib/opentenbase_ctl`
- Real SSH smoke test in an Ubuntu container:
  - configured `openssh-server`, `sshpass`, and user `opentenbase`
  - verified password SSH to `opentenbase@127.0.0.1:22`
  - used a container-only smoke harness to route `install -c` through `pre_install_command_concurrency()` and return after pre-install Step 2, because the current public install flow calls `pre_install_command()` instead
  - broken copy without `threads.clear()` aborted with status 134 and `std::system_error: Invalid argument`
  - fixed copy exited with status 0
  - confirmed the package was copied and extracted under `/home/opentenbase/install/opentenbase/5.99.0`
  - confirmed over SSH that the extracted smoke marker was readable and the test binary was executable

## Notes

The default install path currently does not call `pre_install_command_concurrency()`, so this fixes a latent path rather than the main install flow.
