### PR TITLE
docs: improve quick deployment troubleshooting guide

### DIFF
--- a/README_ZH.md
+++ b/README_ZH.md
@@ -31,17 +31,34 @@ OpenTenBase具有许多类似于PostgreSQL的语言接口，其中的一些可�
 
 ### 依赖
 
-``` 
-yum -y install git sudo gcc make readline-devel zlib-devel openssl-devel uuid-devel bison flex cmake postgresql-devel libssh2-devel sshpass  libcurl-devel libxml2-devel
+以下依赖安装命令需要使用 root 用户执行，或在命令前添加 `sudo`。
+
+对于 RedHat/CentOS：
+
+```shell
+yum -y install git sudo gcc make readline-devel zlib-devel openssl-devel uuid-devel bison flex cmake postgresql-devel libssh2-devel sshpass libcurl-devel libxml2-devel
 ```
 
-或者
+对于 Ubuntu/Debian：
 
+```shell
+apt update
+apt install -y git sudo gcc make libreadline-dev zlib1g-dev libssl-dev \
+  libossp-uuid-dev bison flex cmake libssh2-1-dev sshpass libxml2-dev \
+  libcurl4-openssl-dev libzstd-dev liblz4-dev language-pack-zh-hans
 ```
-apt install -y git sudo gcc make libreadline-dev zlib1g-dev libssl-dev libossp-uuid-dev bison flex cmake libssh2-1-dev sshpass libxml2-dev language-pack-zh-hans
+
+Ubuntu 18.04 软件源提供的 zstd 1.3.3 缺少当前源码使用的部分 API。如果编译时出现 zstd API 未定义错误，请安装更新版本的 zstd 后重新执行 `configure`。本次 Ubuntu 18.04 验证使用 zstd 1.5.5。
+
+使用 `opentenbase_ctl` 部署前，还需要确保目标服务器已启动 SSH 服务。Ubuntu/Debian 可使用以下命令安装 SSH 服务和端口检查工具：
+
+```shell
+apt install -y openssh-server iproute2
 ```
 
 ### 创建用户 'opentenbase'
+
+以下命令需要使用 root 用户执行，或在命令前添加 `sudo`。
 
 ```bash
 # 1. 创建目录 /data
@@ -59,12 +76,16 @@ usermod -aG wheel opentenbase
 # 对于 Debian
 usermod -aG sudo opentenbase
 
-# 5. 为 wheel 组启用 sudo 权限（通过 visudo）
-visudo 
+# 5. RedHat/CentOS 需要通过 visudo 为 wheel 组启用 sudo 权限
+visudo
 # 然后取消注释 "% wheel" 行，保存并退出
 ```
 
+Ubuntu/Debian 默认通过 `sudo` 组授权，不需要取消注释 `%wheel`。完成后可以执行 `visudo -c` 检查 sudoers 配置语法。
+
 ### 编译
+
+先切换到 `opentenbase` 用户。以下源码下载、编译和安装命令均使用该用户执行：
 
 ```bash
 su - opentenbase
@@ -79,13 +100,15 @@ rm -rf ${INSTALL_PATH}/opentenbase_bin_v5.0
 chmod +x configure*
 ./configure --prefix=${INSTALL_PATH}/opentenbase_bin_v5.0 --enable-user-switch --with-libxml --disable-license --with-openssl --with-ossp-uuid CFLAGS="-g"
 make clean
-make -sj
+make -s -j2
 make install
 chmod +x contrib/pgxc_ctl/make_signature
 cd contrib
-make -sj
+make -s -j2
 make install
 ```
+
+`-j2` 已在最小部署路径中验证，可根据可用内存调整并发数。不要省略 `-j` 后的数字；`make -sj` 会启用不受限制的并发，在内存不足时可能导致编译进程被系统终止。
 
 ## 安装
 使用 OPENTENBASE\_CTL 工具来搭建一个集群，例如：搭建一个具有1个全局事务管理节点(GTM)、1个协调器节点(COORDINATOR)以及2个数据节点(DATANODE)的集群。
@@ -94,11 +117,17 @@ make install
 
 #### 1. 安装 opentenbase 并将 opentenbase 安装包的路径导入到环境变量中。
 
+以下命令使用 `opentenbase` 用户执行，并且只对当前 shell 生效。切换用户或重新登录后需要重新设置，或将相同的 `export` 命令加入该用户的 shell 启动文件。
+
 ```shell
 PG_HOME=${INSTALL_PATH}/opentenbase_bin_v5.0
