### PR TITLE
fix: stop install after port assignment failure

### DIFF
--- a/contrib/opentenbase_ctl/src/types/types.cpp
+++ b/contrib/opentenbase_ctl/src/types/types.cpp
@@ -899,7 +899,7 @@ bool parse_command_line(int argc, char** argv, CommandLineArgs& args, Opentenbas
         // Initialize node directories
         if (init_node_directories(config) != 0) {
             LOG_ERROR_FMT("Failed to initialize node directories");
-            return -1;
+            return false;
         }
 
         // Assign ports for nodes
@@ -907,7 +907,7 @@ bool parse_command_line(int argc, char** argv, CommandLineArgs& args, Opentenbas
             // 分配端口
             if (assign_ports_for_nodes(config.nodes, config.server.ssh_user, config.server.ssh_password, config.server.ssh_port) != 0) {
                 LOG_ERROR_FMT("Failed to assign ports for nodes");
-                return -1;
+                return false;
             }
         } else {
             // 查询并补齐端口
@@ -924,12 +924,13 @@ bool parse_command_line(int argc, char** argv, CommandLineArgs& args, Opentenbas
         // 生成操作的节点信息,这个逻辑放到比较靠后的原因是：希望等所有信息补充完后再挑选出要操作的节点
         if (process_op_nodes(args, config) != 0) {
             LOG_INFO_FMT("Invalid --node option. The available options are: cn-master, cn-slave, dn-master, dn-slave, cn0001, ip:port");
-            return -1;
+            return false;
         }
 
         return true;
     } catch (const CLI::ParseError &e) {
-        return app.exit(e);
+        app.exit(e);
+        return false;
     } catch (const std::exception &e) {
         LOG_ERROR_FMT("Error parsing command line arguments: %s", e.what());
         return false;


### PR DESCRIPTION
## Summary

- stop command processing when node directory initialization or port assignment fails
- stop processing when operation-node selection is invalid
- prevent CLI parse error exit codes from being converted to boolean success

Fixes #215

## Root cause

`parse_command_line()` returns `bool`, but several failure paths returned `-1`. In C++, `-1` converts to `true`. After `assign_ports_for_nodes()` exhausted its retries, the parser therefore reported success and `main()` continued with uninitialized node port fields. Those values are architecture- and stack-dependent, explaining the negative ports observed on aarch64.

## Validation

- compiled `types.cpp` in C++17 syntax-only mode
- verified that `parse_command_line()` no longer contains `return -1` or `return app.exit(e)` paths
- ran `git diff --check`

I could not reproduce the full EulerOS/aarch64 deployment locally, so validation focuses on the confirmed control-flow bug and compilation of the changed translation unit.