### PR TITLE
Stop treating parse_command_line failures as success

### DIFF
--- a/contrib/opentenbase_ctl/src/types/types.cpp
+++ b/contrib/opentenbase_ctl/src/types/types.cpp
@@ -487,9 +487,13 @@ int process_op_nodes(CommandLineArgs& args, OpentenbaseConfig& config) {
     {
         return 0;
     }
-    
+
     // 根据 op_nodes_str 的类型决定处理逻辑
     std::string& op_nodes_str = args.op_node;
+    if (op_nodes_str.empty()) {
+        // 未指定 -n 时默认操作所有节点（is_op_node 默认为 true）
+        return 0;
+    }
     if (op_nodes_str == "cn-master") {
         for (auto& node : config.nodes) {
             node.is_op_node = (node.type == Constants::NODE_TYPE_CN_MASTER);
@@ -899,7 +903,7 @@ bool parse_command_line(int argc, char** argv, CommandLineArgs& args, Opentenbas
         // Initialize node directories
         if (init_node_directories(config) != 0) {
             LOG_ERROR_FMT("Failed to initialize node directories");
-            return -1;
+            return false;
         }
 
         // Assign ports for nodes
@@ -907,7 +911,7 @@ bool parse_command_line(int argc, char** argv, CommandLineArgs& args, Opentenbas
             // 分配端口
             if (assign_ports_for_nodes(config.nodes, config.server.ssh_user, config.server.ssh_password, config.server.ssh_port) != 0) {
                 LOG_ERROR_FMT("Failed to assign ports for nodes");
-                return -1;
+                return false;
             }
         } else {
             // 查询并补齐端口
@@ -923,18 +927,24 @@ bool parse_command_line(int argc, char** argv, CommandLineArgs& args, Opentenbas
 
         // 生成操作的节点信息,这个逻辑放到比较靠后的原因是：希望等所有信息补充完后再挑选出要操作的节点
         if (process_op_nodes(args, config) != 0) {
-            LOG_INFO_FMT("Invalid --node option. The available options are: cn-master, cn-slave, dn-master, dn-slave, cn0001, ip:port");
-            return -1;
+            LOG_ERROR_FMT("Invalid --node option. The available options are: cn-master, cn-slave, dn-master, dn-slave, cn0001, ip:port");
+            std::cout << "Invalid --node option. The available options are: cn-master, cn-slave, dn-master, dn-slave, cn0001, ip:port" << std::endl;
+            return false;
         }
 
         return true;
     } catch (const CLI::ParseError &e) {
-        return app.exit(e);
+        // app.exit prints the CLI11 message (or help) and returns the intended
+        // process exit code, but its int result must not flow through this
+        // function's bool contract: any non-zero code would convert to true
+        // and let main() continue with an empty configuration.
+        app.exit(e);
+        return false;
     } catch (const std::exception &e) {
         LOG_ERROR_FMT("Error parsing command line arguments: %s", e.what());
         return false;
     }
-} 
+}
 
 
 // Initialize node directories


### PR DESCRIPTION
### Motivation

`parse_command_line()` in `contrib/opentenbase_ctl/src/types/types.cpp` is declared `bool` but its failure paths returned `-1`, and its `CLI::ParseError` handler did `return app.exit(e);`. Both are `int`-to-`bool` conversions that produce **true**, so `main()` (`if (!parse_command_line(...)) return 1;`) kept executing the command after a parse failure:

```cpp
if (process_op_nodes(args, config) != 0) {
    LOG_INFO_FMT("Invalid --node option. ...");
    return -1;                    // -1 -> true: main() continues!
}
...
} catch (const CLI::ParseError &e) {
    return app.exit(e);           // non-zero error codes -> true
}
```

Concrete consequences (both reproduced, see below):

1. `opentenbase_ctl stop -c config.ini -n 172.16.16.49` — an IP **without** `:port` is an easy typo. `process_op_nodes()` cannot parse it and returns -1 before clearing any node's `is_op_node` flag (all default to `true`), so the `return -1` (→ true) lets `stop_command` run against **every node in the cluster**, having only written an INFO-level log line. The same holds for `start`, `status`, `sql`, `guc`, `scp`, `shell`.
2. `opentenbase_ctl install --bogus-flag` — CLI11 prints the parse error, `app.exit(e)` returns non-zero (→ true), main continues with an empty config, prints "This operation is not supported", and **exits 0**.

The normal "no `-n` given" invocation also went through the broken path: an empty `--node` value fails `parseIpPort()` → `return -1` → true, leaving all `is_op_node` flags at their default. "All nodes" only worked *because of* the bug.

### Modification

- The three `return -1;` failure paths in `parse_command_line()` now `return false;`.
- The `CLI::ParseError` handler calls `app.exit(e)` for its message/help printing but no longer lets its `int` result flow through the `bool` contract.
- The invalid `--node` case is now logged as an error and echoed to the console, matching the other parse failures (which print to `std::cout`).
- `process_op_nodes()` explicitly treats an empty `--node` as "operate on all nodes" (all `is_op_node` flags keep their default `true`), so the common invocation no longer depends on the conversion bug.

### Verification

No unit-test infrastructure exists in this repo; verified with a full build of the tool (`g++ 11.4, -std=c++17`, all sources) run against a demo config whose SSH port is unreachable (never touches a real cluster):

| scenario | before | after |
|---|---|---|
| `stop -c cfg -n 127.0.0.1` (no port) | silently stops **all** nodes — output: `Stop node dn0001 ... Success` ×2, `[Result] Total: 2`, exit 0 | prints `Invalid --node option. The available options are: cn-master, cn-slave, dn-master, dn-slave, cn0001, ip:port`, no node touched, exit 1 |
| `install --bogus-flag` | CLI11 error, then "This operation is not supported", **exit 0** | CLI11 error only, exit 1 |
| `stop -c cfg` (no `-n`) | all nodes, exit 0 | all nodes, exit 0 (unchanged, now by design) |
| `--help` | exit 1 | exit 1 (unchanged) |

Full tool build compiles cleanly before and after the change.
