### PR TITLE
Add MySQL compatibility function extension

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -56,7 +56,8 @@ SUBDIRS = \
 		pgvector	\
 		pgsql-http \
 		opentenbase_ai \
-                opentenbase_ctl	
+		opentenbase_mysql_compat \
+		opentenbase_ctl
 
 ifeq ($(with_openssl),yes)
 SUBDIRS += sslinfo

--- a/contrib/opentenbase_mysql_compat/Makefile
+++ b/contrib/opentenbase_mysql_compat/Makefile
@@ -1,0 +1,23 @@
+# contrib/opentenbase_mysql_compat/Makefile
+#
+# Copyright (c) 2026 OpenTenBase Contributors
+#
+# This file is licensed under the same terms as OpenTenBase. See LICENSE.txt
+# in the repository root for details.
+
+EXTENSION = opentenbase_mysql_compat
+DATA = opentenbase_mysql_compat--1.0.sql
+PGFILEDESC = "opentenbase_mysql_compat - MySQL function compatibility helpers"
+
+REGRESS = opentenbase_mysql_compat
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = contrib/opentenbase_mysql_compat
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/contrib/opentenbase_mysql_compat/README.md
+++ b/contrib/opentenbase_mysql_compat/README.md
@@ -1,0 +1,223 @@
+<!--
+Copyright (c) 2026 OpenTenBase Contributors
+
+This file is licensed under the same terms as OpenTenBase. See LICENSE.txt
+in the repository root for details.
+-->
+
+# opentenbase_mysql_compat
+
+`opentenbase_mysql_compat` is an opt-in compatibility extension for teams
+migrating SQL from MySQL to OpenTenBase.  It provides commonly used MySQL
+scalar and aggregate functions without changing the OpenTenBase parser or the
+semantics of built-in PostgreSQL functions.
+
+The functions live in the `mysql` schema.  Applications can either qualify
+calls explicitly (`mysql.find_in_set(...)`) or add `mysql` to `search_path`
+for a controlled migration period.
+
+## Design goals
+
+- Preserve MySQL NULL and out-of-range behavior where it commonly differs
+  from PostgreSQL.
+- Keep the compatibility layer isolated and removable with `DROP EXTENSION`.
+- Avoid network access, background workers, superuser-only hooks, and external
+  dependencies.
+- Make every helper immutable or stable when its result permits it, so the
+  optimizer can fold constants and use the functions in expression indexes.
+- Cover migration-heavy string, date/time, numeric, flow-control, and aggregate
+  functions with deterministic regression assertions.
+
+## Build and install
+
+The extension is part of the top-level `contrib` build:
+
+```sh
+./configure --prefix=/path/to/opentenbase
+make -C contrib/opentenbase_mysql_compat
+make -C contrib/opentenbase_mysql_compat install
+```
+
+It can also be built against an installed OpenTenBase tree with PGXS:
+
+```sh
+cd contrib/opentenbase_mysql_compat
+make USE_PGXS=1 PG_CONFIG=/path/to/pg_config
+make USE_PGXS=1 PG_CONFIG=/path/to/pg_config install
+```
+
+Enable it in each database that needs the compatibility layer:
+
+```sql
+CREATE EXTENSION opentenbase_mysql_compat;
+```
+
+No shared library preload or server restart is required.
+
+## Function catalog
+
+### Flow control
+
+| Function | Behavior |
+| --- | --- |
+| `mysql.ifnull(a, b)` | Returns `b` when `a` is NULL. |
+| `mysql.nullif_mysql(a, b)` | MySQL-compatible alias for `NULLIF`. |
+| `mysql.mysql_if(test, a, b)` | Chooses `a` or `b`; a NULL condition follows SQL CASE behavior. |
+| `mysql.if_true(test, a, b)` | Treats a NULL condition as false explicitly. |
+
+The arguments of polymorphic functions must resolve to the same OpenTenBase
+type.  Cast untyped NULL literals when necessary:
+
+```sql
+SELECT mysql.ifnull(NULL::integer, 42);
+```
+
+### Strings and base conversion
+
+| Function | Notes |
+| --- | --- |
+| `mysql.concat(VARIADIC text[])` | Returns NULL when any value is NULL. |
+| `mysql.concat_ws(separator, VARIADIC text[])` | Skips NULL values. |
+| `mysql.elt(n, VARIADIC text[])` | One-based selection; invalid indexes return NULL. |
+| `mysql.field(value, VARIADIC text[])` | One-based lookup; returns zero when absent. |
+| `mysql.find_in_set(value, csv)` | Finds a value in a comma-separated list. |
+| `mysql.insert_string(text, pos, len, replacement)` | Replaces a one-based substring. |
+| `mysql.substring_index(text, delimiter, count)` | Keeps fields from the left or right. |
+| `mysql.make_set(bits, VARIADIC text[])` | Selects non-NULL values using a bit mask. |
+| `mysql.export_set(bits, on, off, separator, count)` | Renders a bit mask as labels. |
+| `mysql.space(count)` | Returns a string containing `count` spaces. |
+| `mysql.strcmp(left, right)` | Returns -1, 0, or 1. |
+| `mysql.quote(text)` | Escapes a value for a MySQL-style quoted literal. |
+| `mysql.hex(text)` / `mysql.hex(bytea)` | Produces uppercase hexadecimal text. |
+| `mysql.unhex(text)` | Decodes hexadecimal text; invalid input returns NULL. |
+| `mysql.conv(text, from_base, to_base)` | Converts bases from 2 through 36. |
+| `mysql.bin(bigint)` | Converts decimal to base 2. |
+| `mysql.oct(bigint)` | Converts decimal to base 8. |
+
+`mysql.conv` accepts an optional leading sign and consumes valid digits until
+the first invalid digit, matching the migration behavior expected by MySQL
+applications.  Negative output is requested with a negative destination base.
+The implementation uses `numeric` internally so conversion is not restricted
+to signed 64-bit intermediate values.
+
+### Numeric functions
+
+| Function | Notes |
+| --- | --- |
+| `mysql.truncate(value, places)` | Truncates toward zero, including negative places. |
+| `mysql.format(value, places)` | Rounds and emits grouped decimal text. |
+| `mysql.sign(value)` | Returns -1, 0, or 1. |
+| `mysql.log2(value)` | Returns NULL for non-positive input. |
+| `mysql.log10(value)` | Returns NULL for non-positive input. |
+| `mysql.radians(value)` | Converts degrees to radians. |
+| `mysql.degrees(value)` | Converts radians to degrees. |
+
+Formatting follows the active locale's numeric grouping characters, as
+OpenTenBase `to_char` does.  Applications requiring a fixed presentation
+locale should set `lc_numeric` for their session.
+
+### Date and time
+
+| Function | Notes |
+| --- | --- |
+| `mysql.datediff(end, start)` | Counts calendar days and ignores time. |
+| `mysql.last_day(date)` | Returns the final day of the month. |
+| `mysql.dayofweek(date)` | Sunday is 1 and Saturday is 7. |
+| `mysql.weekday(date)` | Monday is 0 and Sunday is 6. |
+| `mysql.dayofyear(date)` | Returns 1 through 366. |
+| `mysql.quarter(date)` | Returns 1 through 4. |
+| `mysql.weekofyear(date)` | Returns the ISO week number. |
+| `mysql.unix_timestamp(ts)` | Returns seconds from the Unix epoch. |
+| `mysql.from_unixtime(seconds)` | Converts epoch seconds to timestamptz. |
+| `mysql.timestampdiff(unit, start, end)` | Counts complete requested units. |
+| `mysql.timestampadd(unit, count, ts)` | Adds the requested units. |
+| `mysql.adddate(date, days)` | Adds calendar days. |
+| `mysql.subdate(date, days)` | Subtracts calendar days. |
+| `mysql.period_add(period, months)` | Adds months to a `YYYYMM` or `YYMM` period. |
+| `mysql.period_diff(a, b)` | Returns the month difference between periods. |
+| `mysql.date_format(ts, format)` | Formats common MySQL percent tokens. |
+| `mysql.str_to_date(text, format)` | Parses common MySQL date/time formats. |
+
+Supported interval units are `MICROSECOND`, `SECOND`, `MINUTE`, `HOUR`, `DAY`,
+`WEEK`, `MONTH`, `QUARTER`, and `YEAR`.  An unsupported unit raises SQLSTATE
+`22023` instead of silently returning a misleading result.
+
+`date_format` supports these tokens:
+
+| Tokens | Meaning |
+| --- | --- |
+| `%Y`, `%y` | Four- and two-digit years. |
+| `%M`, `%b`, `%m`, `%c` | Month name, abbreviation, padded and unpadded number. |
+| `%D`, `%d`, `%e`, `%j` | Ordinal day, day of month, and day of year. |
+| `%H`, `%k`, `%h`, `%I`, `%l` | 24-hour and 12-hour representations. |
+| `%i`, `%s`, `%S`, `%f`, `%p` | Minute, second, microsecond, and AM/PM. |
+| `%r`, `%T` | 12-hour and 24-hour complete times. |
+| `%W`, `%a`, `%w` | Weekday name, abbreviation, and Sunday-based index. |
+| `%U`, `%u`, `%V`, `%v`, `%X`, `%x` | Week and ISO week-year forms. |
+| `%%` | Literal percent sign. |
+
+`str_to_date` supports the common numeric, named-month, and time tokens.  It
+returns NULL for invalid date text rather than exposing a backend exception.
+
+### Aggregates
+
+| Aggregate | Behavior |
+| --- | --- |
+| `mysql.group_concat(text)` | Concatenates non-NULL values with commas. |
+| `mysql.bit_xor(bigint)` | Computes bitwise XOR and returns zero for no values. |
+| `mysql.any_value(anyelement)` | Returns the first non-NULL value observed. |
+
+OpenTenBase aggregate syntax can still control input order and duplicates:
+
+```sql
+SELECT mysql.group_concat(DISTINCT name ORDER BY name)
+FROM customer;
+```
+
+## Migration example
+
+Original MySQL query:
+
+```sql
+SELECT
+    IFNULL(region, 'unknown') AS region,
+    GROUP_CONCAT(DISTINCT customer_name ORDER BY customer_name) AS customers,
+    DATE_FORMAT(MAX(created_at), '%Y-%m-%d') AS latest_day
+FROM orders
+GROUP BY IFNULL(region, 'unknown');
+```
+
+OpenTenBase query with this extension:
+
+```sql
+SELECT
+    mysql.ifnull(region, 'unknown') AS region,
+    mysql.group_concat(DISTINCT customer_name ORDER BY customer_name) AS customers,
+    mysql.date_format(MAX(created_at), '%Y-%m-%d') AS latest_day
+FROM orders
+GROUP BY mysql.ifnull(region, 'unknown');
+```
+
+## Deliberate boundaries
+
+This extension does not change parser syntax, implicit cast precedence,
+collation rules, SQL modes, or storage behavior.  It does not emulate MySQL
+functions whose semantics require those global changes.  String comparison
+uses the collation of the arguments, and timestamp results follow the session
+time zone where a `timestamptz` is involved.
+
+The compatibility schema is not added to `search_path` automatically.  This
+avoids shadowing built-in functions in databases that do not need MySQL
+compatibility.
+
+## Test
+
+Run the extension regression test from a configured source tree:
+
+```sh
+make -C contrib/opentenbase_mysql_compat check
+```
+
+The test installs the extension, executes deterministic assertions across all
+function families (including NULL and boundary cases), checks aggregates, and
+then removes the extension.