-export PATH="$PATH:$PG_HOME/bin"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PG_HOME/lib"
+export PATH="$PG_HOME/bin:$PATH"
+export LD_LIBRARY_PATH="$PG_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export LC_ALL=C
+
+command -v opentenbase_ctl
+command -v psql
+psql --version
 ```
 
 #### 2. 禁用 SELinux 和防火墙（可选）
@@ -114,21 +143,25 @@ sudo systemctl stop firewalld
 
 #### 3. 创建用于初始化实例的 *.tar.gz 包。
 
-```
+```shell
 cd ${PG_HOME}
 tar -zcf ${INSTALL_PATH}/opentenbase-5.21.8-i.x86_64.tar.gz *
+tar -tzf ${INSTALL_PATH}/opentenbase-5.21.8-i.x86_64.tar.gz | head
 cd ${INSTALL_PATH}
 ```
 
+包名中的版本号会用于生成远端安装目录。修改包名时，需要同步修改配置文件中 `[instance]` 的 `package` 路径，并保留点分数字版本（例如 `5.21.8`）。
+
 ### 集群启动步骤
 
-#### 生成并填写配置文件 
-opentenbase\_config.opentenbase\_ctl 工具可以生成配置文件的模板。您需要在模板中填写集群节点信息。启动 opentenbase\_ctl 工具后，将在当前用户的主目录中生成 opentenbase\_ctl 目录。输入 "prepare config" 命令后，将在 opentenbase\_ctl 目录中生成可直接修改的配置文件模板。
+#### 生成并填写配置文件
+
+当前版本的 `opentenbase_ctl` 不支持 `prepare config` 子命令，需要手工创建配置文件。配置中的 IP、SSH 端口和密码必须与实际环境一致。
 
 * opentenbase\_config.ini 中各字段说明
-```
+
 | 配置类别        | 配置项            | 说明                                                                      |
-|----------------|------------------|---------------------------------------------------------------------------||
+|----------------|------------------|---------------------------------------------------------------------------|
 | instance       | name             | 实例名称，可用字符：字母、数字、下划线，例如：opentenbase_instance01        |
 |                | type             | distributed 表示分布式模式，需要 gtm、coordinator 和 data 节点；centralized 表示集中式模式 |
 |                | package          | 软件包。完整路径（推荐）或相对于 opentenbase_ctl 的相对路径                  |
@@ -139,27 +172,66 @@ opentenbase\_config.opentenbase\_ctl 工具可以生成配置文件的模板。�
 |                |                  | 示例：如果 1 主 1 从，IP 数量与主节点相同；如果 1 主 2 从，IP 数量是主节点的两倍 |
 |                | nodes-per-server | 可选，默认 1。每个 IP 上部署的节点数。示例：主节点有 3 个 IP，配置为 2，则有 6 个节点 |
 |                |                  | cn001-cn006 共 6 个节点，每个服务器分布 2 个节点                            |
+|                | conf             | CN 自定义 GUC 配置文件的绝对路径；没有自定义配置时文件可以为空，但必须存在    |
 | datanodes      | master           | 主节点 IP，自动生成节点名称，在每个 IP 上部署 nodes-per-server 个节点        |
 |                | slave            | 从节点 IP，数量是主节点的整数倍                                             |
 |                |                  | 示例：如果 1 主 1 从，IP 数量与主节点相同；如果 1 主 2 从，IP 数量是主节点的两倍 |
 |                | nodes-per-server | 可选，默认 1。每个 IP 上部署的节点数。示例：主节点有 3 个 IP，配置为 2，则有 6 个节点 |
 |                |                  | dn001-dn006 共 6 个节点，每个服务器分布 2 个节点                            |
+|                | conf             | DN 自定义 GUC 配置文件的绝对路径；没有自定义配置时文件可以为空，但必须存在    |
 | server         | ssh-user         | 远程命令执行用户名，需要提前创建，所有服务器应有相同账户以简化配置管理          |
 |                | ssh-password     | 远程命令执行密码，需要提前创建，所有服务器应有相同密码以简化配置管理            |
 |                | ssh-port         | SSH 端口，所有服务器应保持一致以简化配置管理                                 |
 | log            | level            | opentenbase_ctl 工具执行的日志级别（不是 opentenbase 节点的日志级别）        |
 
-```
-
 #### 1. 为实例创建配置文件 opentenbase\_config.ini
