### PR TITLE
docs: add architecture glossary and newcomer guide (#200)

### DIFF
--- a/GLOSSARY_ZH.md
+++ b/GLOSSARY_ZH.md
@@ -1,0 +1,152 @@
+<!--
+Copyright (C) 2025 OpenTenBase Authors. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# OpenTenBase 架构术语表与新手导览
+
+本文供第一次接触 OpenTenBase 部署和源码的读者查阅。下文先说明组件交互与查询流程，再解释配置文件和源码中常见的 15 个术语。
+
+## 分布式架构概览
+
+```mermaid
+flowchart TB
+    client["应用 / psql"] -->|"1. 连接并发送 SQL"| cn["Coordinator / CN"]
+    cn <-->|"2. 申请 GXID、全局快照并报告事务状态"| gtm["Global Transaction Manager / GTM"]
+    cn -->|"3. 按数据位置分发查询片段"| dn1["DataNode / DN 1"]
+    cn -->|"3. 按数据位置分发查询片段"| dn2["DataNode / DN 2"]
+    dn1 -->|"4. 返回局部结果"| cn
+    dn2 -->|"4. 返回局部结果"| cn
+    cn -->|"5. 汇总并返回结果"| client
+```
+
+图中只表示组件关系，不限定进程数量或端口。一个集群可以有多个 CN 和 DN，也可以为节点配置从节点。客户端在分布式模式下连接 CN；用户数据保存在 DN；GTM 负责全局事务 ID 和快照等事务协调信息，不参与用户表数据的存储。
+
+| 交互 | 谁发起 | 谁处理 | 发生了什么 |
+| --- | --- | --- | --- |
+| 建立会话、提交 SQL | 客户端 | CN | CN 是分布式集群的应用入口，对外提供统一的数据库视图 |
+| 获取事务信息 | CN 或 DN | GTM | 事务按需获取全局事务 ID 和全局快照，并报告事务状态 |
+| 执行查询片段 | CN | 一个或多个 DN | CN 根据表的分布信息选择 DN，并尽量下推过滤、投影、连接或排序等工作 |
+| 保存和读取用户行 | CN 调度 | DN | DN 在本地存储用户数据并执行发送到本节点的工作 |
+| 汇总结果 | DN 返回，CN 汇总 | CN | CN 收集局部结果，完成必要的合并后返回客户端 |
+
+## 查询处理流程
+
+以分布式模式中的查询为例：
+
+```sql
+SELECT id, note
+FROM orders
+WHERE id = 42;
+```
+
+1. 客户端把 SQL 发给任意可用的 CN。
+2. CN 解析和规划语句。事务需要一致性视图时，集群从 GTM 获取 GXID 和全局快照。
+3. CN 根据 `orders` 的分布方式和分布键判断目标 DN。能够确定数据位置时只访问相关 DN，否则可能访问表所在的全部 DN。
+4. DN 在本地读取数据并返回结果。可下推的过滤等操作会尽量在 DN 完成，减少网络传输。
+5. CN 合并局部结果并响应客户端。若写事务涉及多个节点，CN 会在内部使用两阶段提交来协调最终结果。
+
+## 核心术语
+
+### 1. Coordinator（CN，协调节点）
+
+分布式模式的客户端入口。CN 保存集群元数据，接收 SQL，生成并分发在 DN 上执行的工作，最后汇总结果。CN 的职责是协调，不是保存普通用户表数据；它也不是 GTM。
+
+### 2. DataNode（DN，数据节点）
+
+真正保存用户数据并执行本地查询任务的数据库节点。一个表可以把不同数据行分布到多个 DN，也可以在多个 DN 上保存副本。
+
+### 3. Global Transaction Manager（GTM，全局事务管理器）
+
+为集群事务提供全局事务 ID、全局快照和全局时间戳等信息，并跟踪事务状态。它解决的是跨节点事务可见性与协调问题，不负责解析业务 SQL，也不存储用户表。
+
+### 4. 分布式模式（`distributed`）
+
+由 GTM、CN 和 DN 共同组成的部署模式。应用连接 CN，数据可以分散到多个 DN，因此存储和计算能够随 DN 数量扩展。`opentenbase_config.ini` 中使用 `type=distributed`。
+
+### 5. 集中式模式（`centralized`）
+
+不创建独立 GTM 和 CN、只部署 DN 的模式。应用直接连接 DN，适合不需要分布式数据拆分的场景。集中式模式不是“把 GTM、CN、DN 都放到同一台机器”；后者仍然是单机承载的分布式拓扑。
+
+### 6. Catalog（系统目录 / 元数据）
+
+描述数据库对象和集群布局的系统信息，例如表结构、节点和数据分布位置。CN 依靠这些信息规划查询。元数据与用户表中的业务行不同；前者描述“数据在哪里、长什么样”，后者实际保存在 DN。
+
+### 7. Node Group（节点组）
+
+一组 DN 的逻辑别名，可用于定义表所在的子集群。节点组只包含 DN，不包含 CN 或 GTM。它描述数据放置范围，不等同于一个完整 OpenTenBase 集群。
+
+### 8. Distribution Key（分布键）
+
+分布表中用于决定一行数据应落到哪个 DN 的列。例如 `DISTRIBUTE BY SHARD(id)` 中的 `id`。选择分布键时通常要关注数据是否均匀、该列是否稳定，以及常用查询能否利用它缩小访问节点范围。
+
+### 9. Shard Distribution（SHARD 分布）
+
+按照指定分布键把表的行放到参与该表的 DN 上。它的目标是把数据和计算分摊到多个节点；一行数据不等于在每个 DN 都保存一份。
+
+```sql
+CREATE TABLE orders (
+    id bigint,
+    note text
+) DISTRIBUTE BY SHARD(id);
+```
+
+### 10. Replicated Table（复制表）
+
+在相关 DN 上保存完整副本的表，使用 `DISTRIBUTE BY REPLICATION` 创建。读取时可以选择一个副本，写入则需要更新所有副本。它适合体量较小、读取频繁的表，但不应与用于故障切换的“主节点 / 从节点”混为一谈。
+
+```sql
+CREATE TABLE regions (
+    code integer,
+    name text
+) DISTRIBUTE BY REPLICATION;
+```
+
+### 11. GXID（Global Transaction ID，全局事务 ID）
+
+GTM 为集群事务提供的全局有序标识。单个 PostgreSQL 实例的本地 XID 只需要在本实例中解释，GXID 则让参与同一集群的节点能够识别同一个全局事务。
+
+### 12. Global Snapshot（全局快照）
+
+描述集群中哪些事务正在运行、已经提交或已经中止的可见性信息。各节点依据同一全局视图判断哪些行版本可见，避免不同 DN 对同一事务观察不一致。
+
+### 13. Two-Phase Commit（2PC，两阶段提交）
+
+写事务涉及多个 DN 或 CN 时使用的内部协调协议。第一阶段确认所有参与节点都已准备好，第二阶段再统一提交；如果无法满足提交条件，则统一中止，避免只在部分节点生效。
+
+### 14. `opentenbase_ctl`
+
+仓库提供的集群管理命令行工具。它读取 `opentenbase_config.ini`，通过 SSH 在目标主机上安装和管理节点，并提供 `install`、`start`、`stop`、`status` 等子命令。配置中的 `ssh-port` 是远程登录端口，不是 CN 或 DN 的数据库端口。
+
+### 15. 主节点 / 从节点（Master / Slave）
+
+同一类组件中的主备角色，用于提高可用性。CN、DN 和 GTM 都可以在部署配置中出现主从关系；这是一种副本和故障恢复关系，不是 CN、DN、GTM 三种职责之间的上下级关系。数据表的 `REPLICATION` 分布也与节点主从是两个不同概念。
+
+## 分布式模式与集中式模式
+
+| 对比项 | 分布式模式 | 集中式模式 |
+| --- | --- | --- |
+| `type` 配置 | `distributed` | `centralized` |
+| 组件 | GTM + CN + DN | DN |
+| 客户端入口 | CN | DN |
+| 用户数据位置 | 按表的分布规则存放在一个或多个 DN | 集中在 DN 实例中 |
+| 全局事务协调 | GTM 提供全局事务信息 | 不需要独立 GTM |
+| 典型用途 | 数据分片、并行处理、横向扩展 | 单实例或主从形态、较简单的部署需求 |
+
+## 常见概念辨析
+
+- **CN 与 GTM**：CN 处理 SQL 并协调执行；GTM 提供全局事务信息。
+- **复制表与 DN 从节点**：复制表是表的数据分布方式；从节点是数据库实例的高可用副本。
+- **Node Group 与集群**：节点组只是一组 DN；完整分布式集群还包括 CN 和 GTM。
+- **SSH 端口与数据库端口**：`ssh-port` 供 `opentenbase_ctl` 登录主机；CN/DN 端口由工具探测和分配，应以 `status` 输出为准。
+
+## 术语核对依据
+
+本文按当前仓库中的实现和文档交叉核对，主要依据如下：
+
+- [README_ZH.md](README_ZH.md) 的集群概览和 `opentenbase_config.ini` 说明。
+- [架构内部说明](doc/src/sgml/arch-dev.sgml) 中的 GTM、CN、DN、GXID、全局快照、查询下推和两阶段提交说明。
+- [数据定义说明](doc/src/sgml/ddl.sgml) 中的分布表、分布键和复制表说明。
+- [`CREATE NODE GROUP` 说明](doc/src/sgml/ref/create_nodegroup.sgml) 中的节点组范围和限制。
+- [`opentenbase_ctl` 配置模板](contrib/opentenbase_ctl/config/config.ini) 与[命令定义](contrib/opentenbase_ctl/src/command/command.cpp)。
+- [SQL 语法定义](src/backend/parser/gram.y) 中当前支持的 `SHARD`、`HASH`、`REPLICATION` 和 `ROUNDROBIN` 分布语法。

--- a/GLOSSARY_ZH.md
+++ b/GLOSSARY_ZH.md
@@ -11,13 +11,14 @@ SPDX-License-Identifier: BSD-3-Clause
 
 ```mermaid
 flowchart TB
-    client["应用 / psql"] -->|"1. 连接并发送 SQL"| cn["Coordinator / CN"]
-    cn <-->|"2. 申请 GXID、全局快照并报告事务状态"| gtm["Global Transaction Manager / GTM"]
-    cn -->|"3. 按数据位置分发查询片段"| dn1["DataNode / DN 1"]
-    cn -->|"3. 按数据位置分发查询片段"| dn2["DataNode / DN 2"]
-    dn1 -->|"4. 返回局部结果"| cn
-    dn2 -->|"4. 返回局部结果"| cn
-    cn -->|"5. 汇总并返回结果"| client
+    client["应用 / psql"]
+    cn["Coordinator / CN<br/>规划、分发与汇总"]
+    gtm["Global Transaction Manager / GTM<br/>管理全局事务"]
+    dn["一个或多个 DataNode / DN<br/>存储用户数据并执行本地任务"]
+
+    client <-->|"1. SQL 请求 / 4. 最终结果"| cn
+    cn <-->|"事务期间：GXID、全局快照、状态"| gtm
+    cn <-->|"2. 查询片段 / 3. 局部结果"| dn
 ```
 
 图中只表示组件关系，不限定进程数量或端口。一个集群可以有多个 CN 和 DN，也可以为节点配置从节点。客户端在分布式模式下连接 CN；用户数据保存在 DN；GTM 负责全局事务 ID 和快照等事务协调信息，不参与用户表数据的存储。
@@ -25,10 +26,10 @@ flowchart TB
 | 交互 | 谁发起 | 谁处理 | 发生了什么 |
 | --- | --- | --- | --- |
 | 建立会话、提交 SQL | 客户端 | CN | CN 是分布式集群的应用入口，对外提供统一的数据库视图 |
-| 获取事务信息 | CN 或 DN | GTM | 事务按需获取全局事务 ID 和全局快照，并报告事务状态 |
+| 获取、报告事务信息 | CN 或 DN | GTM | 事务按需获取全局事务 ID 和全局快照，并在开始、结束或进入两阶段提交准备阶段时报告状态 |
 | 执行查询片段 | CN | 一个或多个 DN | CN 根据表的分布信息选择 DN，并尽量下推过滤、投影、连接或排序等工作 |
-| 保存和读取用户行 | CN 调度 | DN | DN 在本地存储用户数据并执行发送到本节点的工作 |
-| 汇总结果 | DN 返回，CN 汇总 | CN | CN 收集局部结果，完成必要的合并后返回客户端 |
+| 保存和读取用户行 | CN | DN | CN 向目标 DN 发送任务；DN 在本地存储或读取用户数据 |
+| 返回并汇总结果 | DN | CN | DN 返回局部结果；CN 完成必要的合并后返回客户端 |
 
 ## 查询处理流程
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -14,6 +14,8 @@ OpenTenBase具有许多类似于PostgreSQL的语言接口，其中的一些可�
 
 用户总是连接到 CoordinateNodes，CoordinateNodes 将查询分解为在 DataNodes 中执行的片段，并收集结果。
 
+如果这是您第一次接触 OpenTenBase，建议先阅读[架构术语表与新手导览](GLOSSARY_ZH.md)。
+
 您可以在以下链接获取 OpenTenBase 软件的最新版本：
 
 	https://github.com/OpenTenBase/OpenTenBase


### PR DESCRIPTION
## 关联 Issue

Closes #200

## 改动

- 新增 `GLOSSARY_ZH.md`，整理 15 个部署和源码中常见的架构术语。
- 使用 Mermaid 图和组件交互表说明客户端、CN、DN、GTM 的关系。
- 以一条查询说明 CN 规划和分发、DN 执行、GTM 提供事务信息的流程。
- 对比分布式与集中式部署，并区分复制表、节点主从、Node Group 和集群等易混概念。
- 在 `README_ZH.md` 的概览中增加术语表入口。

## 核对与检查

术语和流程按当前仓库交叉核对：组件和事务流程依据 `doc/src/sgml/arch-dev.sgml`，分布表与复制表依据 `ddl.sgml`，节点组依据 `create_nodegroup.sgml`，分布语法依据 `gram.y`，集中式限制和管理命令依据 `opentenbase_ctl` 源码。

- 术语数量：15 项。
- README 改动范围：2 行入口链接。
- `git diff --check` 和 Markdown lint 通过。
- Mermaid/SQL 代码围栏与新增相对链接检查通过。

## AI 使用策略报告

### 使用范围

本次使用 ChatGPT 辅助汇总候选术语、整理面向新手的初版解释，以及设计 Mermaid 图和组件交互表的初始结构。AI 输出只作为候选内容和检查线索，不作为技术事实来源。

### 审查与验证

- CN、DN、GTM、GXID、全局快照和两阶段提交等组件与事务表述，逐项对照 `doc/src/sgml/arch-dev.sgml`。
- 分布键、SHARD 分布和复制表对照 `doc/src/sgml/ddl.sgml` 与 `src/backend/parser/gram.y`。
- Node Group 的成员范围对照 `doc/src/sgml/ref/create_nodegroup.sgml`；集中式模式和 `opentenbase_ctl` 的行为对照配置模板、解析代码与命令实现。
- 完成技术核对后，再检查术语之间是否自洽，并运行 Markdown lint、相对链接检查和 `git diff --check`；Mermaid 图使用 CLI 实际渲染后人工查看连线和文字布局。

### 纠错与未采用建议

- 初版架构图曾把 GTM 状态报告画成固定的查询步骤。源码说明事务会在开始、结束以及两阶段提交的 `PREPARE` 阶段报告状态，因此最终改为“事务期间”的持续交互，避免错误的时序暗示。
- 未采用“集中式模式就是把 GTM、CN、DN 放在同一台机器”的解释。当前部署工具的集中式模式不创建独立 GTM 和 CN，只部署 DN。
- 未采用“Node Group 可以包含 CN 或 GTM”的说法；`CREATE NODE GROUP` 的定义表明节点组成员范围是 DN。
- 未将复制表与 DN 主从关系合并解释。复制表是表级数据分布方式，节点主从是实例级高可用关系，两者在文档中分别说明。
- 对无法从当前仓库确认、超出新手导览范围或会增加误解的候选术语和架构结论，均未写入最终文档。

最终内容以当前仓库的文档、源码和可复现检查结果为准；AI 只用于提高整理效率，所有技术结论均经过人工审查、验证和纠错。