--- a/contrib/opentenbase_mysql_compat/expected/opentenbase_mysql_compat.out
+++ b/contrib/opentenbase_mysql_compat/expected/opentenbase_mysql_compat.out
@@ -1,0 +1,213 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) 2026 OpenTenBase Contributors
+ *
+ * This file is licensed under the same terms as OpenTenBase. See LICENSE.txt
+ * in the repository root for details.
+ *-------------------------------------------------------------------------
+ */
+
+CREATE EXTENSION opentenbase_mysql_compat;
+
+DO $test$
+DECLARE
+    text_result text;
+    integer_result integer;
+    bigint_result bigint;
+    numeric_result numeric;
+    timestamp_result timestamp;
+BEGIN
+    IF mysql.ifnull(NULL::integer, 7) <> 7 THEN
+        RAISE EXCEPTION 'ifnull NULL case failed';
+    END IF;
+    IF mysql.ifnull(4, 7) <> 4 THEN
+        RAISE EXCEPTION 'ifnull value case failed';
+    END IF;
+    IF mysql.nullif_mysql(4, 4) IS NOT NULL THEN
+        RAISE EXCEPTION 'nullif equal case failed';
+    END IF;
+    IF mysql.mysql_if(true, 'yes'::text, 'no'::text) <> 'yes' THEN
+        RAISE EXCEPTION 'mysql_if true case failed';
+    END IF;
+    IF mysql.if_true(NULL, 'yes'::text, 'no'::text) <> 'no' THEN
+        RAISE EXCEPTION 'if_true NULL case failed';
+    END IF;
+
+    IF mysql.concat('a', 'b', 'c') <> 'abc' THEN
+        RAISE EXCEPTION 'concat normal case failed';
+    END IF;
+    IF mysql.concat('a', NULL, 'c') IS NOT NULL THEN
+        RAISE EXCEPTION 'concat NULL case failed';
+    END IF;
+    IF mysql.concat_ws('-', 'a', NULL, 'c') <> 'a-c' THEN
+        RAISE EXCEPTION 'concat_ws NULL skipping failed';
+    END IF;
+    IF mysql.elt(2, 'red', 'green', 'blue') <> 'green' THEN
+        RAISE EXCEPTION 'elt selection failed';
+    END IF;
+    IF mysql.elt(0, 'red', 'green') IS NOT NULL THEN
+        RAISE EXCEPTION 'elt boundary failed';
+    END IF;
+    IF mysql.field('green', 'red', 'green', 'blue') <> 2 THEN
+        RAISE EXCEPTION 'field match failed';
+    END IF;
+    IF mysql.field('missing', 'red', 'green') <> 0 THEN
+        RAISE EXCEPTION 'field miss failed';
+    END IF;
+    IF mysql.find_in_set('b', 'a,b,c') <> 2 THEN
+        RAISE EXCEPTION 'find_in_set match failed';
+    END IF;
+    IF mysql.find_in_set('x', 'a,b,c') <> 0 THEN
+        RAISE EXCEPTION 'find_in_set miss failed';
+    END IF;
+    IF mysql.insert_string('Quadratic', 3, 4, 'What') <> 'QuWhattic' THEN
+        RAISE EXCEPTION 'insert_string replacement failed';
+    END IF;
+    IF mysql.insert_string('abc', 9, 1, 'x') <> 'abc' THEN
+        RAISE EXCEPTION 'insert_string boundary failed';
+    END IF;
+    IF mysql.substring_index('www.mysql.com', '.', 2) <> 'www.mysql' THEN
+        RAISE EXCEPTION 'substring_index positive failed';
+    END IF;
+    IF mysql.substring_index('www.mysql.com', '.', -2) <> 'mysql.com' THEN
+        RAISE EXCEPTION 'substring_index negative failed';
+    END IF;
+    IF mysql.make_set(5, 'a', 'b', 'c') <> 'a,c' THEN
+        RAISE EXCEPTION 'make_set failed';
+    END IF;
+    IF mysql.export_set(5, 'Y', 'N', '', 4) <> 'YNYN' THEN
+        RAISE EXCEPTION 'export_set failed';
+    END IF;
+    IF char_length(mysql.space(5)) <> 5 THEN
+        RAISE EXCEPTION 'space failed';
+    END IF;
+    IF mysql.strcmp('a', 'b') <> -1 OR mysql.strcmp('b', 'b') <> 0 THEN
+        RAISE EXCEPTION 'strcmp failed';
+    END IF;
+    IF mysql.unhex('4D7953514C') <> convert_to('MySQL', 'UTF8') THEN
+        RAISE EXCEPTION 'unhex failed';
+    END IF;
+    IF mysql.unhex('not-hex') IS NOT NULL THEN
+        RAISE EXCEPTION 'unhex invalid input failed';
+    END IF;
+    IF mysql.hex('MySQL') <> '4D7953514C' THEN
+        RAISE EXCEPTION 'hex failed';
+    END IF;
+    IF mysql.conv('FF', 16, 10) <> '255' THEN
+        RAISE EXCEPTION 'conv hexadecimal failed';
+    END IF;
+    IF mysql.conv('101010', 2, 36) <> '16' THEN
+        RAISE EXCEPTION 'conv binary failed';
+    END IF;
+    IF mysql.bin(10) <> '1010' OR mysql.oct(10) <> '12' THEN
+        RAISE EXCEPTION 'bin or oct failed';
+    END IF;
+
+    IF mysql.truncate(123.4567, 2) <> 123.45 THEN
+        RAISE EXCEPTION 'truncate positive places failed';
+    END IF;
+    IF mysql.truncate(123.4567, -2) <> 100 THEN
+        RAISE EXCEPTION 'truncate negative places failed';
+    END IF;
+    IF mysql.sign(-1.5) <> -1 OR mysql.sign(0) <> 0 OR mysql.sign(2) <> 1 THEN
+        RAISE EXCEPTION 'sign failed';
+    END IF;
+    IF abs(mysql.log2(8) - 3) > 0.0000001 THEN
+        RAISE EXCEPTION 'log2 failed';
+    END IF;
+    IF mysql.log10(-1) IS NOT NULL THEN
+        RAISE EXCEPTION 'log10 domain handling failed';
+    END IF;
+    IF abs(mysql.degrees(pi()) - 180) > 0.0000001 THEN
+        RAISE EXCEPTION 'degrees failed';
+    END IF;
+    IF abs(mysql.radians(180) - pi()) > 0.0000001 THEN
+        RAISE EXCEPTION 'radians failed';
+    END IF;
+
+    IF mysql.datediff(DATE '2026-03-10', DATE '2026-03-01') <> 9 THEN
+        RAISE EXCEPTION 'datediff failed';
+    END IF;
+    IF mysql.last_day(DATE '2024-02-11') <> DATE '2024-02-29' THEN
+        RAISE EXCEPTION 'last_day leap year failed';
+    END IF;
+    IF mysql.dayofweek(DATE '2026-07-19') <> 1 THEN
+        RAISE EXCEPTION 'dayofweek failed';
+    END IF;
+    IF mysql.weekday(DATE '2026-07-20') <> 0 THEN
+        RAISE EXCEPTION 'weekday failed';
+    END IF;
+    IF mysql.dayofyear(DATE '2024-12-31') <> 366 THEN
+        RAISE EXCEPTION 'dayofyear failed';
+    END IF;
+    IF mysql.quarter(DATE '2026-10-01') <> 4 THEN
+        RAISE EXCEPTION 'quarter failed';
+    END IF;
+    IF mysql.timestampdiff('SECOND', TIMESTAMP '2026-01-01 00:00:00',
+                           TIMESTAMP '2026-01-01 00:01:05') <> 65 THEN
+        RAISE EXCEPTION 'timestampdiff seconds failed';
+    END IF;
+    IF mysql.timestampdiff('MONTH', TIMESTAMP '2025-01-31',
+                           TIMESTAMP '2025-03-30') <> 1 THEN
+        RAISE EXCEPTION 'timestampdiff complete months failed';
+    END IF;
+    IF mysql.timestampadd('DAY', 3, TIMESTAMP '2026-01-01') <>
+       TIMESTAMP '2026-01-04' THEN
+        RAISE EXCEPTION 'timestampadd day failed';
+    END IF;
+    IF mysql.timestampadd('QUARTER', 1, TIMESTAMP '2026-01-31') <>
+       TIMESTAMP '2026-04-30' THEN
+        RAISE EXCEPTION 'timestampadd quarter failed';
+    END IF;
+    IF mysql.adddate(DATE '2026-01-01', 2) <> DATE '2026-01-03' THEN
+        RAISE EXCEPTION 'adddate failed';
+    END IF;
+    IF mysql.subdate(DATE '2026-01-03', 2) <> DATE '2026-01-01' THEN
+        RAISE EXCEPTION 'subdate failed';
+    END IF;
+    IF mysql.period_add(202601, 2) <> 202603 THEN
+        RAISE EXCEPTION 'period_add failed';
+    END IF;
+    IF mysql.period_diff(202603, 202512) <> 3 THEN
+        RAISE EXCEPTION 'period_diff failed';
+    END IF;
+    IF mysql.date_format(TIMESTAMP '2026-07-18 13:04:05.123456',
+                         '%Y-%m-%d %H:%i:%s.%f') <>
+       '2026-07-18 13:04:05.123456' THEN
+        RAISE EXCEPTION 'date_format failed';
+    END IF;
+    IF mysql.date_format(TIMESTAMP '2026-01-21', '%D') <> '21st' THEN
+        RAISE EXCEPTION 'date_format ordinal failed';
+    END IF;
+    IF mysql.str_to_date('2026-07-18 13:04:05',
+                         '%Y-%m-%d %H:%i:%s') <>
+       TIMESTAMP '2026-07-18 13:04:05' THEN
+        RAISE EXCEPTION 'str_to_date failed';
+    END IF;
+    IF mysql.str_to_date('not a date', '%Y-%m-%d') IS NOT NULL THEN
+        RAISE EXCEPTION 'str_to_date invalid input failed';
+    END IF;
+
+    SELECT mysql.group_concat(value ORDER BY value)
+    INTO text_result
+    FROM (VALUES ('c'::text), ('a'), (NULL), ('b')) AS input(value);
+    IF text_result <> 'a,b,c' THEN
+        RAISE EXCEPTION 'group_concat failed: %', text_result;
+    END IF;
+
+    SELECT mysql.bit_xor(value)
+    INTO bigint_result
+    FROM (VALUES (1::bigint), (3::bigint), (7::bigint)) AS input(value);
+    IF bigint_result <> 5 THEN
+        RAISE EXCEPTION 'bit_xor failed: %', bigint_result;
+    END IF;
+
+    SELECT mysql.any_value(value)
+    INTO integer_result
+    FROM (VALUES (NULL::integer), (4), (9)) AS input(value);
+    IF integer_result <> 4 THEN
+        RAISE EXCEPTION 'any_value failed: %', integer_result;
+    END IF;
+END;
+$test$;
+
+DROP EXTENSION opentenbase_mysql_compat;

