### PR TITLE
fix: add NULL check after malloc in stat_transaction to prevent NULL pointer dereference

### DIFF
--- a/src/backend/pgxc/pool/execRemote.c
+++ b/src/backend/pgxc/pool/execRemote.c
@@ -244,6 +244,11 @@ stat_transaction(int node_count)
 	if (!statements_per_transaction)
 	{
 		statements_per_transaction = (int *) malloc((MAX_STATEMENTS_PER_TRAN + 1) * sizeof(int));
+		if (statements_per_transaction == NULL)
+		{
+			elog(LOG, "out of memory for statements_per_transaction");
+			return;
+		}
 		memset(statements_per_transaction, 0, (MAX_STATEMENTS_PER_TRAN + 1) * sizeof(int));
 	}
 	if (current_tran_statements > MAX_STATEMENTS_PER_TRAN)
@@ -256,6 +261,11 @@ stat_transaction(int node_count)
 		if (!nodes_per_transaction)
 		{
 			nodes_per_transaction = (int *) malloc(NumDataNodes * sizeof(int));
+			if (nodes_per_transaction == NULL)
+			{
+				elog(LOG, "out of memory for nodes_per_transaction");
+				return;
+			}
 			memset(nodes_per_transaction, 0, NumDataNodes * sizeof(int));
 		}
 		nodes_per_transaction[node_count - 1]++;


### PR DESCRIPTION
## Description

In `stat_transaction()` (src/backend/pgxc/pool/execRemote.c), both `statements_per_transaction` and `nodes_per_transaction` are allocated with `malloc()` but the return values are never checked. If `malloc()` fails and returns `NULL`, the subsequent `memset()` calls will dereference the `NULL` pointer, causing a **segfault crash** of the backend process.

## Root Cause

The `stat_transaction()` function uses `malloc()` to allocate statistics arrays:

```c
statements_per_transaction = (int *) malloc((MAX_STATEMENTS_PER_TRAN + 1) * sizeof(int));
memset(statements_per_transaction, 0, (MAX_STATEMENTS_PER_TRAN + 1) * sizeof(int));
```

```c
nodes_per_transaction = (int *) malloc(NumDataNodes * sizeof(int));
memset(nodes_per_transaction, 0, NumDataNodes * sizeof(int));
```

When `malloc()` returns `NULL` (out of memory), the code proceeds to call `memset()` on a `NULL` pointer, which is undefined behavior and causes a segmentation fault (SIGSEGV), crashing the backend process.

## Fix

Add `NULL` checks after both `malloc()` calls. If allocation fails, log an error message and return early, preventing the `NULL` pointer dereference.

## Verification

- `git diff --check` passes
- Code compiles (syntax-only verification)
- Minimal change: only 10 lines added, no existing logic modified