### PR TITLE
docs: clarify opentenbase_ctl config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ bin  include  lib  opentenbase-5.21.8-i.x86_64.tar.gz  share
 ### Cluster startup steps
 
 #### Generate and fill in configuration file opentenbase\_config.ini .
-opentenbase\_ctl tool can generate a template for the configuration file. You need to fill in the cluster node information in the template. After the opentenbase\_ctl tool is started, opentenbase\_ctl directory will be generated in the current user's home directory. After entering " prepare config" command, the configuration file template that can be directly modified will be generated in opentenbase\_ctl directory.
+opentenbase\_ctl tool can generate a template for the configuration file. You need to fill in the cluster node information in the template. After the opentenbase\_ctl tool is started, opentenbase\_ctl directory will be generated in the current user's home directory. After entering the `prepare config` command, the configuration file template that can be directly modified will be generated in opentenbase\_ctl directory.
 
 * Description of each field in opentenbase\_config.ini
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -123,7 +123,7 @@ cd ${INSTALL_PATH}
 ### 集群启动步骤
 
 #### 生成并填写配置文件 
-opentenbase\_config.opentenbase\_ctl 工具可以生成配置文件的模板。您需要在模板中填写集群节点信息。启动 opentenbase\_ctl 工具后，将在当前用户的主目录中生成 opentenbase\_ctl 目录。输入 "prepare config" 命令后，将在 opentenbase\_ctl 目录中生成可直接修改的配置文件模板。
+opentenbase\_ctl 工具可以生成配置文件的模板。您需要在模板中填写集群节点信息。启动 opentenbase\_ctl 工具后，将在当前用户的主目录中生成 opentenbase\_ctl 目录。输入 `prepare config` 命令后，将在 opentenbase\_ctl 目录中生成可直接修改的配置文件模板。
 
 * opentenbase\_config.ini 中各字段说明
 ```


### PR DESCRIPTION
This PR clarifies the `opentenbase_ctl` configuration template instructions in both English and Chinese README files.

Changes:
- remove the extra leading space from the `prepare config` command in README.md
- fix the duplicated tool name in README_ZH.md
- format `prepare config` as an inline command

Docs-only change; no code tests were run.