### PR TITLE
fix: make ORA package compile script fail fast

### DIFF
--- a/contrib/opentenbase_ora_package_function/opentenbase_ora_package_function_compile.sh
+++ b/contrib/opentenbase_ora_package_function/opentenbase_ora_package_function_compile.sh
@@ -1,32 +1,46 @@
-configure_args=$(cat ../src/Makefile.global | grep "configure_args" | awk -F "configure_args =" '{ print $NF }')
-echo "configure_args:"${configure_args}
+#!/usr/bin/env bash
 
-declare MAKE_JOBS=$(($(cat /proc/cpuinfo | grep processor | wc -l) / 1))
+set -euo pipefail
 
-prefix_args=$( cat ../src/Makefile.global | grep "configure_args" | awk -F "configure_args =" '{ print $NF }' | sed "s/'//g" | awk -F "prefix=" '{ print $NF }' | awk '{ print $1 }' )
-echo "prefix_args:"${prefix_args}
-cd opentenbase_ora_package_function
-echo 'make USE_PGXS=1 ${prefix_args}/bin/pg_config clean'
-make PG_CONFIG=${prefix_args}/bin/pg_config clean
- if [ $? -eq 0 ];then
-            echo "=== opentenbase_ora_package_function_compile clean finished ==="
-        else
-            echo "=== opentenbase_ora_package_function_compile clean error($?) ==="
-            exit 1
- fi
-make PG_CONFIG=${prefix_args}/bin/pg_config -j${MAKE_JOBS}
- if [ $? -eq 0 ];then
-            echo "=== opentenbase_ora_package_function_compile make finished ==="
-        else
-            echo "=== opentenbase_ora_package_function_compile make error($?) ==="
-            exit 1
- fi
-make PG_CONFIG=${prefix_args}/bin/pg_config install -j${MAKE_JOBS}
- if [ $? -eq 0 ];then
-            echo "=== opentenbase_ora_package_function_compile make install finished ==="
-        else
-            echo "=== opentenbase_ora_package_function_compile make install error($?) ==="
-            exit 1
- fi
-echo "=== opentenbase_ora_package_function_compile compile is success  ==="
-            
+script_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+makefile_global="${script_dir}/../../src/Makefile.global"
+
+if [[ ! -r "${makefile_global}" ]]; then
+    echo "ERROR: ${makefile_global} is not readable. Run configure before compiling the extension." >&2
+    exit 1
+fi
+
+configure_args=$(sed -n 's/^configure_args[[:space:]]*=[[:space:]]*//p' "${makefile_global}")
+echo "configure_args:${configure_args}"
+
+make_jobs=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+
+prefix_args=$(printf '%s\n' "${configure_args}" | tr -d "'" | sed -n 's/.*--prefix=\([^[:space:]]*\).*/\1/p')
+if [[ -z "${prefix_args}" ]]; then
+    echo "ERROR: configure_args in ${makefile_global} does not contain --prefix." >&2
+    exit 1
+fi
+echo "prefix_args:${prefix_args}"
+
+cd "${script_dir}"
+
+run_make_step()
+{
+    local step=$1
+    shift
+
+    if "$@"; then
+        echo "=== opentenbase_ora_package_function_compile ${step} finished ==="
+    else
+        local status=$?
+        echo "=== opentenbase_ora_package_function_compile ${step} error(${status}) ===" >&2
+        exit "${status}"
+    fi
+}
+
+echo "make PG_CONFIG=${prefix_args}/bin/pg_config clean"
+run_make_step clean make PG_CONFIG="${prefix_args}/bin/pg_config" clean
+run_make_step make make PG_CONFIG="${prefix_args}/bin/pg_config" -j"${make_jobs}"
+run_make_step "make install" make PG_CONFIG="${prefix_args}/bin/pg_config" install -j"${make_jobs}"
+
+echo "=== opentenbase_ora_package_function_compile compile is success ==="


### PR DESCRIPTION
## Summary

- resolve `Makefile.global` and the extension directory from the script's location
- fail clearly when the configured build file or `--prefix` value is unavailable
- preserve the actual failing `make` exit status
- print the success message only after clean, build, and install all succeed

Fixes #208

## Validation

- ran `bash -n contrib/opentenbase_ora_package_function/opentenbase_ora_package_function_compile.sh`
- invoked the script from the repository root and from `/tmp` with a mock `make` command
- verified all three make steps run from the extension directory
- simulated an install failure with exit status 7; the script returned 7 and did not print the success message
- removed `src/Makefile.global`; the script returned 1 with an actionable configuration error
- ran `git diff --check`

A full extension build was not run because this checkout is not configured; the path and failure control flow were validated with the mock command described above.