### PR TITLE
docs: 设计 OpenTenBase 接入 CloudNativePG 的可行性方案（#201）

### DIFF
--- a/docs/design/issue-201-ai-usage-report.md
+++ b/docs/design/issue-201-ai-usage-report.md
@@ -1,0 +1,92 @@
+<!--
+Copyright (c) 2026 OpenTenBase Contributors
+Licensed under the BSD 3-Clause License. See LICENSE.txt.
+-->
+
+# Issue #201 AI 使用策略自我报告
+
+> 日期：2026-07-28
+> 范围：OpenTenBase 接入 PostgreSQL 社区部署框架的调研、方案、CRD 草案和验证
+
+## 1. 使用原则
+
+本任务使用 AI 辅助做信息检索、源码定位、方案对比、文档结构化和机械校验。AI 不被当作事实来源；关键结论必须回到以下一手证据：
+
+1. OpenTenBase 当前仓库的 README、`opentenbase_ctl` 源码和使用文档。
+2. CloudNativePG 官方版本化文档和官方 GitHub 仓库。
+3. Kubernetes CRD/OpenAPI 的可机器解析结果。
+
+涉及数据安全的能力采用保守原则：没有数据库协议和故障测试证据时，不把“可能可做”写成“已支持”。因此 PoC 明确拒绝 DN 自动缩容、全局 PITR 和未验证的自动 failover。
+
+## 2. AI 参与的工作
+
+| 阶段 | AI 辅助内容 | 人工/证据约束 | 产出 |
+| --- | --- | --- | --- |
+| 调研 | 提取 Issue 验收项；筛选 CNPG、StackGres、Crunchy PGO、Zalando Operator | 只用项目官方资料确认核心能力和许可证 | 框架选择表 |
+| 源码理解 | 搜索 GTM/CN/DN、initdb、pg_basebackup、CREATE/ALTER NODE、node group | 逐段读取当前 commit 对应源码，不依赖二手文章 | 当前安装状态机 |
+| 设计 | 从拓扑、身份、存储、路由、一致性不变量推导 Operator 边界 | 每个自动化能力都要给出安全前置条件和失败行为 | 主设计文档 |
+| PoC | 生成 CRD 和示例 CR | 用 YAML 解析、结构断言和 CRD/schema 检查验证 | 两个 YAML 文件 |
+| 审校 | 检查链接、术语、不可见字符、文档相互引用和 git diff | 命令输出留作 PR checks 说明 | 验证记录 |
+
+未使用 AI 生成或执行生产数据库操作；未向外部服务发送凭据、集群数据或私有代码。
+
+## 3. “调研、比较、验证、修正”记录
+
+### 3.1 调研
+
+- 阅读 Issue #201 的任务要求和评价标准。
+- 阅读 CNPG 的 Architecture、Container Image Requirements、Instance Manager、Service、Storage、Bootstrap、Monitoring 和 capability level 文档。
+- 阅读 OpenTenBase README 和 `opentenbase_ctl` 的初始化、复制、节点目录与 node group 实现。
+- 查看同一 Issue 已出现的公开 PR，避免只做重复的框架罗列，把重点转向可验证的不变量、fail-closed 边界和可执行 CRD。
+
+### 3.2 比较
+
+比较了三种实现路线：
+
+1. fork CNPG；
+2. OpenTenBase 高层 Operator 组合多个 CNPG `Cluster`；
+3. 独立 Operator 复用 CNPG 的运行模式和生态接口。
+
+评价标准不是“能复用多少代码”，而是“复用后是否仍能表达 OpenTenBase 的正确状态，以及上游是否承诺该用法”。最终推荐第三种；第二种保留为有退出门槛的兼容性实验。
+
+### 3.3 验证与修正
+
+本次至少发生了以下关键修正：
+
+| 初始假设/常见说法 | 验证证据 | 修正后的结论 |
+| --- | --- | --- |
+| 可以把 CN/DN 当作自定义 PostgreSQL 镜像直接交给 CNPG | CNPG 1.30 官方文档只支持 PGDG 支持版本和 Primary/Hot Standby 架构 | 只能做 time-boxed spike，不能作为受支持方案 |
+| OpenTenBase 初始化必须严格 `GTM -> DN -> CN` 串行 | `install_distributed_instance()` 在 GTM 主就绪后并行安装 CN/DN 主 | 硬依赖是 GTM 先就绪；CN/DN 主可并行；拓扑注册必须最后 |
+| Pod Running/`pg_isready` 可以作为 Service 就绪条件 | OpenTenBase 还要求 GTM 可达和 CN 节点目录一致 | CN readiness 增加 topologyRevision 校验 |
+| 多个 DN 分别做 PostgreSQL 备份即可得到集群 PITR | 分布式事务跨 DN，且恢复还依赖 GTM/拓扑状态 | 只复用备份传输层；全局 barrier/manifest/恢复验证必须新建 |
+| DN 扩容就是 StatefulSet replicas 增加 | DN groups 代表数据分片，当前通用形态 expand/shrink 受限 | PoC 把 DN groups 视为 immutable，变更 fail closed |
+| StatefulSet ordinal 可直接表示主备角色 | 主备角色可能切换，ordinal 只是稳定实例身份 | Service selector 由数据库确认的角色标签驱动 |
+
+这些修正被同步写入设计、CRD 字段说明和风险表，而不是只保留在调研笔记中。
+
+## 4. 质量与安全控制
+
+- **来源可追溯**：主文档列出版本化官方链接和精确源码行链接。
+- **不伪造运行结果**：本次没有可用 Kubernetes 集群，因此不声称部署 e2e 已通过；只验证静态交付物。
+- **最小权限**：方案要求 namespace-scoped RBAC、Secret 引用和日志脱敏。
+- **破坏性操作默认关闭**：DN 缩容、PVC 删除、自动切换和分布式 PITR 不进入 PoC 的“支持”范围。
+- **幂等优先**：数据库实际状态优先于本地 marker，外部副作用验证成功后才更新 status。
+- **可证伪门槛**：CNPG 组合方案、自动 failover、在线扩容和备份都有明确的 e2e 退出条件。
+
+## 5. 已知局限与后续人工验证
+
+1. 当前设计是 PoC 级控制面方案，不是已运行的 Operator 实现。
+2. CRD 的 `resources`/`affinity` 为草案中的透传字段；正式实现应引用或生成 Kubernetes 结构化类型。
+3. GTM 选主/fencing 的正式协议需要维护者确认。
+4. topology diff SQL、CN/DN 切换后的元数据同步范围需要数据库专家审阅。
+5. 全局备份 barrier 和 restore manifest 需要故障注入与整集群恢复演练。
+6. CNPG child `Cluster` 兼容性需要隔离实验，且不能绕过上游支持声明。
+
+## 6. 工具与模型披露
+
+- AI 助手：OpenAI Codex（GPT-5 系列）
+- 外部检索：GitHub 公共页面、CloudNativePG 官方文档
+- 本地分析：`git`、`rg`、PowerShell、Python 文本/结构断言
+- 版本控制：独立 git worktree 和 issue 专用分支，避免混入其他任务改动
+
+最终责任仍由提交者承担：提交前应人工复核技术结论、引用、Discussion 内容和 PR diff，并由项目维护者决定方案是否进入实现阶段。

