### PR TITLE
Propagate command exit status through the opentenbase_ctl exec layer

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -1776,23 +1776,21 @@ int is_node_running(NodeInfo* node, OpentenbaseConfig* config) {
     std::string command = "ps -ef | grep " + node->data_path + " | grep -v grep";
     std::string result;
     int ret = 0;
-    ret = execute_command(node->ip, config->server.ssh_port, 
+    ret = execute_command(node->ip, config->server.ssh_port,
         config->server.ssh_user, config->server.ssh_password, command, result);
-    if (ret != 0)
+    if (ret == 0)
     {
-        // Unkown
-        LOG_ERROR_FMT("Command execution to retrieve (%s:%s)status failed", node->name.c_str(), node->ip.c_str());
-        return 2;
-    }
-    
-    if (result.empty())
-    {
-        // Stopped
-        return 1;
-    } else {
-        // Running
+        // Running: the grep pipeline matched at least one process
         return 0;
-    } 
+    }
+    if (ret == 1)
+    {
+        // Stopped: grep exits 1 when no matching process exists
+        return 1;
+    }
+    // Unknown: the probe itself failed (e.g. unreachable host)
+    LOG_ERROR_FMT("Command execution to retrieve (%s:%s)status failed", node->name.c_str(), node->ip.c_str());
+    return 2;
 }
 
 /**

--- a/contrib/opentenbase_ctl/src/ssh/remote_ssh.cpp
+++ b/contrib/opentenbase_ctl/src/ssh/remote_ssh.cpp
@@ -19,37 +19,59 @@
 
 #include "../log/log.h"
 
+#include <sys/wait.h>
+
+// Decode the raw pclose() status into the child's exit code; -1 when the
+// child could not be reaped or died from a signal.
+static int
+decode_exit_status(int status) {
+    if (status == -1) {
+        return -1;
+    }
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    return -1;
+}
+
 // Execute remote command
-int 
-remote_ssh_exec(const std::string& ip, int port, const std::string& username, 
+int
+remote_ssh_exec(const std::string& ip, int port, const std::string& username,
                    const std::string& password, const std::string& command,
                    std::string& result) {
                         // 将命令进行 Base64 编码
     std::string encoded_command = string_to_base64(command);
-    std::string cmd = "sshpass -p '" + password + "' ssh -o StrictHostKeyChecking=no -p " + 
-                    std::to_string(port) + " " + username + "@" + ip + 
+    std::string cmd = "sshpass -p '" + password + "' ssh -o StrictHostKeyChecking=no -p " +
+                    std::to_string(port) + " " + username + "@" + ip +
                     " 'echo " + encoded_command + " | base64 --decode | bash' 2>&1";
 
     LOG_INFO_FMT("Executing remote command on %s: %s", ip.c_str(), command.c_str());
-    
+
     std::array<char, 4096> buffer;
     std::stringstream ss;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
-    
+
     if (!pipe) {
         LOG_ERROR_FMT("Failed to execute command on %s", ip.c_str());
         return -1;
     }
-    
+
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         ss << buffer.data();
     }
-    
+
     result = ss.str();
     if (!result.empty()) {
         LOG_INFO_FMT("Command output from %s: %s", ip.c_str(), result.c_str());
     }
-    return 0;
+
+    // The ssh exit status carries the remote command's exit code, so callers
+    // can tell an unreachable host (255) from a failed command (non-zero).
+    int exit_code = decode_exit_status(pclose(pipe.release()));
+    if (exit_code != 0) {
+        LOG_ERROR_FMT("Command on %s exited with code %d", ip.c_str(), exit_code);
+    }
+    return exit_code;
 }
 
 // Transfer file to remote host
@@ -180,29 +202,29 @@ get_home_dir(const std::string& ip, int port, const std::string& username,
 }
 
 // Execute local command
-int 
+int
 local_exec(const std::string& command, std::string& result) {
     LOG_INFO_FMT("Executing local command: %s", command.c_str());
-    
+
     std::array<char, 4096> buffer;
     std::stringstream ss;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"), pclose);
-    
+
     if (!pipe) {
         LOG_ERROR_FMT("Failed to execute local command");
         return -1;
     }
-    
+
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         ss << buffer.data();
     }
-    
+
     result = ss.str();
     if (!result.empty()) {
         LOG_INFO_FMT("Command output: %s", result.c_str());
     }
-    return 0;
-} 
+    return decode_exit_status(pclose(pipe.release()));
+}
 
 // 将字符串IP转换为in_addr结构
 bool ip_to_in_addr(const std::string& ip_str, in_addr& addr) {
@@ -293,10 +315,13 @@ int execute_command(const std::string& ip, int port, const std::string& username
 
     } else {
 
-        // Remote execution
-        if (remote_ssh_exec(ip, port, username, password, command, result) != 0) {
+        // Remote execution: keep the child's exit status (not flattened to
+        // -1) so callers like is_node_running can tell a "no match" grep
+        // pipeline (1) from an unreachable host (255).
+        int ret = remote_ssh_exec(ip, port, username, password, command, result);
+        if (ret != 0) {
             LOG_ERROR_FMT("Failed to execute command Remote : %s", command.c_str());
-            return -1;
+            return ret;
         }
     }
 
@@ -320,10 +345,12 @@ int execute_sql_by_psql(const std::string& ip, int port, const std::string& user
         }
 
     } else {
-        // Remote execution
-        if (remote_ssh_exec(ip, port, username, password, command, result) != 0) {
+        // Remote execution: keep the child's exit status for callers that
+        // classify results by exit code.
+        int ret = remote_ssh_exec(ip, port, username, password, command, result);
+        if (ret != 0) {
             LOG_ERROR_FMT("Failed to excute(%s) on server %s, err: %s",command.c_str(),ip.c_str(),result.c_str());
-            return -1;
+            return ret;
         }
     }
 
@@ -333,29 +360,29 @@ int execute_sql_by_psql(const std::string& ip, int port, const std::string& user
 
 int local_exec_as_user(const std::string& user, const std::string& command, std::string& result) {
     LOG_INFO_FMT("Executing local command as user '%s': %s", user.c_str(), command.c_str());
-    
+
     // 使用sudo -u以指定用户身份执行命令
     std::string full_command = "sudo -u " + user + " bash -c \"" + command + "\"";
-    
+
     std::array<char, 4096> buffer;
     std::stringstream ss;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(full_command.c_str(), "r"), pclose);
-    
+
     if (!pipe) {
         LOG_ERROR_FMT("Failed to execute command as user '%s'", user.c_str());
         return -1;
     }
-    
+
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
         ss << buffer.data();
     }
-    
+
     result = ss.str();
     if (!result.empty()) {
         LOG_INFO_FMT("Command output from user '%s': %s", user.c_str(), result.c_str());
     }
-    
-    return 0;
+
+    return decode_exit_status(pclose(pipe.release()));
 }
 
 // Base64 编码表
@@ -426,25 +453,24 @@ std::string string_to_base64(const std::string& input) {
 
 
 // Check if port is available
-int 
+int
 check_port_available(const char *ip, int port, const char *username, const char *password, int ssh_port) {
     std::string cmd = "export PATH=/usr/local/bin:/usr/bin:/usr/sbin:$PATH && ss -tln | grep -q ':" + std::to_string(port) + "'";
     std::string result;
-    
+
     int ret = remote_ssh_exec(ip, ssh_port, username, password, cmd, result);
-    
+
+    // grep -q prints no output: it exits 0 when ss lists the port and 1 when
+    // it does not, so classify by the propagated exit status. Any other code
+    // means the remote probe itself failed.
     if (ret == 0) {
-        // Command executed successfully, check return value
-        if (result.empty()) {
-            // No port found, means port is available
-            return 0;
-        } else {
-            // Port found, means port is occupied
-            return 1;
-        }
-    } else {
-        // Command execution failed
-        LOG_ERROR_FMT("Failed to check port %d on %s: %s", port, ip, result.c_str());
-        return -1;
+        // Port found, means port is occupied
+        return 1;
     }
+    if (ret == 1) {
+        // No port found, means port is available
+        return 0;
+    }
+    LOG_ERROR_FMT("Failed to check port %d on %s: %s", port, ip, result.c_str());
+    return -1;
 }


### PR DESCRIPTION
### Motivation

`remote_ssh_exec`, `local_exec` and `local_exec_as_user` (all in `contrib/opentenbase_ctl/src/ssh/remote_ssh.cpp`) read the child process's output with `fgets()` and let the `unique_ptr<FILE, decltype(&pclose)>` destructor run `pclose()`, which **discards the exit status**, then `return 0;` unconditionally:

```cpp
std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
...
while (fgets(...) != nullptr) { ss << buffer.data(); }
result = ss.str();
return 0;    // <-- pclose status destroyed with the pipe
```

Consequences — every failure mode is reported as success:
- unreachable host / refused connection (ssh exits 255)
- wrong password / sshpass missing
- remote command not found, `initdb` failure, `rm` failure, …
- local command failures (`local_exec`, `local_exec_as_user`)

So every `if (ret != 0)` / `if (remote_ssh_exec(...) != 0)` check in `node.cpp`, `cluster.cpp` and `types.cpp` was **dead code** — the install/config pipeline keeps running on top of a broken state. `remote_scp_file` in the same file already shows the correct pattern (explicit `pclose()` + status check).

### Modification

1. Decode the `pclose()` status (`WIFEXITED`/`WEXITSTATUS`) and return the child's exit code from `remote_ssh_exec`, `local_exec` and `local_exec_as_user`.
2. Keep that exit code (instead of flattening to `-1`) through `execute_command` / `execute_sql_by_psql`, so callers can distinguish exit codes while all existing `!= 0` checks keep working.
3. Adapt the two callers whose logic depended on the broken always-0 contract:
   - `check_port_available` probes with `ss -tln | grep -q ':PORT'`. `grep -q` prints **no output** whether the port is listed or not, so the old `result.empty()` test classified every port as "available" (install hands out colliding ports). Classify by exit status: 0 = occupied, 1 = free, anything else = probe failure.
   - `is_node_running` probes with `ps -ef | grep <data_path> | grep -v grep`, which exits 1 when no process matches. Previously an unreachable host's sshpass error text landed in `result` (stderr is merged via `2>&1`), making the node report as **"Running"**. Classify by exit status: 0 = running, 1 = stopped, anything else = unknown — the `Unknown` state is now reachable as intended.

### Verification

No unit-test infrastructure exists in this repo, so I verified with a standalone harness that links the real `remote_ssh.cpp` + `log.cpp` and runs against a local sshd (replaced `get_home_dir`-style remote paths with real ssh sessions on 127.0.0.1):

| check | before | after |
|---|---|---|
| `local_exec("exit 7")` | returned 0 | returns 7 |
| `local_exec_as_user("root","exit 9")` | returned 0 | returns non-zero (9; 127 when sudo absent) |
| `remote_ssh_exec` to unreachable port | returned 0 | returns 255 |
| `remote_ssh_exec(..., "exit 5")` over live sshd | returned 0 | returns 5 |
| `remote_ssh_exec(..., "echo x")` over live sshd | 0 + output captured | 0 + output captured (unchanged) |
| `check_port_available` on a TCP port occupied by the harness | returned 0 ("available") | returns 1 ("occupied") |
| `check_port_available` on a free port | 0 | 0 |
| `execute_command` with the `ps\|grep` pipeline shape, no match | returned 0 | returns 1 (→ "Stopped") |

Before the fix the harness reports `6 CHECK(S) FAILED`; after the fix `ALL CHECKS PASS`. Also demonstrated end to end: against a host whose sshd is down, `status` used to print `is Running` (sshpass error text in the result string); with the fix the probe exits 255 and the node is classified `Unknown`.

Full tool build check: all `opentenbase_ctl` sources compile cleanly (`g++ 11.4, -std=c++17`) before and after the change.

One pre-existing caller visible in review: `get_node_port` (types.cpp) greps `postgresql.conf` and returns `""` both when the key is missing and when the file is unreadable — with the fix it now logs an error in the unreadable case; the return value is unchanged.
