### PR TITLE
fix: unify bool via stdbool.h for modern toolchain compatibility

### DIFF
--- a/src/include/c.h
+++ b/src/include/c.h
@@ -220,6 +220,7 @@
 
 #ifndef __cplusplus
 
+#include <stdbool.h>
 #ifndef bool
 typedef char bool;
 #endif


### PR DESCRIPTION
## Problem
Closes #192.

OpenTenBase fails to build on modern distributions:
- **GCC 12+** (Ubuntu 22.04): `error: conflicting types for '...'` — `bool` resolves to `char` in some translation units and to `_Bool` in others, because system headers transitively pull in `<stdbool.h>` inconsistently.
- **GCC 14** (Ubuntu 24.04, Fedora 40+): additionally `-Werror=incompatible-pointer-types` / `-Werror=implicit-function-declaration`.

## Root cause
`src/include/c.h` defines bool under a `#ifndef bool` guard:
```c
#ifndef bool
typedef char bool;
#endif
```
When a system header defines `bool` to `_Bool` (via `<stdbool.h>`) before/around this, `bool` becomes inconsistent across translation units, so the same function ends up with conflicting signatures — a hard error, not a warning.

## Fix
Explicitly `#include <stdbool.h>` in the bool section of `c.h` so `bool`/`true`/`false` resolve to the standard definitions uniformly in every translation unit. The existing `#ifndef bool/true/false` guards become no-ops in C; C++ keeps its built-in bool.

This fixes the **root cause** (type correctness), preferable to the `-Wno-error=...` suppression suggested in #192.

## Verification
Built successfully on Ubuntu 22.04 (previously failed with `conflicting types` on both gcc-11 and gcc-12):
```
postgres (PostgreSQL) 10.0 @ OpenTenBase_v5.0 (commit: b612d77cb)
```
`_Bool` is a 1-byte type like `char`, so existing `((bool) 1)` casts and `bool *` usages remain valid.