--- a/docs/design/issue-201-discussion.md
+++ b/docs/design/issue-201-discussion.md
@@ -1,0 +1,66 @@
+<!--
+Copyright (c) 2026 OpenTenBase Contributors
+Licensed under the BSD 3-Clause License. See LICENSE.txt.
+-->
+
+# 提案：以 CloudNativePG 为运行模式基线的 OpenTenBase Kubernetes Operator
+
+## 背景
+
+我针对 Issue #201 调研了 CloudNativePG、StackGres、Crunchy PGO 和 Zalando PostgreSQL Operator，并进一步对照了 OpenTenBase 当前 `opentenbase_ctl` 的源码实现。
+
+核心结论是：OpenTenBase 不能被建模为一个普通 PostgreSQL 主备集群。它的正确状态同时依赖 GTM、多个 Coordinator（CN）、多个 DataNode（DN）、稳定节点身份、CN 节点目录和默认 node group。现有 PostgreSQL Operator 可以复用大量 Kubernetes 运维经验，但不能直接接管这些分布式语义。
+
+## 推荐方案
+
+推荐新建 `OpenTenBaseCluster` 高层 Operator：
+
+- 一个 CR 表达集中式或分布式拓扑。
+- GTM 使用一个 StatefulSet；每个逻辑 CN/DN 各使用一个 StatefulSet，同组 ordinal 承载主备实例。
+- 使用 headless Service 提供稳定节点 DNS，单独的 CN read-write Service 作为客户端入口。
+- 初始化状态机以当前源码为准：`GTM 主 -> CN/DN 主并行 -> 各备节点 -> 节点目录和默认 node group`。
+- topology reconcile 使用 Kubernetes Lease 串行化，以规范化拓扑哈希作为 `topologyRevision`，所有 serving CN 都验证一致后才对外 Ready。
+- PoC 对 DN groups 的变更 fail closed；不把 StatefulSet 扩缩容误当作数据再平衡。
+
+CloudNativePG 作为设计基线，复用的是：
+
+- CRD/status/conditions 的控制器模式；
+- 每实例独立 PVC、shared-nothing 调度和反亲和；
+- 基于数据库角色的 Service selector；
+- Prometheus/PodMonitor 和自定义 SQL 指标接入；
+- 先备后主、受控切换的滚动升级思想；
+- 对象存储、凭据、Job 和备份插件的外围模式。
+
+必须新建的是：
+
+- GTM 生命周期和 fencing；
+- CN/DN 角色化 initdb 与 instance agent；
+- 跨角色 bootstrap 和 topology diff/reconcile；
+- DN 再平衡边界；
+- 全局一致备份 barrier、manifest 和整集群恢复；
+- OpenTenBase 角色感知的升级与故障切换。
+
+不建议直接 fork CNPG。CNPG 1.30 官方边界是 PGDG 支持版本、一个 Primary 加可选 Hot Standby；OpenTenBase 镜像可做 time-boxed 兼容性实验，但不应在未经上游支持和 e2e 证明时作为生产依赖。
+
+## PoC 安全边界
+
+第一版只完成声明式创建、幂等重试、重启恢复、稳定 Service/PVC 和拓扑一致性检查。以下能力默认关闭：
+
+- DN 自动扩容/缩容；
+- 未完成 fencing 协议的自动主备切换；
+- 把各 DN 独立物理备份描述为全局 PITR；
+- 删除 CR 时自动删除 PVC。
+
+目标是先证明控制器在重复 apply、Operator 崩溃、Pod 重建和部分初始化失败后仍能收敛到同一个 topologyRevision，再逐步打开 HA、备份和在线拓扑变更。
+
+## 希望社区确认的问题
+
+1. 是否已有可供 Operator 调用的正式 topology diff/reconcile API？
+2. GTM 推荐的选主、fencing 和同步协议是什么？
+3. 通用形态是否同意在再平衡 API 成熟前把 DN groups 设为 immutable？
+4. CN/DN 主备切换后，节点目录需要在哪些节点上原子更新？
+5. 是否已有全局一致备份的事务屏障或快照接口？
+6. Operator 更适合放在本仓库 `contrib/`，还是独立仓库？
+7. 是否接受“以 CNPG 行为模式为基线，但不承诺 API/二进制兼容”的定位？
+
+完整设计、CRD 草案、示例资源和 AI 使用报告会随对应 PR 提交。欢迎维护者重点审阅初始化顺序、GTM fencing、节点目录幂等性和 DN 扩缩容边界。

