### PR TITLE
Fix delete command hang when any node deletion fails

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -1188,23 +1188,7 @@ int delete_command(OpentenbaseConfig *config) {
         });
     }
 
-    // Update total progress bar
-    while (true) {
-        int total_progress = 30;  // Base progress
-        bool all_completed = true;
-        
-        for (size_t i = 0; i < config->nodes.size(); ++i) {
-            if (results[i] == 0) {
-                total_progress += 70 / config->nodes.size();
-            } else {
-                all_completed = false;
-            }
-        }
-        
-        if (all_completed) break;
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-
+    // Wait for all threads to complete
     for (auto& thread : threads) {
         thread.join();
     }


### PR DESCRIPTION
## Problem

`opentenbase_ctl delete` can hang forever when the deletion of any node fails.

`delete_command()` in `contrib/opentenbase_ctl/src/cluster/cluster.cpp` spawns one worker thread per node, then waits with this loop before joining the threads:

```cpp
// Update total progress bar
while (true) {
    int total_progress = 30;  // Base progress
    bool all_completed = true;
    for (size_t i = 0; i < config->nodes.size(); ++i) {
        if (results[i] == 0) {
            total_progress += 70 / config->nodes.size();
        } else {
            all_completed = false;
        }
    }
    if (all_completed) break;
    std::this_thread::sleep_for(std::chrono::milliseconds(100));
}
```

Two defects:

- **Hang on failure.** If any node deletion fails, its worker writes `-1` into `results[i]`, `all_completed` can never become `true` again (nothing inside the loop changes `results`), and the process spins in this loop forever — it never reaches `thread.join()` below and never returns the error. The CLI hangs after printing the per-node `Failed` line, e.g. when `stop_node()` fails quickly (SSH connection refused fails within milliseconds).
- **Dead code.** `total_progress` is computed but never used, and since `results[]` is initialized to `0`, the loop can equally exit immediately before the worker threads have even run — it never provided any actual waiting; the `join()` below was already doing all of it.

## Fix

Remove the dead loop and join the threads directly — the same pattern already used by `start_command()`, `stop_command()` and `status_command()` in this file.

## Verification

Verified on `master` @ `b612d77` (Ubuntu 22.04, g++ 11.4.0):

- Full tool build before and after the change (`g++ -std=c++17 -Isrc ... -lssh2 -lpthread` over all 10 sources) compiles cleanly both ways.
- Logic reproduction of the exact loop with worker threads where one node deletion fails fast: the original loop is killed by `timeout 3` (exit 124 — still spinning); with the fix, the command completes in milliseconds, prints the per-node results and propagates the failure (`return -1`) to the caller.
- The all-success path is unchanged: the removed loop exited immediately in that case anyway, and `join()` still provides the waiting.

---

**AI disclosure:** This change was prepared with AI assistance (GitHub Copilot/Claude-style tooling guided by a human contributor).