-```
-mkdir -p ./logs
-touch opentenbase_config.ini
+
+以下命令在 `${INSTALL_PATH}` 中创建部署配置和空的自定义 GUC 文件：
+
+```shell
+cd ${INSTALL_PATH}
+touch postgres.conf opentenbase_config.ini
 vim opentenbase_config.ini
 ```
 
-* 例如，如果我有两台服务器 172.16.16.49 和 172.16.16.131，分布在两台服务器上的典型分布式实例配置如下。您可以复制此配置信息并根据您的部署要求进行修改。不要忘记填写 ssh 密码配置。
+* 单机最小分布式配置
+
+以下配置用于在一台服务器上部署 1 个 GTM、1 个 CN 和 1 个 DN，已在 `127.0.0.1` 上完成验证。使用前必须将 `ssh-password` 和 `ssh-port` 改为当前 `opentenbase` 用户的实际 SSH 认证信息。
+
+```ini
+[instance]
+name=opentenbase_minimal
+type=distributed
+package=/data/opentenbase/install/opentenbase-5.21.8-i.x86_64.tar.gz
+
+[gtm]
+master=127.0.0.1
+slave=
+
+[coordinators]
+master=127.0.0.1
+slave=
+nodes-per-server=1
+conf=/data/opentenbase/install/postgres.conf
+
+[datanodes]
+master=127.0.0.1
+slave=
+nodes-per-server=1
+conf=/data/opentenbase/install/postgres.conf
+
+[server]
+ssh-user=opentenbase
+ssh-password=请替换为实际密码
+ssh-port=36000
+
+[log]
+level=INFO
 ```
+
+* 例如，如果我有两台服务器 172.16.16.49 和 172.16.16.131，分布在两台服务器上的典型分布式实例配置如下。您可以复制此配置信息并根据您的部署要求进行修改。不要忘记填写 ssh 密码配置。
+
+```ini
 # 实例配置
 [instance]
 name=opentenbase01
@@ -176,12 +248,14 @@ slave=172.16.16.50,172.16.16.131
 master=172.16.16.49
 slave= 172.16.16.131
 nodes-per-server=1
+conf=/data/opentenbase/install/postgres.conf
 
 # 数据节点
 [datanodes]
 master=172.16.16.49,172.16.16.131
 slave=172.16.16.131,172.16.16.49
 nodes-per-server=1
+conf=/data/opentenbase/install/postgres.conf
 
 # 登录和部署账户
 [server]
@@ -196,7 +270,8 @@ level=DEBUG
 
 
 * 同样，典型集中式实例的配置如下。不要忘记填写 ssh 密码配置。
-```
+
+```ini
 # 实例配置
 [instance]
 name=opentenbase02
@@ -208,6 +283,7 @@ package=/data/opentenbase/install/opentenbase-5.21.8-i.x86_64.tar.gz
 master=172.16.16.49
 slave=172.16.16.131
 nodes-per-server=1
+conf=/data/opentenbase/install/postgres.conf
 
 # 登录和部署账户
 [server]
@@ -222,9 +298,23 @@ level=DEBUG
 
 #### 2. 执行实例安装命令。
 
+安装前，先从执行机验证配置中的每台服务器都可以通过相同的 SSH 用户、密码和端口登录。以下命令以单机最小配置为例：
+
+```shell
+sshpass -p '请替换为实际密码' ssh -o StrictHostKeyChecking=no \
+  -p 36000 opentenbase@127.0.0.1 'id'
 ```
-export LD_LIBRARY_PATH=/data/opentenbase/install/opentenbase_bin_v5.0/lib
-./opentenbase_bin_v5.0/bin/opentenbase_ctl install  -c opentenbase_config.ini
+
+SSH 验证通过后，在 `${INSTALL_PATH}` 目录执行安装：
+
+```shell
+cd ${INSTALL_PATH}
+opentenbase_ctl install -c opentenbase_config.ini
+```
+
+以下是多节点安装成功时的输出示例：
+
+```text
 
 ====== Start to Install Opentenbase test_cluster01  ====== 
 
@@ -267,8 +357,14 @@ step 6: Create node group ...
 ```
 * 当您看到 'Installation completed successfully' 字样时，表示安装已完成。尽情享受您的 opentenbase 之旅吧。
 * 您可以检查实例的状态