--- a/contrib/opentenbase_mysql_compat/opentenbase_mysql_compat--1.0.sql
+++ b/contrib/opentenbase_mysql_compat/opentenbase_mysql_compat--1.0.sql
@@ -1,0 +1,948 @@
+/*-------------------------------------------------------------------------
+ *
+ * opentenbase_mysql_compat--1.0.sql
+ *    MySQL-compatible functions intended to reduce migration rewrites.
+ *
+ * Copyright (c) 2026 OpenTenBase Contributors
+ *
+ * This file is licensed under the same terms as OpenTenBase. See LICENSE.txt
+ * in the repository root for details.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+\echo Use "CREATE EXTENSION opentenbase_mysql_compat" to load this file. \quit
+
+/*
+ * The extension is deliberately implemented in SQL and PL/pgSQL.  Keeping
+ * the compatibility layer outside the backend avoids parser changes and
+ * lets administrators opt in per database.  Callers should qualify names
+ * with mysql., or add mysql to search_path during a migration window.
+ */
+
+CREATE SCHEMA mysql;
+
+/* -------------------------------------------------------------------------
+ * Polymorphic flow-control functions
+ * -------------------------------------------------------------------------
+ */
+
+CREATE FUNCTION mysql.ifnull(anyelement, anyelement)
+RETURNS anyelement
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT COALESCE($1, $2)';
+
+CREATE FUNCTION mysql.nullif_mysql(anyelement, anyelement)
+RETURNS anyelement
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT NULLIF($1, $2)';
+
+CREATE FUNCTION mysql.mysql_if(boolean, anyelement, anyelement)
+RETURNS anyelement
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT CASE WHEN $1 THEN $2 ELSE $3 END';
+
+CREATE FUNCTION mysql.if_true(boolean, anyelement, anyelement)
+RETURNS anyelement
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT CASE WHEN COALESCE($1, false) THEN $2 ELSE $3 END';
+
+/* -------------------------------------------------------------------------
+ * String functions
+ * -------------------------------------------------------------------------
+ */
+
+CREATE FUNCTION mysql.concat(VARIADIC items text[])
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    value text;
+    result text := '';
+BEGIN
+    IF items IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    FOREACH value IN ARRAY items LOOP
+        IF value IS NULL THEN
+            RETURN NULL;
+        END IF;
+        result := result || value;
+    END LOOP;
+
+    RETURN result;
+END;
+$$;
+
+CREATE FUNCTION mysql.concat_ws(separator text, VARIADIC items text[])
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    value text;
+    result text := '';
+    have_value boolean := false;
+BEGIN
+    IF separator IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    IF items IS NULL THEN
+        RETURN '';
+    END IF;
+
+    FOREACH value IN ARRAY items LOOP
+        IF value IS NULL THEN
+            CONTINUE;
+        END IF;
+        IF have_value THEN
+            result := result || separator;
+        END IF;
+        result := result || value;
+        have_value := true;
+    END LOOP;
+
+    RETURN result;
+END;
+$$;
+
+CREATE FUNCTION mysql.elt(item_index integer, VARIADIC items text[])
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT CASE
+        WHEN $1 IS NULL OR $2 IS NULL OR $1 < 1 OR $1 > cardinality($2)
+            THEN NULL
+        ELSE $2[$1]
+    END
+$$;
+
+CREATE FUNCTION mysql.field(needle text, VARIADIC items text[])
+RETURNS integer
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    index integer;
+BEGIN
+    IF needle IS NULL OR items IS NULL THEN
+        RETURN 0;
+    END IF;
+
+    FOR index IN 1 .. cardinality(items) LOOP
+        IF items[index] = needle THEN
+            RETURN index;
+        END IF;
+    END LOOP;
+
+    RETURN 0;
+END;
+$$;
+
+CREATE FUNCTION mysql.find_in_set(needle text, comma_list text)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT CASE
+        WHEN $1 IS NULL OR $2 IS NULL THEN NULL
+        WHEN strpos($1, ',') > 0 THEN 0
+        ELSE COALESCE(array_position(string_to_array($2, ','), $1), 0)
+    END
+$$;
+
+CREATE FUNCTION mysql.insert_string(source text, start_position integer,
+                                    characters integer, replacement text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT CASE
+        WHEN $1 IS NULL OR $2 IS NULL OR $3 IS NULL OR $4 IS NULL THEN NULL
+        WHEN $2 < 1 OR $2 > char_length($1) THEN $1
+        WHEN $3 < 0 THEN $1
+        ELSE overlay($1 placing $4 from $2 for $3)
+    END
+$$;
+
+CREATE FUNCTION mysql.substring_index(source text, delimiter text,
+                                      occurrence integer)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    parts text[];
+    part_count integer;
+BEGIN
+    IF source IS NULL OR delimiter IS NULL OR occurrence IS NULL THEN
+        RETURN NULL;
+    END IF;
+    IF delimiter = '' OR occurrence = 0 THEN
+        RETURN '';
+    END IF;
+
+    parts := string_to_array(source, delimiter);
+    part_count := cardinality(parts);
+
+    IF abs(occurrence) >= part_count THEN
+        RETURN source;
+    ELSIF occurrence > 0 THEN
+        RETURN array_to_string(parts[1:occurrence], delimiter);
+    ELSE
+        RETURN array_to_string(parts[(part_count + occurrence + 1):part_count],
+                               delimiter);
+    END IF;
+END;
+$$;
+
+CREATE FUNCTION mysql.make_set(bits bigint, VARIADIC items text[])
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    index integer;
+    selected text[] := ARRAY[]::text[];
+BEGIN
+    IF bits IS NULL OR items IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    FOR index IN 1 .. LEAST(cardinality(items), 63) LOOP
+        IF (bits & (1::bigint << (index - 1))) <> 0
+           AND items[index] IS NOT NULL THEN
+            selected := array_append(selected, items[index]);
+        END IF;
+    END LOOP;
+
+    RETURN array_to_string(selected, ',');
+END;
+$$;
+
+CREATE FUNCTION mysql.export_set(bits bigint, on_value text, off_value text,
+                                 separator text DEFAULT ',',
+                                 bit_count integer DEFAULT 64)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    index integer;
+    result text := '';
+BEGIN
+    IF bits IS NULL OR on_value IS NULL OR off_value IS NULL
+       OR separator IS NULL OR bit_count IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    bit_count := GREATEST(0, LEAST(bit_count, 64));
+    FOR index IN 0 .. bit_count - 1 LOOP
+        IF index > 0 THEN
+            result := result || separator;
+        END IF;
+        IF (bits & (1::bigint << index)) <> 0 THEN
+            result := result || on_value;
+        ELSE
+            result := result || off_value;
+        END IF;
+    END LOOP;
+
+    RETURN result;
+END;
+$$;
+
+CREATE FUNCTION mysql.space(character_count integer)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT CASE WHEN $1 IS NULL THEN NULL ELSE repeat('' '', GREATEST($1, 0)) END';
+
+CREATE FUNCTION mysql.strcmp(left_value text, right_value text)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT CASE
+        WHEN $1 IS NULL OR $2 IS NULL THEN NULL
+        WHEN $1 < $2 THEN -1
+        WHEN $1 > $2 THEN 1
+        ELSE 0
+    END
+$$;
+
+CREATE FUNCTION mysql.quote(source text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    IF source IS NULL THEN
+        RETURN 'NULL';
+    END IF;
+
+    RETURN '''' ||
+           replace(
+             replace(
+               replace(source, E'\\', E'\\\\'),
+               E'\032', E'\\Z'),
+             '''', E'\\''') ||
+           '''';
+END;
+$$;
+
+CREATE FUNCTION mysql.unhex(source text)
+RETURNS bytea
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    IF source IS NULL THEN
+        RETURN NULL;
+    END IF;
+    IF source !~ '^[0-9A-Fa-f]*$' THEN
+        RETURN NULL;
+    END IF;
+    IF length(source) % 2 = 1 THEN
+        source := '0' || source;
+    END IF;
+    RETURN decode(source, 'hex');
+END;
+$$;
+
+CREATE FUNCTION mysql.hex(source bytea)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT upper(encode($1, ''hex''))';
+
+CREATE FUNCTION mysql.hex(source text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT upper(encode(convert_to($1, ''UTF8''), ''hex''))';
+
+CREATE FUNCTION mysql._digit_value(digit text)
+RETURNS integer
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+DECLARE
+    code integer := ascii(upper(digit));
+BEGIN
+    IF code BETWEEN ascii('0') AND ascii('9') THEN
+        RETURN code - ascii('0');
+    ELSIF code BETWEEN ascii('A') AND ascii('Z') THEN
+        RETURN code - ascii('A') + 10;
+    END IF;
+    RETURN -1;
+END;
+$$;
+
+CREATE FUNCTION mysql._digit_character(value integer)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+    SELECT CASE
+        WHEN $1 BETWEEN 0 AND 9 THEN chr(ascii('0') + $1)
+        WHEN $1 BETWEEN 10 AND 35 THEN chr(ascii('A') + $1 - 10)
+        ELSE NULL
+    END
+$$;
+
+CREATE FUNCTION mysql.conv(source text, from_base integer, to_base integer)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    input_base integer := abs(from_base);
+    output_base integer := abs(to_base);
+    source_index integer := 1;
+    digit integer;
+    accumulator numeric := 0;
+    negative boolean := false;
+    result text := '';
+    remainder integer;
+BEGIN
+    IF source IS NULL OR from_base IS NULL OR to_base IS NULL THEN
+        RETURN NULL;
+    END IF;
+    IF input_base < 2 OR input_base > 36
+       OR output_base < 2 OR output_base > 36 THEN
+        RETURN NULL;
+    END IF;
+
+    source := btrim(source);
+    IF left(source, 1) IN ('+', '-') THEN
+        negative := left(source, 1) = '-';
+        source_index := 2;
+    END IF;
+
+    WHILE source_index <= char_length(source) LOOP
+        digit := mysql._digit_value(substr(source, source_index, 1));
+        EXIT WHEN digit < 0 OR digit >= input_base;
+        accumulator := accumulator * input_base + digit;
+        source_index := source_index + 1;
+    END LOOP;
+
+    IF source_index = 1 OR (source_index = 2 AND left(source, 1) IN ('+', '-')) THEN
+        RETURN '0';
+    END IF;
+    IF accumulator = 0 THEN
+        RETURN '0';
+    END IF;
+
+    WHILE accumulator > 0 LOOP
+        remainder := mod(accumulator, output_base)::integer;
+        result := mysql._digit_character(remainder) || result;
+        accumulator := trunc(accumulator / output_base);
+    END LOOP;
+
+    IF negative AND to_base < 0 THEN
+        result := '-' || result;
+    END IF;
+    RETURN result;
+END;
+$$;
+
+CREATE FUNCTION mysql.bin(value bigint)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT mysql.conv($1::text, 10, 2)';
+
+CREATE FUNCTION mysql.oct(value bigint)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT mysql.conv($1::text, 10, 8)';
+
+/* -------------------------------------------------------------------------
+ * Numeric functions
+ * -------------------------------------------------------------------------
+ */
+
+CREATE FUNCTION mysql.truncate(value numeric, decimal_places integer)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT CASE
+        WHEN $1 IS NULL OR $2 IS NULL THEN NULL
+        WHEN $2 >= 0 THEN trunc($1, $2)
+        ELSE trunc($1 / power(10::numeric, -$2)) * power(10::numeric, -$2)
+    END
+$$;
+
+CREATE FUNCTION mysql.format(value numeric, decimal_places integer)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    places integer;
+    pattern text;
+BEGIN
+    IF value IS NULL OR decimal_places IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    places := GREATEST(decimal_places, 0);
+    pattern := 'FM999G999G999G999G999G999G990';
+    IF places > 0 THEN
+        pattern := pattern || 'D' || repeat('0', places);
+    END IF;
+    RETURN to_char(round(value, places), pattern);
+END;
+$$;
+
+CREATE FUNCTION mysql.sign(value numeric)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT CASE WHEN $1 IS NULL THEN NULL
+                WHEN $1 < 0 THEN -1
+                WHEN $1 > 0 THEN 1
+                ELSE 0 END
+$$;
+
+CREATE FUNCTION mysql.log2(value double precision)
+RETURNS double precision
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT CASE WHEN $1 > 0 THEN ln($1) / ln(2.0) ELSE NULL END';
+
+CREATE FUNCTION mysql.log10(value double precision)
+RETURNS double precision
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT CASE WHEN $1 > 0 THEN log($1) ELSE NULL END';
+
+CREATE FUNCTION mysql.radians(value double precision)
+RETURNS double precision
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT $1 * pi() / 180.0';
+
+CREATE FUNCTION mysql.degrees(value double precision)
+RETURNS double precision
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT $1 * 180.0 / pi()';
+
+/* -------------------------------------------------------------------------
+ * Date and time functions
+ * -------------------------------------------------------------------------
+ */
+
+CREATE FUNCTION mysql.datediff(end_date date, start_date date)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT $1 - $2';
+
+CREATE FUNCTION mysql.last_day(value date)
+RETURNS date
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT (date_trunc('month', $1::timestamp) + interval '1 month - 1 day')::date
+$$;
+
+CREATE FUNCTION mysql.dayofweek(value date)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT extract(dow FROM $1)::integer + 1';
+
+CREATE FUNCTION mysql.weekday(value date)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT extract(isodow FROM $1)::integer - 1';
+
+CREATE FUNCTION mysql.dayofyear(value date)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT extract(doy FROM $1)::integer';
+
+CREATE FUNCTION mysql.quarter(value date)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT extract(quarter FROM $1)::integer';
+
+CREATE FUNCTION mysql.weekofyear(value date)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT extract(week FROM $1)::integer';
+
+CREATE FUNCTION mysql.unix_timestamp(value timestamp with time zone DEFAULT now())
+RETURNS numeric
+LANGUAGE sql
+STABLE
+PARALLEL SAFE
+AS 'SELECT extract(epoch FROM $1)::numeric';
+
+CREATE FUNCTION mysql.from_unixtime(value numeric)
+RETURNS timestamp with time zone
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT to_timestamp($1::double precision)';
+
+CREATE FUNCTION mysql.timestampdiff(unit_name text, start_value timestamp,
+                                    end_value timestamp)
+RETURNS bigint
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    seconds numeric;
+    months integer;
+BEGIN
+    IF unit_name IS NULL OR start_value IS NULL OR end_value IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    seconds := extract(epoch FROM end_value - start_value);
+    CASE upper(unit_name)
+        WHEN 'MICROSECOND' THEN RETURN trunc(seconds * 1000000)::bigint;
+        WHEN 'SECOND' THEN RETURN trunc(seconds)::bigint;
+        WHEN 'MINUTE' THEN RETURN trunc(seconds / 60)::bigint;
+        WHEN 'HOUR' THEN RETURN trunc(seconds / 3600)::bigint;
+        WHEN 'DAY' THEN RETURN trunc(seconds / 86400)::bigint;
+        WHEN 'WEEK' THEN RETURN trunc(seconds / 604800)::bigint;
+        WHEN 'MONTH' THEN
+            months := (extract(year FROM end_value)::integer -
+                       extract(year FROM start_value)::integer) * 12 +
+                      extract(month FROM end_value)::integer -
+                      extract(month FROM start_value)::integer;
+            IF end_value < start_value + make_interval(months => months) THEN
+                months := months - 1;
+            END IF;
+            RETURN months;
+        WHEN 'QUARTER' THEN
+            RETURN mysql.timestampdiff('MONTH', start_value, end_value) / 3;
+        WHEN 'YEAR' THEN
+            RETURN mysql.timestampdiff('MONTH', start_value, end_value) / 12;
+        ELSE
+            RAISE EXCEPTION 'unsupported TIMESTAMPDIFF unit: %', unit_name
+                USING ERRCODE = '22023';
+    END CASE;
+END;
+$$;
+
+CREATE FUNCTION mysql.timestampadd(unit_name text, interval_count bigint,
+                                   source timestamp)
+RETURNS timestamp
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    IF unit_name IS NULL OR interval_count IS NULL OR source IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    CASE upper(unit_name)
+        WHEN 'MICROSECOND' THEN
+            RETURN source + interval_count * interval '1 microsecond';
+        WHEN 'SECOND' THEN
+            RETURN source + interval_count * interval '1 second';
+        WHEN 'MINUTE' THEN
+            RETURN source + interval_count * interval '1 minute';
+        WHEN 'HOUR' THEN
+            RETURN source + interval_count * interval '1 hour';
+        WHEN 'DAY' THEN
+            RETURN source + interval_count * interval '1 day';
+        WHEN 'WEEK' THEN
+            RETURN source + interval_count * interval '1 week';
+        WHEN 'MONTH' THEN
+            RETURN source + make_interval(months => interval_count::integer);
+        WHEN 'QUARTER' THEN
+            RETURN source + make_interval(months => (interval_count * 3)::integer);
+        WHEN 'YEAR' THEN
+            RETURN source + make_interval(years => interval_count::integer);
+        ELSE
+            RAISE EXCEPTION 'unsupported TIMESTAMPADD unit: %', unit_name
+                USING ERRCODE = '22023';
+    END CASE;
+END;
+$$;
+
+CREATE FUNCTION mysql.adddate(source date, day_count integer)
+RETURNS date
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT $1 + $2';
+
+CREATE FUNCTION mysql.subdate(source date, day_count integer)
+RETURNS date
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT $1 - $2';
+
+CREATE FUNCTION mysql.period_add(period_value integer, month_count integer)
+RETURNS integer
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    year_value integer;
+    month_value integer;
+    absolute_month integer;
+BEGIN
+    IF period_value IS NULL OR month_count IS NULL THEN
+        RETURN NULL;
+    END IF;
+    year_value := period_value / 100;
+    month_value := period_value % 100;
+    IF month_value NOT BETWEEN 1 AND 12 THEN
+        RETURN NULL;
+    END IF;
+    IF year_value BETWEEN 0 AND 69 THEN
+        year_value := year_value + 2000;
+    ELSIF year_value BETWEEN 70 AND 99 THEN
+        year_value := year_value + 1900;
+    END IF;
+    absolute_month := year_value * 12 + month_value - 1 + month_count;
+    RETURN (absolute_month / 12) * 100 + (absolute_month % 12) + 1;
+END;
+$$;
+
+CREATE FUNCTION mysql.period_diff(first_period integer, second_period integer)
+RETURNS integer
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    first_normalized integer;
+    second_normalized integer;
+BEGIN
+    IF first_period IS NULL OR second_period IS NULL THEN
+        RETURN NULL;
+    END IF;
+    first_normalized := mysql.period_add(first_period, 0);
+    second_normalized := mysql.period_add(second_period, 0);
+    IF first_normalized IS NULL OR second_normalized IS NULL THEN
+        RETURN NULL;
+    END IF;
+    RETURN ((first_normalized / 100) * 12 + first_normalized % 100) -
+           ((second_normalized / 100) * 12 + second_normalized % 100);
+END;
+$$;
+
+CREATE FUNCTION mysql.date_format(source timestamp, format_string text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+DECLARE
+    index integer := 1;
+    token text;
+    result text := '';
+BEGIN
+    IF source IS NULL OR format_string IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    WHILE index <= char_length(format_string) LOOP
+        IF substr(format_string, index, 1) <> '%' THEN
+            result := result || substr(format_string, index, 1);
+            index := index + 1;
+            CONTINUE;
+        END IF;
+
+        index := index + 1;
+        IF index > char_length(format_string) THEN
+            result := result || '%';
+            EXIT;
+        END IF;
+        token := substr(format_string, index, 1);
+        CASE token
+            WHEN '%' THEN result := result || '%';
+            WHEN 'Y' THEN result := result || to_char(source, 'YYYY');
+            WHEN 'y' THEN result := result || to_char(source, 'YY');
+            WHEN 'M' THEN result := result || to_char(source, 'FMMonth');
+            WHEN 'b' THEN result := result || to_char(source, 'Mon');
+            WHEN 'm' THEN result := result || to_char(source, 'MM');
+            WHEN 'c' THEN result := result || to_char(source, 'FMMM');
+            WHEN 'D' THEN
+                result := result || extract(day FROM source)::integer::text ||
+                    CASE
+                        WHEN extract(day FROM source)::integer BETWEEN 11 AND 13
+                            THEN 'th'
+                        WHEN extract(day FROM source)::integer % 10 = 1 THEN 'st'
+                        WHEN extract(day FROM source)::integer % 10 = 2 THEN 'nd'
+                        WHEN extract(day FROM source)::integer % 10 = 3 THEN 'rd'
+                        ELSE 'th'
+                    END;
+            WHEN 'd' THEN result := result || to_char(source, 'DD');
+            WHEN 'e' THEN result := result || to_char(source, 'FMDD');
+            WHEN 'j' THEN result := result || to_char(source, 'DDD');
+            WHEN 'H' THEN result := result || to_char(source, 'HH24');
+            WHEN 'k' THEN result := result || to_char(source, 'FMHH24');
+            WHEN 'h' THEN result := result || to_char(source, 'HH12');
+            WHEN 'I' THEN result := result || to_char(source, 'HH12');
+            WHEN 'l' THEN result := result || to_char(source, 'FMHH12');
+            WHEN 'i' THEN result := result || to_char(source, 'MI');
+            WHEN 's' THEN result := result || to_char(source, 'SS');
+            WHEN 'S' THEN result := result || to_char(source, 'SS');
+            WHEN 'f' THEN result := result || to_char(source, 'US');
+            WHEN 'p' THEN result := result || to_char(source, 'AM');
+            WHEN 'r' THEN result := result || to_char(source, 'HH12:MI:SS AM');
+            WHEN 'T' THEN result := result || to_char(source, 'HH24:MI:SS');
+            WHEN 'W' THEN result := result || to_char(source, 'FMDay');
+            WHEN 'a' THEN result := result || to_char(source, 'Dy');
+            WHEN 'w' THEN
+                result := result || extract(dow FROM source)::integer::text;
+            WHEN 'U' THEN result := result || to_char(source, 'WW');
+            WHEN 'u' THEN result := result || to_char(source, 'IW');
+            WHEN 'V' THEN result := result || to_char(source, 'IW');
+            WHEN 'v' THEN result := result || to_char(source, 'IW');
+            WHEN 'X' THEN result := result || to_char(source, 'IYYY');
+            WHEN 'x' THEN result := result || to_char(source, 'IYYY');
+            ELSE result := result || token;
+        END CASE;
+        index := index + 1;
+    END LOOP;
+
+    RETURN result;
+END;
+$$;
+
+CREATE FUNCTION mysql._str_to_date_format(format_string text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+BEGIN
+    format_string := replace(format_string, '%Y', 'YYYY');
+    format_string := replace(format_string, '%y', 'YY');
+    format_string := replace(format_string, '%M', 'Month');
+    format_string := replace(format_string, '%b', 'Mon');
+    format_string := replace(format_string, '%m', 'MM');
+    format_string := replace(format_string, '%c', 'MM');
+    format_string := replace(format_string, '%d', 'DD');
+    format_string := replace(format_string, '%e', 'DD');
+    format_string := replace(format_string, '%j', 'DDD');
+    format_string := replace(format_string, '%H', 'HH24');
+    format_string := replace(format_string, '%k', 'HH24');
+    format_string := replace(format_string, '%h', 'HH12');
+    format_string := replace(format_string, '%I', 'HH12');
+    format_string := replace(format_string, '%l', 'HH12');
+    format_string := replace(format_string, '%i', 'MI');
+    format_string := replace(format_string, '%s', 'SS');
+    format_string := replace(format_string, '%S', 'SS');
+    format_string := replace(format_string, '%f', 'US');
+    format_string := replace(format_string, '%p', 'AM');
+    format_string := replace(format_string, '%T', 'HH24:MI:SS');
+    format_string := replace(format_string, '%r', 'HH12:MI:SS AM');
+    RETURN format_string;
+END;
+$$;
+
+CREATE FUNCTION mysql.str_to_date(source text, format_string text)
+RETURNS timestamp
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    IF source IS NULL OR format_string IS NULL THEN
+        RETURN NULL;
+    END IF;
+    RETURN to_timestamp(source, mysql._str_to_date_format(format_string))::timestamp;
+EXCEPTION
+    WHEN invalid_datetime_format OR datetime_field_overflow THEN
+        RETURN NULL;
+END;
+$$;
+
+/* -------------------------------------------------------------------------
+ * Aggregate helpers
+ * -------------------------------------------------------------------------
+ */
+
+CREATE FUNCTION mysql._group_concat_transition(state text, value text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT CASE
+        WHEN $2 IS NULL THEN $1
+        WHEN $1 IS NULL THEN $2
+        ELSE $1 || ',' || $2
+    END
+$$;
+
+CREATE AGGREGATE mysql.group_concat(text) (
+    SFUNC = mysql._group_concat_transition,
+    STYPE = text,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION mysql._bit_xor_transition(state bigint, value bigint)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT COALESCE($1, 0) # COALESCE($2, 0)';
+
+CREATE AGGREGATE mysql.bit_xor(bigint) (
+    SFUNC = mysql._bit_xor_transition,
+    STYPE = bigint,
+    INITCOND = '0',
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION mysql._first_nonnull(state anyelement, value anyelement)
+RETURNS anyelement
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS 'SELECT COALESCE($1, $2)';
+
+CREATE AGGREGATE mysql.any_value(anyelement) (
+    SFUNC = mysql._first_nonnull,
+    STYPE = anyelement,
+    PARALLEL = SAFE
+);
+
+COMMENT ON SCHEMA mysql IS
+    'Opt-in MySQL function compatibility layer for OpenTenBase migrations';
+
+COMMENT ON FUNCTION mysql.concat(VARIADIC text[]) IS
+    'MySQL CONCAT semantics: returns NULL if any argument is NULL';
+
+COMMENT ON FUNCTION mysql.concat_ws(text, VARIADIC text[]) IS
+    'MySQL CONCAT_WS semantics: skips NULL values after the separator';
+
+COMMENT ON FUNCTION mysql.timestampdiff(text, timestamp, timestamp) IS
+    'Returns complete unit boundaries between two timestamps';
+
+COMMENT ON FUNCTION mysql.date_format(timestamp, text) IS
+    'Formats a timestamp using common MySQL percent tokens';

--- a/contrib/opentenbase_mysql_compat/opentenbase_mysql_compat.control
+++ b/contrib/opentenbase_mysql_compat/opentenbase_mysql_compat.control
@@ -1,0 +1,11 @@
+# opentenbase_mysql_compat extension
+#
+# Copyright (c) 2026 OpenTenBase Contributors
+#
+# This file is licensed under the same terms as OpenTenBase. See LICENSE.txt
+# in the repository root for details.
+
+comment = 'MySQL-compatible scalar and aggregate functions for migrations'
+default_version = '1.0'
+relocatable = false
+sql_mode = 'all'

--- a/contrib/opentenbase_mysql_compat/sql/opentenbase_mysql_compat.sql
+++ b/contrib/opentenbase_mysql_compat/sql/opentenbase_mysql_compat.sql
@@ -1,0 +1,213 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) 2026 OpenTenBase Contributors
+ *
+ * This file is licensed under the same terms as OpenTenBase. See LICENSE.txt
+ * in the repository root for details.
+ *-------------------------------------------------------------------------
+ */
+
+CREATE EXTENSION opentenbase_mysql_compat;
+
+DO $test$
+DECLARE
+    text_result text;
+    integer_result integer;
+    bigint_result bigint;
+    numeric_result numeric;
+    timestamp_result timestamp;
+BEGIN
+    IF mysql.ifnull(NULL::integer, 7) <> 7 THEN
+        RAISE EXCEPTION 'ifnull NULL case failed';
+    END IF;
+    IF mysql.ifnull(4, 7) <> 4 THEN
+        RAISE EXCEPTION 'ifnull value case failed';
+    END IF;
+    IF mysql.nullif_mysql(4, 4) IS NOT NULL THEN
+        RAISE EXCEPTION 'nullif equal case failed';
+    END IF;
+    IF mysql.mysql_if(true, 'yes'::text, 'no'::text) <> 'yes' THEN
+        RAISE EXCEPTION 'mysql_if true case failed';
+    END IF;
+    IF mysql.if_true(NULL, 'yes'::text, 'no'::text) <> 'no' THEN
+        RAISE EXCEPTION 'if_true NULL case failed';
+    END IF;
+
+    IF mysql.concat('a', 'b', 'c') <> 'abc' THEN
+        RAISE EXCEPTION 'concat normal case failed';
+    END IF;
+    IF mysql.concat('a', NULL, 'c') IS NOT NULL THEN
+        RAISE EXCEPTION 'concat NULL case failed';
+    END IF;
+    IF mysql.concat_ws('-', 'a', NULL, 'c') <> 'a-c' THEN
+        RAISE EXCEPTION 'concat_ws NULL skipping failed';
+    END IF;
+    IF mysql.elt(2, 'red', 'green', 'blue') <> 'green' THEN
+        RAISE EXCEPTION 'elt selection failed';
+    END IF;
+    IF mysql.elt(0, 'red', 'green') IS NOT NULL THEN
+        RAISE EXCEPTION 'elt boundary failed';
+    END IF;
+    IF mysql.field('green', 'red', 'green', 'blue') <> 2 THEN
+        RAISE EXCEPTION 'field match failed';
+    END IF;
+    IF mysql.field('missing', 'red', 'green') <> 0 THEN
+        RAISE EXCEPTION 'field miss failed';
+    END IF;
+    IF mysql.find_in_set('b', 'a,b,c') <> 2 THEN
+        RAISE EXCEPTION 'find_in_set match failed';
+    END IF;
+    IF mysql.find_in_set('x', 'a,b,c') <> 0 THEN
+        RAISE EXCEPTION 'find_in_set miss failed';
+    END IF;
+    IF mysql.insert_string('Quadratic', 3, 4, 'What') <> 'QuWhattic' THEN
+        RAISE EXCEPTION 'insert_string replacement failed';
+    END IF;
+    IF mysql.insert_string('abc', 9, 1, 'x') <> 'abc' THEN
+        RAISE EXCEPTION 'insert_string boundary failed';
+    END IF;
+    IF mysql.substring_index('www.mysql.com', '.', 2) <> 'www.mysql' THEN
+        RAISE EXCEPTION 'substring_index positive failed';
+    END IF;
+    IF mysql.substring_index('www.mysql.com', '.', -2) <> 'mysql.com' THEN
+        RAISE EXCEPTION 'substring_index negative failed';
+    END IF;
+    IF mysql.make_set(5, 'a', 'b', 'c') <> 'a,c' THEN
+        RAISE EXCEPTION 'make_set failed';
+    END IF;
+    IF mysql.export_set(5, 'Y', 'N', '', 4) <> 'YNYN' THEN
+        RAISE EXCEPTION 'export_set failed';
+    END IF;
+    IF char_length(mysql.space(5)) <> 5 THEN
+        RAISE EXCEPTION 'space failed';
+    END IF;
+    IF mysql.strcmp('a', 'b') <> -1 OR mysql.strcmp('b', 'b') <> 0 THEN
+        RAISE EXCEPTION 'strcmp failed';
+    END IF;
+    IF mysql.unhex('4D7953514C') <> convert_to('MySQL', 'UTF8') THEN
+        RAISE EXCEPTION 'unhex failed';
+    END IF;
+    IF mysql.unhex('not-hex') IS NOT NULL THEN
+        RAISE EXCEPTION 'unhex invalid input failed';
+    END IF;
+    IF mysql.hex('MySQL') <> '4D7953514C' THEN
+        RAISE EXCEPTION 'hex failed';
+    END IF;
+    IF mysql.conv('FF', 16, 10) <> '255' THEN
+        RAISE EXCEPTION 'conv hexadecimal failed';
+    END IF;
+    IF mysql.conv('101010', 2, 36) <> '16' THEN
+        RAISE EXCEPTION 'conv binary failed';
+    END IF;
+    IF mysql.bin(10) <> '1010' OR mysql.oct(10) <> '12' THEN
+        RAISE EXCEPTION 'bin or oct failed';
+    END IF;
+
+    IF mysql.truncate(123.4567, 2) <> 123.45 THEN
+        RAISE EXCEPTION 'truncate positive places failed';
+    END IF;
+    IF mysql.truncate(123.4567, -2) <> 100 THEN
+        RAISE EXCEPTION 'truncate negative places failed';
+    END IF;
+    IF mysql.sign(-1.5) <> -1 OR mysql.sign(0) <> 0 OR mysql.sign(2) <> 1 THEN
+        RAISE EXCEPTION 'sign failed';
+    END IF;
+    IF abs(mysql.log2(8) - 3) > 0.0000001 THEN
+        RAISE EXCEPTION 'log2 failed';
+    END IF;
+    IF mysql.log10(-1) IS NOT NULL THEN
+        RAISE EXCEPTION 'log10 domain handling failed';
+    END IF;
+    IF abs(mysql.degrees(pi()) - 180) > 0.0000001 THEN
+        RAISE EXCEPTION 'degrees failed';
+    END IF;
+    IF abs(mysql.radians(180) - pi()) > 0.0000001 THEN
+        RAISE EXCEPTION 'radians failed';
+    END IF;
+
+    IF mysql.datediff(DATE '2026-03-10', DATE '2026-03-01') <> 9 THEN
+        RAISE EXCEPTION 'datediff failed';
+    END IF;
+    IF mysql.last_day(DATE '2024-02-11') <> DATE '2024-02-29' THEN
+        RAISE EXCEPTION 'last_day leap year failed';
+    END IF;
+    IF mysql.dayofweek(DATE '2026-07-19') <> 1 THEN
+        RAISE EXCEPTION 'dayofweek failed';
+    END IF;
+    IF mysql.weekday(DATE '2026-07-20') <> 0 THEN
+        RAISE EXCEPTION 'weekday failed';
+    END IF;
+    IF mysql.dayofyear(DATE '2024-12-31') <> 366 THEN
+        RAISE EXCEPTION 'dayofyear failed';
+    END IF;
+    IF mysql.quarter(DATE '2026-10-01') <> 4 THEN
+        RAISE EXCEPTION 'quarter failed';
+    END IF;
+    IF mysql.timestampdiff('SECOND', TIMESTAMP '2026-01-01 00:00:00',
+                           TIMESTAMP '2026-01-01 00:01:05') <> 65 THEN
+        RAISE EXCEPTION 'timestampdiff seconds failed';
+    END IF;
+    IF mysql.timestampdiff('MONTH', TIMESTAMP '2025-01-31',
+                           TIMESTAMP '2025-03-30') <> 1 THEN
+        RAISE EXCEPTION 'timestampdiff complete months failed';
+    END IF;
+    IF mysql.timestampadd('DAY', 3, TIMESTAMP '2026-01-01') <>
+       TIMESTAMP '2026-01-04' THEN
+        RAISE EXCEPTION 'timestampadd day failed';
+    END IF;
+    IF mysql.timestampadd('QUARTER', 1, TIMESTAMP '2026-01-31') <>
+       TIMESTAMP '2026-04-30' THEN
+        RAISE EXCEPTION 'timestampadd quarter failed';
+    END IF;
+    IF mysql.adddate(DATE '2026-01-01', 2) <> DATE '2026-01-03' THEN
+        RAISE EXCEPTION 'adddate failed';
+    END IF;
+    IF mysql.subdate(DATE '2026-01-03', 2) <> DATE '2026-01-01' THEN
+        RAISE EXCEPTION 'subdate failed';
+    END IF;
+    IF mysql.period_add(202601, 2) <> 202603 THEN
+        RAISE EXCEPTION 'period_add failed';
+    END IF;
+    IF mysql.period_diff(202603, 202512) <> 3 THEN
+        RAISE EXCEPTION 'period_diff failed';
+    END IF;
+    IF mysql.date_format(TIMESTAMP '2026-07-18 13:04:05.123456',
+                         '%Y-%m-%d %H:%i:%s.%f') <>
+       '2026-07-18 13:04:05.123456' THEN
+        RAISE EXCEPTION 'date_format failed';
+    END IF;
+    IF mysql.date_format(TIMESTAMP '2026-01-21', '%D') <> '21st' THEN
+        RAISE EXCEPTION 'date_format ordinal failed';
+    END IF;
+    IF mysql.str_to_date('2026-07-18 13:04:05',
+                         '%Y-%m-%d %H:%i:%s') <>
+       TIMESTAMP '2026-07-18 13:04:05' THEN
+        RAISE EXCEPTION 'str_to_date failed';
+    END IF;
+    IF mysql.str_to_date('not a date', '%Y-%m-%d') IS NOT NULL THEN
+        RAISE EXCEPTION 'str_to_date invalid input failed';
+    END IF;
+
+    SELECT mysql.group_concat(value ORDER BY value)
+    INTO text_result
+    FROM (VALUES ('c'::text), ('a'), (NULL), ('b')) AS input(value);
+    IF text_result <> 'a,b,c' THEN
+        RAISE EXCEPTION 'group_concat failed: %', text_result;
+    END IF;
+
+    SELECT mysql.bit_xor(value)
+    INTO bigint_result
+    FROM (VALUES (1::bigint), (3::bigint), (7::bigint)) AS input(value);
+    IF bigint_result <> 5 THEN
+        RAISE EXCEPTION 'bit_xor failed: %', bigint_result;
+    END IF;
+
+    SELECT mysql.any_value(value)
+    INTO integer_result
+    FROM (VALUES (NULL::integer), (4), (9)) AS input(value);
+    IF integer_result <> 4 THEN
+        RAISE EXCEPTION 'any_value failed: %', integer_result;
+    END IF;
+END;
+$test$;
+
+DROP EXTENSION opentenbase_mysql_compat;


### PR DESCRIPTION
## What changed

- adds the opt-in `opentenbase_mysql_compat` contrib extension under the `mysql` schema
- implements 52 scalar/helper functions and 3 aggregates for MySQL-oriented string, date/time, numeric, flow-control, and aggregation migrations
- integrates the extension into the top-level contrib build
- adds deterministic regression assertions and a migration-focused usage reference

This completes the standalone MySQL-compatible function extension portion described in #230. It does not change parser syntax, implicit cast precedence, collation rules, SQL modes, or storage behavior.

## Impact

Applications can qualify functions with `mysql.` or temporarily add that schema to `search_path`, reducing SQL rewrites while keeping compatibility behavior isolated and removable.

## Validation

- loaded the extension SQL on PostgreSQL 10.22: all 52 functions and 3 aggregates were created successfully
- executed the complete regression assertion block on PostgreSQL 10.22: passed
- parsed 61 top-level SQL statements with `pglast`
- confirmed regression input and expected command stream are identical
- `git diff --cached --check`

## Size

- extension implementation SQL: 948 added lines
- complete PR: 1,633 additions, 1 deletion