--- a/docs/design/opentenbase-cluster-crd.yaml
+++ b/docs/design/opentenbase-cluster-crd.yaml
@@ -1,0 +1,354 @@
+# Copyright (c) 2026 OpenTenBase Contributors
+# Licensed under the BSD 3-Clause License. See LICENSE.txt.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: opentenbaseclusters.database.opentenbase.org
+spec:
+  group: database.opentenbase.org
+  scope: Namespaced
+  names:
+    plural: opentenbaseclusters
+    singular: opentenbasecluster
+    kind: OpenTenBaseCluster
+    shortNames:
+      - otbc
+    categories:
+      - all
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Mode
+          type: string
+          jsonPath: .spec.mode
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Ready
+          type: string
+          jsonPath: .status.ready
+        - name: Revision
+          type: string
+          jsonPath: .status.topologyRevision
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          x-kubernetes-validations:
+            - rule: >-
+                self.spec.mode == 'Centralized'
+                  ? (!has(self.spec.gtm) &&
+                     !has(self.spec.coordinator) &&
+                     self.spec.datanode.groups == 1)
+                  : (has(self.spec.gtm) &&
+                     has(self.spec.coordinator))
+              message: >-
+                Centralized mode requires exactly one DataNode group and forbids
+                GTM/Coordinator; Distributed mode requires both GTM and Coordinator.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - mode
+                - image
+                - datanode
+              properties:
+                mode:
+                  type: string
+                  enum:
+                    - Centralized
+                    - Distributed
+                  description: OpenTenBase deployment mode.
+                image:
+                  type: string
+                  minLength: 1
+                  description: >-
+                    Immutable OpenTenBase application image reference. Production
+                    deployments should use a digest.
+                imagePullPolicy:
+                  type: string
+                  enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                  default: IfNotPresent
+                imagePullSecrets:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                gtm:
+                  type: object
+                  description: Required only in Distributed mode.
+                  required:
+                    - replicas
+                    - storage
+                  properties:
+                    replicas:
+                      type: integer
+                      format: int32
+                      minimum: 1
+                      maximum: 3
+                      default: 2
+                      description: Number of GTM instances in the logical GTM group.
+                    storage:
+                      type: object
+                      required:
+                        - size
+                      properties:
+                        size:
+                          type: string
+                          minLength: 1
+                        storageClassName:
+                          type: string
+                        retainOnDelete:
+                          type: boolean
+                          default: true
+                    resources:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    affinity:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                coordinator:
+                  type: object
+                  description: Required only in Distributed mode.
+                  required:
+                    - groups
+                    - replicasPerGroup
+                    - storage
+                  properties:
+                    groups:
+                      type: integer
+                      format: int32
+                      minimum: 1
+                      maximum: 64
+                      description: Number of logical Coordinator nodes.
+                    replicasPerGroup:
+                      type: integer
+                      format: int32
+                      minimum: 1
+                      maximum: 3
+                      default: 1
+                      description: Number of physical instances for each logical node.
+                    storage:
+                      type: object
+                      required:
+                        - size
+                      properties:
+                        size:
+                          type: string
+                          minLength: 1
+                        storageClassName:
+                          type: string
+                        retainOnDelete:
+                          type: boolean
+                          default: true
+                    resources:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    affinity:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                datanode:
+                  type: object
+                  required:
+                    - groups
+                    - replicasPerGroup
+                    - storage
+                  properties:
+                    groups:
+                      type: integer
+                      format: int32
+                      minimum: 1
+                      maximum: 256
+                      description: >-
+                        Number of logical DataNode groups. The PoC treats this
+                        field as immutable after creation.
+                    replicasPerGroup:
+                      type: integer
+                      format: int32
+                      minimum: 1
+                      maximum: 3
+                      default: 1
+                      description: Number of physical instances for each logical node.
+                    storage:
+                      type: object
+                      required:
+                        - size
+                      properties:
+                        size:
+                          type: string
+                          minLength: 1
+                        storageClassName:
+                          type: string
+                        retainOnDelete:
+                          type: boolean
+                          default: true
+                    resources:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    affinity:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                service:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - ClusterIP
+                        - LoadBalancer
+                        - NodePort
+                      default: ClusterIP
+                    annotations:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    loadBalancerSourceRanges:
+                      type: array
+                      items:
+                        type: string
+                observability:
+                  type: object
+                  properties:
+                    podMonitor:
+                      type: boolean
+                      default: false
+                    scrapeInterval:
+                      type: string
+                      pattern: ^[0-9]+(ms|s|m|h)$
+                      default: 30s
+                    customQueriesConfigMap:
+                      type: string
+                safety:
+                  type: object
+                  properties:
+                    topologyChangePolicy:
+                      type: string
+                      enum:
+                        - Manual
+                        - OnlineSafe
+                      default: Manual
+                      description: >-
+                        Manual is the PoC default. OnlineSafe may only enable
+                        operations proven safe by the controller.
+                    pause:
+                      type: boolean
+                      default: false
+                      description: Pause new mutations while continuing observation.
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Provisioning
+                    - BootstrappingGTM
+                    - BootstrappingDataPlane
+                    - BootstrappingReplicas
+                    - RegisteringTopology
+                    - Ready
+                    - Scaling
+                    - Upgrading
+                    - Degraded
+                    - Deleting
+                ready:
+                  type: string
+                  enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                topologyRevision:
+                  type: string
+                roleStatus:
+                  type: object
+                  properties:
+                    gtm:
+                      type: object
+                      properties:
+                        desired:
+                          type: integer
+                          format: int32
+                        ready:
+                          type: integer
+                          format: int32
+                        primary:
+                          type: string
+                    coordinator:
+                      type: object
+                      properties:
+                        desired:
+                          type: integer
+                          format: int32
+                        ready:
+                          type: integer
+                          format: int32
+                        serving:
+                          type: integer
+                          format: int32
+                    datanode:
+                      type: object
+                      properties:
+                        desired:
+                          type: integer
+                          format: int32
+                        ready:
+                          type: integer
+                          format: int32
+                conditions:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - type
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                      - lastTransitionTime
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time

--- a/docs/design/opentenbase-cluster-example.yaml
+++ b/docs/design/opentenbase-cluster-example.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 OpenTenBase Contributors
+# Licensed under the BSD 3-Clause License. See LICENSE.txt.
+
+apiVersion: database.opentenbase.org/v1alpha1
+kind: OpenTenBaseCluster
+metadata:
+  name: demo
+  namespace: database
+spec:
+  mode: Distributed
+  # A real deployment should pin an immutable digest.
+  image: ghcr.io/opentenbase/opentenbase:5.0.0
+  imagePullPolicy: IfNotPresent
+  gtm:
+    replicas: 2
+    storage:
+      size: 10Gi
+      storageClassName: fast-rwo
+      retainOnDelete: true
+    resources:
+      requests:
+        cpu: "500m"
+        memory: 1Gi
+      limits:
+        memory: 2Gi
+  coordinator:
+    groups: 2
+    replicasPerGroup: 2
+    storage:
+      size: 20Gi
+      storageClassName: fast-rwo
+      retainOnDelete: true
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+      limits:
+        memory: 4Gi
+  datanode:
+    groups: 2
+    replicasPerGroup: 2
+    storage:
+      size: 100Gi
+      storageClassName: fast-rwo
+      retainOnDelete: true
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+      limits:
+        memory: 8Gi
+  service:
+    type: ClusterIP
+  observability:
+    podMonitor: true
+    scrapeInterval: 30s
+  safety:
+    topologyChangePolicy: Manual
+    pause: false

