### PR TITLE
Fix initgtm version check with build metadata

### DIFF
--- a/src/bin/initgtm/initgtm.c
+++ b/src/bin/initgtm/initgtm.c
@@ -22,6 +22,7 @@
 #include "postgres_fe.h"
 
 #include <dirent.h>
+#include <ctype.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <locale.h>
@@ -94,6 +95,7 @@ static void setup_control(void);
 static void trapsig(int signum);
 static void check_ok(void);
 static void usage(const char *progname);
+static void build_backend_version_prefix(char *versionstr, size_t versionstr_len);
 
 #ifdef WIN32
 static int	CreateRestrictedProcess(char *cmd, PROCESS_INFORMATION *processInfo);
@@ -801,6 +803,23 @@ usage(const char *progname)
 	printf(_("  -V, --version             output version information, then exit\n"));
 }
 
+static void
+build_backend_version_prefix(char *versionstr, size_t versionstr_len)
+{
+	char	   *version_token;
+	char	   *version_token_end;
+
+	snprintf(versionstr, versionstr_len, "postgres (PostgreSQL) %s", PG_VERSION);
+
+	version_token = versionstr + strlen("postgres (PostgreSQL) ");
+	version_token_end = version_token;
+	while (*version_token_end != '\0' &&
+		   !isspace((unsigned char) *version_token_end))
+		version_token_end++;
+
+	*version_token_end = '\0';
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -823,6 +842,7 @@ main(int argc, char *argv[])
 	char	   *effective_user;
 	char		bin_dir[MAXPGPATH];
 	char	   *pg_data_native;
+	char		backend_version_prefix[MAXPGPATH];
 	bool		node_type_specified = false;
 
 	progname = get_progname(argv[0]);
@@ -969,9 +989,16 @@ main(int argc, char *argv[])
 	}
 #endif
 
-	/* Like for initdb, check if a valid version of Postgres is running */
-	if ((ret = find_other_exec(argv[0], "postgres", PG_BACKEND_VERSIONSTR,
-							   backend_exec)) < 0)
+	/*
+	 * Like for initdb, check if a valid version of Postgres is running.
+	 * OpenTenBase package versions can include build metadata such as tags and
+	 * timestamps, so initgtm only requires the stable version token to match.
+	 */
+	build_backend_version_prefix(backend_version_prefix,
+								 sizeof(backend_version_prefix));
+	if ((ret = find_other_exec_with_version_prefix(argv[0], "postgres",
+												   backend_version_prefix,
+												   backend_exec)) < 0)
 	{
 		char        full_path[MAXPGPATH];
 

--- a/src/common/exec.c
+++ b/src/common/exec.c
@@ -21,6 +21,7 @@
 #endif
 
 #include <signal.h>
+#include <ctype.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -42,6 +43,10 @@
 static int	validate_exec(const char *path);
 static int	resolve_symlinks(char *path);
 static char *pipe_read_line(char *cmd, char *line, int maxsize);
+static int	find_other_exec_internal(const char *argv0, const char *target,
+									 const char *versionstr, bool prefix_match,
+									 char *retpath);
+static bool version_prefix_match(const char *line, const char *prefix);
 
 #ifdef WIN32
 static BOOL GetTokenUser(HANDLE hToken, PTOKEN_USER *ppTokenUser);
@@ -307,6 +312,25 @@ int
 find_other_exec(const char *argv0, const char *target,
 				const char *versionstr, char *retpath)
 {
+	return find_other_exec_internal(argv0, target, versionstr, false, retpath);
+}
+
+/*
+ * Find another program in our binary's directory, then make sure its version
+ * starts with the supplied prefix.
+ */
+int
+find_other_exec_with_version_prefix(const char *argv0, const char *target,
+									const char *versionstr, char *retpath)
+{
+	return find_other_exec_internal(argv0, target, versionstr, true, retpath);
+}
+
+static int
+find_other_exec_internal(const char *argv0, const char *target,
+						 const char *versionstr, bool prefix_match,
+						 char *retpath)
+{
 	char		cmd[MAXPGPATH];
 	char		line[MAXPGPATH];
 
@@ -329,10 +353,30 @@ find_other_exec(const char *argv0, const char *target,
 	if (!pipe_read_line(cmd, line, sizeof(line)))
 		return -1;
 
-	if (strcmp(line, versionstr) != 0)
+	if (prefix_match)
+	{
+		if (!version_prefix_match(line, versionstr))
+			return -2;
+	}
+	else if (strcmp(line, versionstr) != 0)
 		return -2;
 
 	return 0;
+}
+
+static bool
+version_prefix_match(const char *line, const char *prefix)
+{
+	size_t		prefix_len = strlen(prefix);
+	unsigned char next;
+
+	if (strncmp(line, prefix, prefix_len) != 0)
+		return false;
+
+	next = (unsigned char) line[prefix_len];
+
+	return next == '\0' || next == '\n' || next == '-' ||
+		next == '@' || (!isdigit(next) && next != '.');
 }
 
 

--- a/src/include/port.h
+++ b/src/include/port.h
@@ -97,6 +97,8 @@ extern void set_pglocale_pgservice(const char *argv0, const char *app);
 extern int	find_my_exec(const char *argv0, char *retpath);
 extern int find_other_exec(const char *argv0, const char *target,
 				const char *versionstr, char *retpath);
+extern int find_other_exec_with_version_prefix(const char *argv0, const char *target,
+				const char *versionstr, char *retpath);
 
 /* Doesn't belong here, but this is used with find_other_exec(), so... */
 #define PG_BACKEND_VERSIONSTR "postgres (PostgreSQL) " PG_VERSION "\n"


### PR DESCRIPTION
## Summary

This PR fixes `initgtm` rejecting a colocated `postgres` binary when the stable PostgreSQL version is the same but the `--version` string contains different OpenTenBase build metadata such as tags or timestamps.

## Changes

- Add `find_other_exec_with_version_prefix()` for callers that need prefix-based version validation.
- Keep existing `find_other_exec()` exact matching behavior unchanged for `initdb`, `pg_ctl`, and other callers.
- Update `initgtm` to validate the stable `postgres (PostgreSQL) <version-token>` prefix instead of the full `PG_VERSION` build string.
- Preserve mismatch detection for different version numbers such as `10.0` vs `10.0.1`.

## Verification

- Built `src/common` and `src/bin/initgtm` in the retained Ubuntu container.
- Verified fixed `initgtm` does not report `not the same version` when fake `postgres -V` returns the same `10.0` token with different build metadata.
- Verified fixed `initgtm` still reports `not the same version` when fake `postgres -V` returns `10.0.1`.
- Verified the old source fails the same metadata-only mismatch case.

Fixes #191
