### PR TITLE
fix: add NULL check after malloc in RecoverShardStatistic to prevent crash

### DIFF
--- a/src/backend/pgxc/shard/shardmap.c
+++ b/src/backend/pgxc/shard/shardmap.c
@@ -3353,6 +3353,11 @@ RecoverShardStatistic(void)
 	int nelems = MAX_SHARDS;
 	int size   = sizeof(ShardRecord) * nelems;
 	ShardRecord *rec = (ShardRecord *)malloc(size);
+	if (rec == NULL)
+	{
+		elog(LOG, "out of memory for shard statistic recovery, size=%d", size);
+		return;
+	}
 
 	if(access(SHARD_STATISTIC_FILE_PATH, F_OK) == 0)
 	{


### PR DESCRIPTION
## Description

In `RecoverShardStatistic()` (src/backend/pgxc/shard/shardmap.c), a large allocation via `malloc()` is performed without checking the return value:

```c
int size = sizeof(ShardRecord) * nelems;  // nelems = MAX_SHARDS
ShardRecord *rec = (ShardRecord *)malloc(size);
```

If `malloc()` returns `NULL` (out of memory), the subsequent `read(fd, rec, size)` call will write to a `NULL` pointer, causing a **segfault crash**. Additionally, `free(rec)` at the end would also crash on a `NULL` pointer (though `free(NULL)` is technically safe, the `read()` before it is not).

## Root Cause

`RecoverShardStatistic()` allocates `MAX_SHARDS * sizeof(ShardRecord)` bytes with `malloc()`. When the system is under memory pressure and `malloc()` returns `NULL`, the code proceeds to:
1. Call `read(fd, rec, size)` — writing to `NULL`, causing SIGSEGV
2. Dereference `rec[i]` in a loop — accessing `NULL` memory, causing SIGSEGV

## Fix

Add a `NULL` check after `malloc()`. If allocation fails, log an error and return early, preventing the crash.

```c
ShardRecord *rec = (ShardRecord *)malloc(size);
if (rec == NULL)
{
    elog(LOG, "out of memory for shard statistic recovery, size=%d", size);
    return;
}
```

## Verification

- `git diff --check` passes
- Minimal change: only 5 lines added, no existing logic modified