--- a/docs/plans/2026-07-28-opentenbase-cloudnativepg-integration-design.md
+++ b/docs/plans/2026-07-28-opentenbase-cloudnativepg-integration-design.md
@@ -1,0 +1,406 @@
+<!--
+Copyright (c) 2026 OpenTenBase Contributors
+Licensed under the BSD 3-Clause License. See LICENSE.txt.
+-->
+
+# OpenTenBase 接入 CloudNativePG 社区部署框架的可行性设计
+
+> 状态：Issue #201 设计提案
+> 调研基线：OpenTenBase `b612d77c`；CloudNativePG 1.28 运维文档及 1.30 镜像支持边界；Kubernetes `apiextensions.k8s.io/v1`
+> 日期：2026-07-28
+
+## 1. 结论先行
+
+OpenTenBase 不应直接 fork CloudNativePG（下文简称 CNPG），也不应把整个分布式集群伪装成一个 CNPG `Cluster`。推荐新建一个较薄的 `OpenTenBaseCluster` 高层 Operator，复用 CNPG 已验证的 Kubernetes 运维模式和外围生态，但由 OpenTenBase 自己维护 GTM、Coordinator（CN）、DataNode（DN）之间的拓扑不变量。
+
+最小 PoC 的边界是：
+
+- 用一个 `OpenTenBaseCluster` CRD 表达集中式或分布式拓扑。
+- GTM 使用一个 StatefulSet；每个逻辑 CN、DN 各使用一个独立 StatefulSet，副本 ordinal 表示该逻辑节点的主备实例。
+- 使用稳定的 headless Service 完成节点间寻址，使用单独的 CN read-write Service 作为客户端入口。
+- 按 `GTM 主 -> CN/DN 主并行 -> 各备节点 -> 分布式节点目录和默认 node group` 的状态机初始化，任一步骤都必须可重试。
+- PoC 只允许创建时确定 DN 分片数。DN 扩缩容、全局一致备份和自动角色切换在具备数据库级协议前一律 fail closed。
+- 监控先复用 Prometheus/PodMonitor 接入方式；备份只复用对象存储、凭据和 Job 等外围模式，不宣称单节点备份天然等于分布式一致备份。
+
+配套交付物：
+
+- [`OpenTenBaseCluster` CRD 草案](../design/opentenbase-cluster-crd.yaml)
+- [最小集群示例](../design/opentenbase-cluster-example.yaml)
+- [AI 使用策略自我报告](../design/issue-201-ai-usage-report.md)
+
+## 2. 从第一性原理定义“集群正确”
+
+Operator 的目标不是让 Pod 数量等于 `spec`，而是持续保证下面的不变量。
+
+### 2.1 数据与路由不变量
+
+1. 用户流量只进入可服务的 CN，不直接把 DN 暴露为业务入口。
+2. 每个 CN/DN 主实例都有稳定且唯一的节点名；Pod IP 变化不能改变数据库节点身份。
+3. 每个可服务 CN 看到的 CN/DN 节点目录必须与 `spec` 对应的期望拓扑一致。
+4. 分布式模式下必须先有可用 GTM，CN/DN 才能完成初始化并对外 Ready。
+5. DN 分片集合变化不是普通的 StatefulSet 扩缩容，而是数据放置、再平衡和元数据变更事务。
+
+### 2.2 高可用与存储不变量
+
+1. StatefulSet ordinal 是实例身份，不等于数据库角色；主备角色必须由数据库状态确认。
+2. 同一逻辑节点的主、备不能共享同一数据目录，且应跨 worker node/可用区调度。
+3. Service selector 只能指向数据库确认可服务的实例，不能仅依赖 Pod `Running`。
+4. 任何自动切换都必须同时更新 GTM/CN/DN 的依赖关系和路由元数据；做不到时宁可标记 `Degraded` 并停止自动操作。
+
+### 2.3 控制器不变量
+
+1. `spec` 是期望状态，`status.observedGeneration` 表明控制器实际处理过的版本。
+2. 每一步必须幂等：重复 reconcile 不重复创建数据库节点、不破坏已完成初始化。
+3. 拓扑变更以规范化拓扑的哈希 `topologyRevision` 为提交标识；数据库元数据成功后才推进 `status`。
+4. 单集群拓扑写操作由 Kubernetes `Lease` 串行化；失败后从数据库实际状态重新发现，而不是盲目重放。
+5. 删除 PVC、缩减 DN 或覆盖数据库角色属于破坏性操作，必须有显式策略和人工确认。
+
+这些约束决定了复用边界：Kubernetes 资源管理可以复用，分布式数据库语义必须新建。
+
+## 3. 为什么选择 CloudNativePG
+
+先对候选框架做轻量筛选，再对推荐项深入分析。
+
+| 维度 | CloudNativePG | StackGres | Crunchy PGO | Zalando Operator |
+| --- | --- | --- | --- | --- |
+| 核心定位 | Kubernetes-native PostgreSQL 生命周期 | PostgreSQL 平台，集成面较大 | PostgreSQL 集群与 pgBackRest | Patroni/Spilo 体系 |
+| 许可证 | Apache-2.0 | AGPL-3.0 | Apache-2.0 | MIT |
+| HA 控制 | 自有 instance manager + K8s API | Patroni | Patroni | Patroni |
+| 存储/Service/监控/滚动升级文档 | 完整且边界明确 | 完整 | 完整 | 完整 |
+| 作为 OpenTenBase 设计基线 | **推荐**：原生控制器模式清晰，依赖较少 | 平台耦合较重 | 备份能力强但 Patroni 假设仍在 | 与 Spilo 镜像耦合较深 |
+
+选择 CNPG 不是因为它能直接运行 OpenTenBase，而是因为它把 PostgreSQL Operator 的核心责任拆得最清楚：CRD/status、每实例 Pod 管理、Service selector、独立 PVC、探针、滚动更新、备份插件和 Prometheus 指标。它因此适合作为“哪些能复用、哪些不能复用”的参照系。
+
+## 4. CNPG 核心抽象与复用判定
+
+| 能力 | CNPG 1.30 的抽象 | OpenTenBase 处理 | 判定 |
+| --- | --- | --- | --- |
+| CRD | 一个 `Cluster` 表达一个 PostgreSQL 主实例和可选热备 | 一个 `OpenTenBaseCluster` 表达 GTM + 多个 CN/DN 逻辑节点及其主备 | 新建 |
+| Operator | reconcile 单 PostgreSQL 集群生命周期 | 高层拓扑状态机，编排多个角色和数据库目录 | 新建，复用控制器模式 |
+| Pod 管理 | 每实例一个 Pod，instance manager 为 PID 1 并管理 postmaster/探针 | GTM 不是 PostgreSQL postmaster；CN/DN 还需角色化 initdb 和拓扑注册 | 新建 role-aware instance agent |
+| Service | `rw` 指主、`ro` 指备、`r` 指任意实例 | 客户端只需要 CN 服务；GTM、DN 默认仅内部 headless/primary 服务 | 复用 Service 模式，新建 selector 语义 |
+| 存储 | 每实例独立 PVC，推荐 shared-nothing | GTM、每个 CN/DN 实例同样需要独立 PVC 和反亲和 | 可直接复用 K8s 模式 |
+| 备份 | 单 PostgreSQL 集群的 base backup、WAL、PITR，推荐 CNPG-I/Barman | 多 DN + GTM 的恢复点必须全局一致 | 仅复用传输/凭据/Job；一致性协议新建 |
+| 监控 | 内置 exporter，支持自定义 SQL 指标和 PodMonitor | 增加 GTM、路由目录、跨 DN 事务、各角色复制延迟指标 | 复用 Prometheus 接入，新建指标集 |
+| 升级 | 先备后主、受控 switchover 的滚动更新 | 还需按 GTM/CN/DN 依赖和兼容矩阵排序 | 复用策略思想，新建编排 |
+
+CNPG 官方明确限制应用镜像为“一个 Primary + 多个可选 Hot Standby”的 PostgreSQL 架构，并只支持 PGDG 正式支持的 PostgreSQL 版本。因此，把 OpenTenBase 镜像直接声明为受支持的 CNPG 镜像是不成立的产品承诺。可以做兼容性 spike，但不能作为 PoC 的控制面基础。
+
+## 5. OpenTenBase 当前部署模型
+
+OpenTenBase 的公开说明和 `opentenbase_ctl` 源码共同给出以下事实：
+
+- 分布式模式由 GTM、CN、DN 组成；用户连接 CN，数据保存在 DN，GTM 管理全局事务。
+- 集中式模式只有一个逻辑 DN 组，不需要 GTM/CN。
+- CN/DN 初始化不是普通 `initdb`：还需要 `--nodename`、`--nodetype` 和 GTM 主节点参数。
+- CN/DN 的备实例从同名主实例执行 `pg_basebackup`。
+- 安装器实际顺序是 GTM 主节点先启动；CN/DN 主节点可并行；之后启动 CN/DN/GTM 备节点；最后创建默认 node group。
+- 通用产品形态尚不能把 `expand`/`shrink` 当作安全能力。
+
+这也修正了“GTM -> DN -> CN 必须完全串行”的过度简化。真正的硬依赖是 GTM 必须先就绪；CN/DN 主实例在拥有 GTM 地址后可以并行初始化，但分布式节点目录和默认 node group 只能在所有必要主实例就绪后提交。
+
+## 6. 三种接入方式
+
+### 方案 A：fork CNPG
+
+优点是可以直接修改现成 controller、instance manager 和备份代码。缺点是 CNPG 的核心不变量就是单主多备；为了 GTM 和多 CN/DN 改写该不变量，实际会触及 API、故障切换、Service、备份和升级的全部核心路径。长期还要持续合并上游变化。
+
+**结论：拒绝。** 这不是小范围适配，而是用错误的领域模型做二次开发。
+
+### 方案 B：高层 Operator 组合多个 CNPG `Cluster`
+
+每个 CN/DN 逻辑节点对应一个 CNPG `Cluster`，GTM 由 OpenTenBase Operator 自管。它能最大化复用单逻辑节点内的复制、PVC、Service、备份和滚动更新。
+
+主要风险是 CNPG 明确不支持 OpenTenBase 版本/镜像和多角色语义；instance manager 会覆盖入口并按 PostgreSQL 单集群假设管理进程。跨 CNPG child resource 的拓扑提交、故障切换和全局备份仍需新建。
+
+**结论：只作为 time-boxed 兼容性 spike。** 通过以下门槛后才可考虑进入第二阶段：
+
+1. OpenTenBase CN/DN 镜像通过 CNPG bootstrap、探针、复制和 switchover e2e。
+2. CNPG 升级不会覆盖 OpenTenBase 必需配置。
+3. 上游明确接受或至少记录该非 PGDG 使用边界。
+
+### 方案 C：独立 Operator，复用 CNPG 模式与生态
+
+Operator 直接管理 StatefulSet、Service、PVC、Secret、ConfigMap、Lease 和 PodMonitor。Pod 内使用轻量 `otb-instance-manager` 管理 CN/DN/GTM 的角色化启动、探针和优雅退出。外围能力遵循 CNPG 已验证的接口和运行模式。
+
+**结论：推荐。** 它的新增代码正好覆盖 OpenTenBase 独有语义，并避免依赖 CNPG 不承诺的扩展点。
+
+## 7. 推荐架构
+
+```mermaid
+flowchart TB
+  CR["OpenTenBaseCluster CR"]
+  OP["OpenTenBase Operator"]
+  LEASE["Topology Lease"]
+  CR --> OP
+  OP --> LEASE
+
+  subgraph GTM["GTM logical group"]
+    GTMSS["StatefulSet: demo-gtm"]
+    GTMSVC["Headless + primary Service"]
+    GTMPVC["PVC per ordinal"]
+    GTMSS --> GTMSVC
+    GTMSS --> GTMPVC
+  end
+
+  subgraph CN["Coordinator groups"]
+    CNSS["StatefulSet per logical CN"]
+    CNSVC["Headless per group"]
+    CNRW["Cluster client Service"]
+    CNPVC["PVC per ordinal"]
+    CNSS --> CNSVC
+    CNSS --> CNRW
+    CNSS --> CNPVC
+  end
+
+  subgraph DN["DataNode groups"]
+    DNSS["StatefulSet per logical DN"]
+    DNSVC["Headless + primary per group"]
+    DNPVC["PVC per ordinal"]
+    DNSS --> DNSVC
+    DNSS --> DNPVC
+  end
+
+  OP --> GTMSS
+  OP --> CNSS
+  OP --> DNSS
+  GTMSVC --> CNSS
+  GTMSVC --> DNSS
+  CNSS --> DNSS
+  METRICS["Prometheus / PodMonitor"] --> GTMSS
+  METRICS --> CNSS
+  METRICS --> DNSS
+```
+
+### 7.1 资源映射
+
+以 `coordinator.groups: 2`、`replicasPerGroup: 2` 为例：
+
+- `demo-gtm`：一个 StatefulSet，ordinal 0/1 提供两个稳定候选实例；实际主备角色由数据库状态确认，不能由 ordinal 推导。
+- `demo-cn-0`、`demo-cn-1`：每个逻辑 CN 一个 StatefulSet，每个有两个实例。
+- `demo-dn-0`、`demo-dn-1`：每个逻辑 DN 分片一个 StatefulSet，每个有两个实例。
+
+不采用“所有 CN 一个 StatefulSet、所有 DN 一个 StatefulSet”，因为那会把“逻辑节点编号”和“主备编号”压进同一 ordinal，导致滚动、PVC 所有权、反亲和、故障域和缩容语义难以验证。
+
+### 7.2 Service
+
+| Service | Selector | 用途 | 默认暴露 |
+| --- | --- | --- | --- |
+| `<name>-gtm` | 当前 GTM primary 标签 | CN/DN 的 GTM 地址 | 仅集群内 |
+| `<name>-gtm-headless` | 全部 GTM 实例 | 稳定 DNS、复制 | 仅集群内 |
+| `<name>-cn-<n>-headless` | 指定逻辑 CN 全部实例 | 主备复制/发现 | 仅集群内 |
+| `<name>-rw` | 所有 `role=coordinator, serving=true` 的主实例 | 应用入口，可为 ClusterIP/LoadBalancer | 按 CRD |
+| `<name>-dn-<n>` | 指定逻辑 DN 当前 primary | CN 到 DN 路由 | 仅集群内 |
+| `<name>-dn-<n>-headless` | 指定逻辑 DN 全部实例 | 主备复制/发现 | 仅集群内 |
+
+DN 和 GTM 不提供默认外部 Service。网络策略只允许 Operator、同集群数据库 Pod、监控和明确授权的运维 Job 访问内部端口。
+
+### 7.3 Readiness 语义
+
+Pod readiness 必须高于 `pg_isready`：
+
+- GTM：进程响应且确认当前角色。
+- DN：本地数据库可用、能访问期望 GTM、节点身份匹配。
+- CN：本地数据库可用、能访问 GTM、实际节点目录哈希等于 `status.topologyRevision`。
+
+只有 CN 满足最后一条时，Operator 才设置 `serving=true`，客户端 Service 才会选中它。
+
+## 8. Reconcile 与初始化状态机
+
+| Phase | 控制器动作 | 进入下一阶段的门槛 |
+| --- | --- | --- |
+| `Pending` | 默认值、CEL/webhook 校验、生成规范拓扑和 revision | spec 合法；镜像、Secret、StorageClass 可解析 |
+| `Provisioning` | 创建 ServiceAccount、Secret/ConfigMap、Service、PVC/StatefulSet 模板 | 所有 owner reference 和资源规格一致 |
+| `BootstrappingGTM` | 初始化并启动 GTM primary，再建立 standby | GTM primary 探针通过；standby 达到策略要求 |
+| `BootstrappingDataPlane` | CN/DN primary 并行执行角色化 initdb 和启动 | 所有必要 primary 可本地连接并能访问 GTM |
+| `BootstrappingReplicas` | CN/DN standby 通过同组 primary 的 `pg_basebackup` 创建 | 每组达到 `replicasPerGroup` 的就绪门槛 |
+| `RegisteringTopology` | 获取 Lease；比较实际目录；执行 CREATE/ALTER NODE 和默认 node group；再次读取校验 | 每个 serving CN 的实际目录哈希等于期望 revision |
+| `Ready` | 设置 Conditions、Service selector、持续健康检查 | 所有核心不变量成立 |
+| `Degraded` | 停止危险自动操作，保留诊断信息和可恢复资源 | 人工修复或后续 reconcile 重新满足门槛 |
+
+### 8.1 幂等与故障恢复
+
+- 初始化用 PVC 内 marker + 数据库实际查询双重确认；marker 只能作为提示，数据库状态是最终证据。
+- SQL 不直接盲重放：先查询节点目录，再生成差异化的 `CREATE NODE`/`ALTER NODE`；不在期望拓扑中的节点只报告，不在 PoC 自动删除。
+- `status` 只有在外部副作用确认成功后更新。
+- reconcile 使用退避和 Kubernetes Event；不可恢复配置错误设置 `SpecInvalid=True`，不会不断重启 Pod。
+- Operator 崩溃后可从 StatefulSet/PVC、数据库角色和节点目录重建 observed state。
+
+## 9. CRD 关键语义
+
+CRD 草案把“逻辑组数”和“每组实例数”分开：
+
+```yaml
+spec:
+  mode: Distributed
+  gtm:
+    replicas: 2
+  coordinator:
+    groups: 2
+    replicasPerGroup: 2
+  datanode:
+    groups: 2
+    replicasPerGroup: 2
+```
+
+- `groups` 决定数据库逻辑节点/分片数量。
+- `replicasPerGroup` 决定同一逻辑节点的数据副本数量。
+- `mode: Centralized` 时禁止 GTM/CN，且 `datanode.groups` 必须为 1。
+- `status` 暴露 phase、conditions、observedGeneration、topologyRevision 和每角色 ready/desired 数量。
+- PoC 默认 `topologyChangePolicy: Manual`，避免把 StatefulSet 数量变化误当作安全的数据库扩缩容。
+
+## 10. 生命周期边界
+
+### 10.1 扩容与缩容
+
+| 操作 | PoC 行为 | 后续实现前置条件 |
+| --- | --- | --- |
+| 增加 CN 逻辑组 | 生成变更计划，默认等待人工批准 | 所有节点目录幂等注册、连接排空和回滚测试 |
+| 减少 CN 逻辑组 | 拒绝 | Service 摘除、连接排空、全拓扑 DROP NODE 协议 |
+| 增加 DN 逻辑组 | 拒绝 | OpenTenBase 通用形态的数据迁移/再平衡协议 |
+| 减少 DN 逻辑组 | 拒绝 | 分片排空、数据完整性证明、显式破坏性批准 |
+| 增加同组 standby | 计划态或实验开关 | `pg_basebackup`、复制槽/参数、角色确认 e2e |
+| PVC 扩容 | StorageClass 支持时允许 increase-only | 文件系统扩容和磁盘指标验证 |
+
+### 10.2 故障切换
+
+PoC 提供检测和 fencing，不提供“看到 Pod 失败就自动 promote”：
+
+1. 先确认旧主不可写，避免双主。
+2. 选择满足复制位置、时间线和拓扑 revision 的候选。
+3. 按数据库协议 promote。
+4. 更新 GTM/DN/CN 依赖和 Service selector。
+5. 从所有 serving CN 验证拓扑。
+
+在这套协议通过网络分区、Operator 重启、旧主复活和部分元数据提交测试前，自动切换会放大数据损坏风险。
+
+### 10.3 升级
+
+- Operator 自身升级与数据库镜像升级分离。
+- 数据库升级先做兼容性 preflight 和备份可恢复性检查。
+- 同一逻辑组先升级 standby，再受控切换，再升级旧主。
+- 集群角色顺序由版本兼容矩阵决定；默认 CN/DN 分批，GTM 最后，任一批次失败即停止。
+- 主版本升级不伪装成滚动升级，使用逻辑迁移或经过验证的 dump/restore/蓝绿流程。
+
+## 11. 备份与恢复
+
+CNPG 的单集群 base backup + WAL/PITR 不能自动提升为 OpenTenBase 全局一致备份。独立备份各 DN 可能对应不同全局事务边界；只恢复 DN 而没有匹配的 GTM/目录状态，也不能证明集群一致。
+
+因此分两层处理：
+
+1. **可复用层**：对象存储凭据、加密、保留策略、上传/恢复 Job、CSI VolumeSnapshot、告警和备份 CR 状态模式。
+2. **必须新建层**：全局写入屏障或一致性快照协议、各 DN/GTM 恢复点清单、拓扑 revision、原子发布的 backup manifest、全角色恢复顺序和恢复后校验。
+
+PoC 不暴露“已支持 PITR”的字段。第一版备份实验只允许在显式维护窗口内完成全局 checkpoint/写入 fencing 后，对所有成员产生同一 manifest；恢复测试成功前不得标记 `BackupReady=True`。
+
+## 12. 监控
+
+复用 CNPG 的 Prometheus 思路：每个实例在独立 metrics 端口导出基础 PostgreSQL/进程/存储指标，Operator 可选创建 PodMonitor。新增 OpenTenBase 指标：
+
+- `opentenbase_role_up{role,logical_node,instance}`
+- `opentenbase_topology_revision{coordinator}`
+- `opentenbase_topology_mismatch_total`
+- `opentenbase_gtm_connectivity`
+- `opentenbase_replication_lag_bytes{logical_node,instance}`
+- `opentenbase_reconcile_phase`
+- `opentenbase_reconcile_errors_total{reason}`
+- `opentenbase_dn_group_count`
+
+关键告警包括：无 serving CN、GTM 不可达、同组出现多个 primary、CN 拓扑 revision 不一致、复制延迟超过阈值、PVC 容量不足、reconcile 长时间停在同一 phase。
+
+## 13. 安全与权限
+
+- Operator 使用 namespace-scoped Role，默认不需要 cluster-admin。
+- Secret 只通过引用传入，不复制到 CR status/Event/日志。
+- 数据库 Pod 使用非 root、只读 root filesystem、独立 ServiceAccount 和最小 Linux capabilities。
+- 拓扑 SQL 使用专用管理凭据；业务账号不能执行节点目录变更。
+- admission 校验模式和拓扑下限；破坏性变更由 webhook/Operator 双重拒绝。
+- finalizer 只保证数据库级清理顺序，不默认删除 PVC；PVC 保留策略必须显式配置。
+
+## 14. 风险登记
+
+| 风险 | 后果 | PoC 缓解/验证 |
+| --- | --- | --- |
+| StatefulSet ordinal 被误当作数据库主角色 | 双主或错误路由 | 角色探针 + selector 标签只由 instance agent/Operator 更新 |
+| 拓扑 SQL 部分成功 | CN 目录不一致 | Lease、revision、读后校验、差异化重试 |
+| Pod IP 进入数据库目录 | 重建后路由失效 | 只注册稳定 Service DNS |
+| DN 数量直接缩减 | 数据丢失 | spec 变更 fail closed |
+| 各 DN 独立备份 | 恢复后全局不一致 | 不宣称分布式 PITR；先设计全局 manifest/barrier |
+| GTM 自动切换协议不完整 | GXID/快照风险 | PoC 只检测和 fencing，人工 promote |
+| OpenTenBase 镜像交给 CNPG instance manager | 上游不支持、升级不可预测 | 仅限隔离 compatibility spike |
+| Operator 删除导致资源误删 | 数据丢失 | PVC 默认 Retain，finalizer 明确列出阻塞原因 |
+
+## 15. 分阶段落地
+
+### Phase 0：兼容性与不变量实验（1–2 周）
+
+- 制作 Kubernetes 可运行的 OpenTenBase 镜像。
+- 在 Kind 上验证 GTM、单 CN、单 DN 的角色化 initdb、稳定 DNS、重启和 PVC 重挂载。
+- time-box CNPG child `Cluster` spike，记录 instance manager 的具体不兼容点。
+- 退出门槛：初始化命令、探针和数据库目录查询都有可重复 e2e。
+
+### Phase 1：最小 Operator（2–4 周）
+
+- 实现 CRD、默认值/校验、资源生成、phase/status/conditions。
+- 实现 GTM -> CN/DN -> topology 的幂等 bootstrap。
+- 实现 CN 客户端 Service、基础指标、网络策略。
+- 退出门槛：删除任意非数据 Pod、重启 Operator、重复 apply CR 都能收敛到同一 topologyRevision。
+
+### Phase 2：单逻辑组 HA（3–5 周）
+
+- 实现 CN/DN standby、fencing、人工 switchover、复制延迟门槛。
+- 增加跨 node/zone 调度和 PDB。
+- 退出门槛：主 Pod 丢失、网络分区、旧主恢复场景无双主，RPO/RTO 有测量结果。
+
+### Phase 3：数据保护与受控演进
+
+- 定义全局 backup manifest/barrier，完成整集群恢复演练。
+- 实现 CN 安全扩展；DN 扩展必须等数据库再平衡接口成熟。
+- 形成版本兼容矩阵和滚动升级 e2e。
+
+## 16. PoC 验证矩阵
+
+| 场景 | 期望结果 |
+| --- | --- |
+| 首次创建 distributed CR | 按 phase 收敛，所有 serving CN 目录 revision 相同 |
+| 重复 apply 相同 CR | 不重复 initdb/CREATE NODE，资源无无意义 diff |
+| Operator 在每个 phase 崩溃并重启 | 从外部实际状态恢复并继续 |
+| GTM 未就绪 | CN/DN 不 Ready，不进入 topology 注册 |
+| CN/DN Pod 重建 | PVC 和逻辑节点名保持，Service DNS 不变 |
+| CN 目录被手工修改 | 检测 mismatch；只执行可证明安全的修复，否则 Degraded |
+| 修改 DN groups | admission 或 reconcile 明确拒绝，现有数据面不变 |
+| 同组出现双 primary 信号 | 摘除 Service、设置 SplitBrainSuspected，不自动选主 |
+| PVC 接近满 | 指标与告警生效，不通过盲目 failover 掩盖磁盘问题 |
+| 删除 CR | 受 finalizer/保留策略控制，PVC 默认保留 |
+
+## 17. 待社区讨论
+
+1. OpenTenBase 是否已有可供 Operator 调用的正式 topology diff/reconcile API，还是首版只能通过 SQL 和 `opentenbase_ctl` 能力拆分？
+2. GTM 当前推荐的选主、fencing 和数据同步协议是什么？哪些状态可以安全暴露为探针？
+3. 通用 OpenTenBase 形态何时能提供 DN 在线再平衡接口？在此之前是否同意 CRD 把 DN groups 设为 immutable？
+4. CN/DN 主备切换后，哪些节点目录字段必须同步更新，是否需要全 CN 广播？
+5. 全局一致备份是否已有事务屏障/快照接口可复用？
+6. 社区倾向把 Operator 放在本仓库 `contrib/`，还是建立独立仓库以隔离 Go/Kubernetes 发布周期？
+7. 是否接受以 CNPG 1.30 为行为基线但不承诺 API/二进制兼容的定位？
+
+## 18. 参考资料
+
+### CloudNativePG 官方资料
+
+- [项目主页与许可证](https://github.com/cloudnative-pg/cloudnative-pg)
+- [1.30 Container Image Requirements](https://cloudnative-pg.io/docs/1.30/container_images/)
+- [1.28 Architecture](https://cloudnative-pg.io/docs/1.28/architecture/)
+- [1.28 Postgres Instance Manager](https://cloudnative-pg.io/docs/1.28/instance_manager/)
+- [1.28 Service Management](https://cloudnative-pg.io/docs/1.28/service_management/)
+- [1.28 Storage](https://cloudnative-pg.io/docs/1.28/storage/)
+- [1.28 Bootstrap](https://cloudnative-pg.io/docs/1.28/bootstrap/)
+- [1.28 Monitoring](https://cloudnative-pg.io/docs/1.28/monitoring/)
+- [Operator capability levels](https://cloudnative-pg.io/docs/current/operator_capability_levels/)
+
+### OpenTenBase 一手资料
+
+- [OpenTenBase 架构与部署说明](https://github.com/OpenTenBase/OpenTenBase/blob/b612d77c/README.md)
+- [`opentenbase_ctl` 初始化参数](https://github.com/OpenTenBase/OpenTenBase/blob/b612d77c/contrib/opentenbase_ctl/src/cluster/cluster.cpp#L829-L870)
+- [`opentenbase_ctl` 分布式安装状态机](https://github.com/OpenTenBase/OpenTenBase/blob/b612d77c/contrib/opentenbase_ctl/src/cluster/cluster.cpp#L1009-L1077)
+- [`opentenbase_ctl` 节点目录和默认 node group](https://github.com/OpenTenBase/OpenTenBase/blob/b612d77c/contrib/opentenbase_ctl/src/cluster/cluster.cpp#L161-L223)
+- [`opentenbase_ctl` 用户文档](https://github.com/OpenTenBase/OpenTenBase/blob/b612d77c/contrib/opentenbase_ctl/README.md)


### PR DESCRIPTION
## 概述

- 对比 CloudNativePG、StackGres、Crunchy PGO 和 Zalando Operator，选择 CloudNativePG 作为运维设计基线
- 从 OpenTenBase 的 GTM、Coordinator、DataNode、拓扑目录和存储不变量推导安全边界
- 设计角色感知的 `OpenTenBaseCluster` 协调状态机，避免把分布式数据库错误建模为单一 PostgreSQL 主备集群
- 提供结构化 CRD 草案、最小集群示例和 AI 使用策略报告

## 背景与方案

现有 PostgreSQL Operator 通常假设一个 PostgreSQL 主实例和若干热备实例。OpenTenBase 还需要处理跨角色引导、稳定的分布式节点身份、GTM 可用性、CN 节点目录一致性以及具备数据语义的 DN 扩缩容。直接复用单集群状态模型，会让不安全的操作看起来合法。

本方案复用 CloudNativePG 在状态管理、单实例存储、Service、监控和受控升级方面已经验证的 Kubernetes 模式，同时由专用控制器负责 OpenTenBase 特有的拓扑、GTM、备份一致性和扩缩容语义。

源码核查还修正了一个常见的过度简化：当前安装器先启动 GTM 主节点，然后并行启动 CN/DN 主节点，再启动各备节点，最后创建默认 node group。

## 交付物

- [可行性设计方案](https://github.com/soso23412/OpenTenBase/blob/b99adafe6ce6958503796057d2f1b36f034bf5f5/docs/plans/2026-07-28-opentenbase-cloudnativepg-integration-design.md)
- [`OpenTenBaseCluster` CRD 草案](https://github.com/soso23412/OpenTenBase/blob/b99adafe6ce6958503796057d2f1b36f034bf5f5/docs/design/opentenbase-cluster-crd.yaml)
- [最小集群示例](https://github.com/soso23412/OpenTenBase/blob/b99adafe6ce6958503796057d2f1b36f034bf5f5/docs/design/opentenbase-cluster-example.yaml)
- [AI 使用策略报告](https://github.com/soso23412/OpenTenBase/blob/b99adafe6ce6958503796057d2f1b36f034bf5f5/docs/design/issue-201-ai-usage-report.md)

## 验证

- `git diff HEAD^ --check`
- CRD 和示例资源的结构断言
- Markdown 本地链接校验
- 不可见格式字符和 Tab 扫描
- 对照 `opentenbase_ctl` 初始化及拓扑代码核查关键结论

编写环境中没有可用的 Kubernetes 集群，因此本 PR 不声称已经完成服务端 CRD 校验或部署端到端测试。

关联 Issue：#201

AI 辅助：OpenAI Codex