+
+```shell
+opentenbase_ctl status -c opentenbase_config.ini
 ```
-[opentenbase@VM-16-49-tencentos opentenbase_ctl]$ ./opentenbase_bin_v5.0/bin/opentenbase_ctl status -c opentenbase_config.ini
+
+状态输出示例：
+
+```text
 
 ------------- Instance status -----------  
 Instance name: test_cluster01
@@ -292,15 +388,121 @@ PSQL connection: psql -h 172.16.16.49 -p 11000 -U opentenbase postgres
 ```
 
 ## 使用
-* 连接到 CN 主节点执行 SQL
 
+### 连接到 CN 主节点执行 SQL
+
+先执行状态命令，从 `Master CN Connection Info` 中获取实际安装目录、CN IP 和端口：
+
+```shell
+opentenbase_ctl status -c opentenbase_config.ini
 ```
-export LD_LIBRARY_PATH=/home/opentenbase/install/opentenbase/5.21.8/lib  && export PATH=/home/opentenbase/install/opentenbase/5.21.8/bin:${PATH} 
-$ psql -h ${CoordinateNode_IP} -p ${CoordinateNode_PORT} -U opentenbase -d postgres
 
-postgres=# 
+以下命令对应前面的单机最小配置。端口被占用时工具会自动选择其他端口，因此应以状态命令的实际输出为准：
 
+```shell
+export LD_LIBRARY_PATH=/data/opentenbase/install/opentenbase/5.21.8/lib
+export PATH=/data/opentenbase/install/opentenbase/5.21.8/bin:$PATH
+psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres
 ```
+
+### 基础 SQL 验证
+
+连接 CN 后，可以执行以下 SQL 验证版本和基本读写。本示例中的 `SHARD` 分布语法已使用当前源码构建结果验证：
+
+```sql
+select version();
+
+drop table if exists opentenbase_quickstart;
+create table opentenbase_quickstart (
+    id integer,
+    note text
+) distribute by shard(id);
+
+insert into opentenbase_quickstart values (1, 'alpha'), (2, 'beta');
+select id, note from opentenbase_quickstart order by id;
+```
+
+查询应返回刚插入的两行数据。当前构建使用 `DISTRIBUTE BY HASH(id)` 会报 `Cannot support distribute type: Hash`，不要将旧版 `HASH` 示例用于该验证路径。
+
+## 常见错误与排查
+
+### 1. `opentenbase_ctl: command not found`
+
+可能原因是 OpenTenBase 的 `bin` 目录未加入当前 shell 的 `PATH`，或切换用户后环境变量未重新设置。
+
+```shell
+echo "$PATH"
+echo "$PG_HOME"
+command -v opentenbase_ctl
+```
+
+确认 `PG_HOME` 指向实际编译安装目录后重新设置：
+
+```shell
+export PG_HOME=/data/opentenbase/install/opentenbase_bin_v5.0
+export PATH="$PG_HOME/bin:$PATH"
+```
+
+### 2. 动态库加载失败：`cannot open shared object file`
+
+检查当前库路径以及 `postgres` 是否存在未解析的动态库：
+
+```shell
+echo "$LD_LIBRARY_PATH"
+ldd "$PG_HOME/bin/postgres" | grep 'not found'
+```
+
+确认路径后重新设置：
+
+```shell
+export LD_LIBRARY_PATH="$PG_HOME/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+```
+
+### 3. SSH 登录或软件包分发失败
+
+确认 sshd 已启动、配置中的 `ssh-port` 与实际监听端口一致，并从执行机验证相同的用户和密码：
+
+```shell
+ss -lntp | grep 36000
+sshpass -p '请替换为实际密码' ssh -o StrictHostKeyChecking=no \
+  -p 36000 opentenbase@127.0.0.1 'id'
+```
+
+未配置公钥时，`ssh localhost` 免密登录失败是正常的；配置了 `ssh-password` 后，`opentenbase_ctl` 可以通过 `sshpass` 使用密码认证。多机部署时，应对配置中的每个 IP 执行同样的登录检查。
+
+### 4. 节点端口被占用
+
+当前工具从 `11000` 开始为节点自动寻找端口。安装前可以检查该端口段是否已有监听进程：
+
+```shell
+ss -lntp | grep -E ':(11000|11001|11002|11003|11004|11005|11006|11007|11008)[[:space:]]'
+```
+
+如果存在冲突，应先确认占用进程是否属于已有 OpenTenBase 实例。不要直接终止未知进程；清理旧实例或释放端口后，再使用新的实例名称执行安装。
+
+### 5. Ubuntu/Debian 编译时缺少依赖
+
+本次 Ubuntu 18.04 验证中实际出现过以下错误：
+
+* `zstd library not found`：检查 `libzstd-dev`、`liblz4-dev` 和 zstd 版本。
+* `curl/curl.h: No such file or directory`：安装 `libcurl4-openssl-dev`。
+* `curl-config: Command not found`：同样检查 `libcurl4-openssl-dev` 是否安装成功。
+
+安装依赖前先执行 `apt update`。Ubuntu 18.04 自带的 zstd 1.3.3 对当前源码过旧，本次验证使用 zstd 1.5.5。
+
+### 6. 权限、配置文件或路径不一致
+
+创建 `/data` 和 `opentenbase` 用户需要管理员权限；源码编译、打包和集群安装应使用 `opentenbase` 用户。检查关键路径的属主和可读性：
+
+```shell
+whoami
+ls -ld /data /data/opentenbase ${INSTALL_PATH}
+test -r ${INSTALL_PATH}/opentenbase-5.21.8-i.x86_64.tar.gz
+test -r ${INSTALL_PATH}/postgres.conf
+```
+
+配置文件中的 `package` 和 `conf` 建议使用绝对路径。`conf` 指向的文件即使没有自定义 GUC 也必须存在；缺少该字段或文件会导致配置解析失败。
+
 
 ## 引用  
 


