### PR TITLE
修复 CN 透明转发 text DataRow 导致 pgjdbc binary timestamp 解析失败

### DIFF
--- a/src/backend/access/common/printtup.c
+++ b/src/backend/access/common/printtup.c
@@ -515,33 +515,30 @@ printtup(TupleTableSlot *slot, DestReceiver *self)
 	}
 
 #ifdef PGXC
-	if (!(slot->tts_datarow && slot->tts_tupleDescriptor->cn_penetrate_tuple))
-	{
-		/* Set or update my derived attribute info, if needed */
-		if (myState->attrinfo != typeinfo || myState->nattrs != natts)
-			printtup_prepare_info(myState, typeinfo, natts);
+	/* Set or update my derived attribute info, if needed */
+	if (myState->attrinfo != typeinfo || myState->nattrs != natts)
+		printtup_prepare_info(myState, typeinfo, natts);
 
-		/*
-		 * The datanodes would have sent all attributes in TEXT form. But
-		 * if the client has asked for any attribute to be sent in a binary format,
-		 * then we must decode the datarow and send every attribute in the format
-		 * that the client has asked for. Otherwise its ok to just forward the
-		 * datarow as it is
-		 */
-		for (i = 0; i < natts; ++i)
-		{
-			PrinttupAttrInfo *thisState = myState->myinfo + i;
-			if (thisState->format != 0)
-				binary = true;
-		}
+	/*
+	 * The datanodes would have sent all attributes in TEXT form. But
+	 * if the client has asked for any attribute to be sent in a binary format,
+	 * then we must decode the datarow and send every attribute in the format
+	 * that the client has asked for. Otherwise its ok to just forward the
+	 * datarow as it is.
+	 */
+	for (i = 0; i < natts; ++i)
+	{
+		PrinttupAttrInfo *thisState = myState->myinfo + i;
+		if (thisState->format != 0)
+			binary = true;
 	}
 
 	/*
 	 * If we are having DataRow-based tuple we do not have to encode attribute
 	 * values, just send over the DataRow message as we received it from the
-	 * Datanode
+	 * Datanode.  This is only safe when the frontend asked for text output.
 	 */
-	if (slot->tts_datarow && (!binary || slot->tts_tupleDescriptor->cn_penetrate_tuple) && slot->tts_tupleDescriptor->natts > 0)
+	if (slot->tts_datarow && !binary && slot->tts_tupleDescriptor->natts > 0)
 	{
 		pq_putmessage(message_type, slot->tts_datarow->msg, slot->tts_datarow->msglen);
 #ifdef __OPENTENBASE_C__


### PR DESCRIPTION
**组名：大肘子队**

Fixes #268

﻿## 背景

关联 Issue：#268

pgjdbc 在同一个无参数 `PreparedStatement` 执行多次后，会请求 binary result。OpenTenBase CN 到 DN 的无参数查询可能走 Simple Query，DN 返回 text 格式的 `DataRow`。当 `cn_penetrate_tuple` 开启时，CN 原样转发 DN 返回的 text `DataRow`，导致客户端把 text timestamp 当作 binary timestamp 解析，出现：

```text
Unsupported binary encoding of timestamp
```

## 修改内容

本 PR 调整 `src/backend/access/common/printtup.c` 中 DataRow 透明转发逻辑：

- 始终根据客户端请求的 result format 初始化并检查 `PrinttupAttrInfo`。
- 如果客户端请求中存在 binary result，则不再原样转发 DN 返回的 `DataRow`。
- 只有客户端请求全为 text result 时，才允许透明转发 `DataRow`。
- binary result 场景交回 CN 解码并按客户端请求重新编码。

这样可以避免 `cn_penetrate_tuple` 绕过客户端 result format 检查。

## 验证情况

已在独立测试环境验证：

- 默认 pgjdbc 配置下，无参数 `PreparedStatement` 连续执行不再报错。
- `prepareThreshold=1` 下不再报错。
- `binaryTransfer=false` 仍正常。
- `timestamp`、`timestamptz`、NULL 时间字段均正常读取。
- 抓包确认修复后：
  - DN -> CN 仍返回 text timestamp / timestamptz。
  - CN -> pgjdbc 在客户端请求 binary result 时返回 8 字节 binary timestamp / timestamptz。

## 说明

测试中还发现另一个与 binary parameter / Extended Query 相关的问题，和本 PR 修复的 result DataRow 透明转发问题不同，计划另行提交 Issue 跟踪。
