### PR TITLE
fix: add NULL check after pg_malloc in gtm_ctl to prevent crash

### DIFF
--- a/src/gtm/gtm_ctl/gtm_ctl.c
+++ b/src/gtm/gtm_ctl/gtm_ctl.c
@@ -1449,6 +1449,11 @@ main(int argc, char **argv)
 					{
 						char	   *gtmdata_D;
 						char	   *env_var = pg_malloc(strlen(optarg) + 9);
+						if (env_var == NULL)
+						{
+							fprintf(stderr, "out of memory for env_var\n");
+							exit(1);
+						}
 
 						gtmdata_D = xstrdup(optarg);
 						canonicalize_path(gtmdata_D);
@@ -1462,6 +1467,11 @@ main(int argc, char **argv)
 						 * 'ps' display
 						 */
 						gtmdata_opt = (char *) pg_malloc(strlen(gtmdata_D) + 8);
+						if (gtmdata_opt == NULL)
+						{
+							fprintf(stderr, "out of memory for gtmdata_opt\n");
+							exit(1);
+						}
 						snprintf(gtmdata_opt, strlen(gtmdata_D) + 8,
 								 "-D \"%s\" ",
 								 gtmdata_D);


### PR DESCRIPTION
## Description

In `gtm_ctl.c`, two `pg_malloc()` calls for `env_var` and `gtmdata_opt` are made without checking the return values. If `pg_malloc()` returns `NULL`, the subsequent `snprintf()` calls would write to a `NULL` pointer, causing a **segfault crash** of the `gtm_ctl` utility.

## Root Cause

```c
char *env_var = pg_malloc(strlen(optarg) + 9);
// ... immediately used in snprintf without NULL check
```

```c
gtmdata_opt = (char *) pg_malloc(strlen(gtmdata_D) + 8);
// ... immediately used in snprintf without NULL check
```

## Fix

Add `NULL` checks after both `pg_malloc()` calls. If allocation fails, print an error message and exit.

## Verification

- `git diff --check` passes
- Minimal change: only 10 lines added, no existing logic modified