### PR DESCRIPTION
修改内容

本 PR 基于 README_ZH.md 完成 OpenTenBase 最小部署路径验证，并对快速部署说明进行优化，主要包括：

1. 补充 Ubuntu/Debian 环境下的软件包索引更新、构建依赖和 SSH 前置工具说明。
2. 明确 root 与 opentenbase 用户的命令边界，将无界并发编译命令调整为可控的 make -s -j2。
3. 完善 PATH、LD_LIBRARY_PATH、部署包、配置文件和路径说明。
4. 修正当前工具不支持的 prepare config 描述，补充必需的 conf 字段。
5. 增加经过验证的单机最小部署拓扑、CN 节点连接、基础 SQL 验证和“常见错误与排查”小节。

关联 Issue

Fixes #199

部署验证环境

* OS: Ubuntu 18.04.6 LTS（Docker，宿主机 macOS 26.5.1）
* Kernel: Linux 7.0.5-orbstack-00330-ge3df4e19b0a0-dirty
* CPU 架构: x86_64（宿主机 arm64）
* GCC: 7.5.0
* Make: GNU Make 4.1
* CMake: 3.10.2
* OpenTenBase commit: b612d77cbfd4d762f20c54c35f7caf09d57ef098

部署验证步骤

本地已完成以下验证：

* 依赖安装
* 创建 opentenbase 用户
* 源码编译
* 环境变量配置
* opentenbase_ctl 最小部署（1 GTM、1 CN、1 DN）
* 连接 CN 节点
* 基础 SQL 验证

部署过程中遇到的问题

1. Ubuntu 容器首次安装依赖时无法定位软件包
    * 现象：apt install 报 Unable to locate package。
    * 原因：新建容器尚未更新软件包索引。
    * 处理方式：先执行 apt update，再安装依赖。
    * 是否已在文档中补充：是。
2. zstd/lz4 和 curl 开发依赖不完整
    * 现象：出现 zstd library not found、zstd API 未定义、curl/curl.h: No such file or directory 和 curl-config: Command not found。
    * 原因：缺少开发包，且 Ubuntu 18.04 自带 zstd 1.3.3 对当前源码过旧。
    * 处理方式：补充 zstd、lz4、curl 开发依赖；本次使用 zstd 1.5.5 完成构建。
    * 是否已在文档中补充：是。
3. make -sj 导致内存耗尽
    * 现象：编译进程被系统终止，Docker/OrbStack 中断。
    * 原因：-j 未指定数字会启用不受限制的并发。
    * 处理方式：改用 make -s -j2。
    * 是否已在文档中补充：是。
4. README 中的配置生成和配置字段与当前工具不一致
    * 现象：prepare config 输出不支持；删除 conf 字段后配置解析失败并返回 1。
    * 原因：当前工具没有 prepare 子命令，且 CN/DN 自定义配置文件路径实际为必需项。
    * 处理方式：改为手工创建配置和空 postgres.conf，补充 conf 的绝对路径。
    * 是否已在文档中补充：是。
