### PR TITLE
fix: add NULL check after pg_malloc in GTM main thread initialization

### DIFF
--- a/src/gtm/main/main.c
+++ b/src/gtm/main/main.c
@@ -327,6 +327,11 @@ MainThreadInit()
 	 * use malloc
 	 */
 	thrinfo = (GTM_ThreadInfo *)pg_malloc(sizeof (GTM_ThreadInfo));
+	if (thrinfo == NULL)
+	{
+		fprintf(stderr, "out of memory for thread info\n");
+		exit(1);
+	}
 
 	memset(thrinfo, 0, sizeof(GTM_ThreadInfo));
 
@@ -349,8 +354,18 @@ MainThreadInit()
 	thrinfo->max_lock_number     = g_max_lock_number;
 	thrinfo->backup_timer_handle = INVALID_TIMER_HANDLE;
 	thrinfo->locks_hold = (GTM_RWLock**)pg_malloc(sizeof(void*) * g_max_lock_number);
+	if (thrinfo->locks_hold == NULL)
+	{
+		fprintf(stderr, "out of memory for locks_hold array\n");
+		exit(1);
+	}
 #ifdef __XLOG__
 	thrinfo->write_locks_hold = (GTM_RWLock**)pg_malloc(sizeof(void*) * g_max_lock_number);
+	if (thrinfo->write_locks_hold == NULL)
+	{
+		fprintf(stderr, "out of memory for write_locks_hold array\n");
+		exit(1);
+	}
 	thrinfo->current_write_number = 0;
 	thrinfo->xlog_inserting = false;
     thrinfo->xlog_waiter.pos      = InvalidXLogRecPtr;
@@ -415,12 +430,22 @@ BaseInit(char *data_dir)
     if (Log_directory == NULL)
     {
         Log_directory = (char *) pg_malloc(GTM_MAX_PATH);
+        if (Log_directory == NULL)
+        {
+            fprintf(stderr, "out of memory for log directory\n");
+            exit(1);
+        }
         sprintf(Log_directory, "%s/%s", GTMDataDir, GTM_LOG_FILE_DIR);
     }
 
     if (GTMLogFile == NULL)
     {
         GTMLogFile = (char *) pg_malloc(GTM_MAX_PATH);
+        if (GTMLogFile == NULL)
+        {
+            fprintf(stderr, "out of memory for GTM log file\n");
+            exit(1);
+        }
         sprintf(GTMLogFile, "%s/%s", Log_directory, GTM_LOG_FILE);
     }
 


### PR DESCRIPTION
## Description

In `MainThreadInit()` and `BaseInit()` (src/gtm/main/main.c), multiple `pg_malloc()` calls are made without checking the return values. If `pg_malloc()` fails and returns `NULL`, the subsequent operations (including `memset()`, `sprintf()`, and array dereference) will crash the GTM process with a **segfault (SIGSEGV)**.

## Root Cause

Five `pg_malloc()` calls in GTM main thread initialization lack NULL checks:

1. `thrinfo = (GTM_ThreadInfo *)pg_malloc(sizeof(GTM_ThreadInfo))` — followed by `memset(thrinfo, 0, ...)` which crashes on NULL
2. `thrinfo->locks_hold = (GTM_RWLock**)pg_malloc(...)` — followed by `memset(thrinfo->locks_hold, 0, ...)` which crashes on NULL
3. `thrinfo->write_locks_hold = (GTM_RWLock**)pg_malloc(...)` — followed by dereference which crashes on NULL
4. `Log_directory = (char *) pg_malloc(GTM_MAX_PATH)` — followed by `sprintf(Log_directory, ...)` which crashes on NULL
5. `GTMLogFile = (char *) pg_malloc(GTM_MAX_PATH)` — followed by `sprintf(GTMLogFile, ...)` which crashes on NULL

All of these are in the GTM startup path. A memory allocation failure during startup would cause an undefined behavior crash rather than a clean error exit.

## Fix

Add `NULL` checks after each `pg_malloc()` call. If allocation fails, print an error message to stderr and call `exit(1)` for a clean exit, preventing the segfault crash.

## Verification

- `git diff --check` passes
- Minimal change: only 25 lines added (5 NULL checks), no existing logic modified
- Uses `fprintf(stderr)` + `exit(1)` which is consistent with existing error handling in this file (e.g., `SetMyThreadInfo` failure path)