5. 旧 HASH 建表示例不适用于当前构建
    * 现象：DISTRIBUTE BY HASH(id) 返回 Cannot support distribute type: Hash。
    * 原因：当前 v5 构建路径使用 SHARD 分布语法。
    * 处理方式：使用 DISTRIBUTE BY SHARD(id)，建表、插入和查询均成功。
    * 是否已在文档中补充：是。

关键部署成功日志

本次在 Ubuntu 18.04 amd64 Docker 环境中完成 OpenTenBase 最小部署验证，部署拓扑为 1 GTM、1 CN、1 DN。

1. 集群安装成功

Installation completed successfully

2. 节点状态检查

Total: 3, Running: 3, Stopped: 0, Unknown: 0

最小集群节点包括：

gtm0001: 127.0.0.1:11000
cn0001: 127.0.0.1:11003
dn0001: 127.0.0.1:11006

3. CN 节点连接验证

psql -h 127.0.0.1 -p 11003 -U opentenbase -d postgres -v ON_ERROR_STOP=1 -c "select version();"

返回结果包含：

PostgreSQL 10.0 @ OpenTenBase_v5.0 (commit: b612d77cb)

4. 基础 SQL 验证

drop table if exists issue199_smoke_test;
create table issue199_smoke_test (
  id integer,
  note text
) distribute by shard(id);
insert into issue199_smoke_test values
  (1, 'alpha'),
  (2, 'beta');
select id, note from issue199_smoke_test order by id;

查询结果：

 id | note
----+-------
  1 | alpha
  2 | beta

AI 使用策略自我报告

本次 Issue #199 中，我使用了 ChatGPT 和 Codex CLI 辅助完成任务。

ChatGPT 主要用于理解 Issue 要求、拆解任务流程、制定分阶段执行方案、生成 Codex 提示词，以及辅助整理 PR 描述和 AI 使用策略报告。Codex CLI 主要用于阅读仓库文件、梳理 README_ZH.md 的最小部署路径、辅助执行本地及 Docker 环境中的验证命令、根据真实终端输出归纳部署问题，并辅助修改 README 文档和检查 Markdown 格式。

AI 在本次任务中的作用仅限于流程拆解、问题归纳、命令编排、文档结构建议和文字整理，不替代真实部署验证。依赖安装、源码编译、opentenbase_ctl 最小部署、CN 节点连接和基础 SQL 验证均以本地实际执行结果、退出码和终端输出为准，没有使用 AI 编造部署结果、错误日志或验证结论。

本次写入 README_ZH.md 的内容均经过人工检查和本地验证。未经复现、未经验证，或与当前 README_ZH.md 部署路径不一致的 AI 建议没有写入最终文档。例如，未将 postgresql-server-dev-all 写成 Ubuntu 必需依赖，因为本次未安装该包也完成了构建；未将动态库加载失败写成实际故障，因为本次没有复现该问题；未要求必须配置 SSH 免密，因为本次使用 ssh-password 的密码认证已完成部署；未沿用旧的 DISTRIBUTE BY HASH SQL 示例，因为当前构建实际返回 Cannot support distribute type: Hash，最终改用验证通过的 DISTRIBUTE BY SHARD 示例。

被采纳的 AI 建议包括：在宿主机 macOS arm64 不属于 README 支持环境时，使用 Ubuntu 18.04 amd64 Docker 环境进行验证；将任务拆分为环境检查、依赖安装、编译、部署、CN 连接、SQL 验证和文档修改等阶段；根据真实报错补充 zstd、lz4、curl 依赖说明；将无界并发的 make -sj 调整为可控的 make -s -j2；修正当前工具不支持的 prepare config 描述；补充必需的 conf 字段、单机最小拓扑、CN 连接命令、基础 SQL 示例和“常见错误与排查”小节。

提交前，我使用 git diff README_ZH.md 和 git diff --check 检查文档修改范围与格式，确认本次提交只包含与 Issue #199 相关的 README 文档优化。个人进度记录文件未加入本次提交。

补充说明

本机未安装 markdownlint；已执行 git diff --check、代码围栏闭合检查，并在容器中复核 README 新增的环境变量、动态库和关键路径检查命令。

如有文档风格或部署说明不符合项目规范的地方，我可以继续修改。