### PR TITLE
opentenbase_ctl: preserve per-node failure codes in guc concurrency executors

### DIFF
--- a/contrib/opentenbase_ctl/src/node/node.cpp
+++ b/contrib/opentenbase_ctl/src/node/node.cpp
@@ -1468,13 +1468,13 @@ int excute_show_guc_concurrency(OpentenbaseConfig *configInfo, const std::vector
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to show config item " << configInfo->guc.guc_name  << '\n';
                 results[i] = ret;
                 failedCount++;
-                // todo：failedCount++ 应该用原子操作或加锁，否则多线程下不安全！下面会提到 
-            } 
+                // todo：failedCount++ 应该用原子操作或加锁，否则多线程下不安全！下面会提到
+            } else {
+                // 成功
+                results[i] = 0;
+                std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " "<< configInfo->guc.guc_name <<"=" << output << '\n';
+            }
 
-            // 成功
-            results[i] = 0; 
-            std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " "<< configInfo->guc.guc_name <<"=" << output << '\n';
-            
             tatolCount++;
         });
         // 手动递增索引
@@ -1537,14 +1537,14 @@ int excute_del_guc_concurrency(OpentenbaseConfig *configInfo, const std::vector<
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
                 results[i] = ret;
                 failedCount++;
-                // todo：failedCount++ 应该用原子操作或加锁，否则多线程下不安全！下面会提到 
-            } 
+                // todo：failedCount++ 应该用原子操作或加锁，否则多线程下不安全！下面会提到
+            } else {
+                // 成功
+                results[i] = 0;
+                std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Result: " << output << '\n';
+                std::cout << output.c_str() << '\n';
+            }
 
-            // 成功
-            results[i] = 0; 
-            std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Result: " << output << '\n';
-            std::cout << output.c_str() << '\n';
-            
             tatolCount++;
         });
         // 手动递增索引
@@ -1605,29 +1605,30 @@ int excute_change_guc_concurrency(OpentenbaseConfig *configInfo, const std::vect
 
             int ret = delete_guc(configInfo, node);
             if (ret != 0) {
-                LOG_WARN_FMT("Failed to delete config item %s on node %s (%s)", 
-                        configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str());
-                std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
-                results[i] = ret;
-                failedCount++;
-                // todo：failedCount++ 应该用原子操作或加锁，否则多线程下不安全！下面会提到 
-            } 
-
-            ret = add_guc(configInfo, node);
-            if (ret != 0) {
-                LOG_WARN_FMT("Failed to delete config item %s on node %s (%s)", 
+                LOG_WARN_FMT("Failed to delete config item %s on node %s (%s)",
                         configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str());
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
                 results[i] = ret;
                 failedCount++;
                 // todo：failedCount++ 应该用原子操作或加锁，否则多线程下不安全！下面会提到
-            } 
+            } else {
+                // 删除成功后再写入新值，避免删除失败时追加导致配置重复
+                ret = add_guc(configInfo, node);
+                if (ret != 0) {
+                    LOG_WARN_FMT("Failed to add config item %s on node %s (%s)",
+                            configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str());
+                    std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to add config item " << configInfo->guc.guc_name  << '\n';
+                    results[i] = ret;
+                    failedCount++;
+                    // todo：failedCount++ 应该用原子操作或加锁，否则多线程下不安全！下面会提到
+                } else {
+                    // 成功
+                    results[i] = 0;
+                    std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " " << configInfo->guc.guc_name << " Change to " << configInfo->guc.guc_value << '\n';
+                    std::cout << output.c_str() << '\n';
+                }
+            }
 
-            // 成功
-            results[i] = 0; 
-            std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " " << configInfo->guc.guc_name << " Change to " << configInfo->guc.guc_value << '\n';
-            std::cout << output.c_str() << '\n';
-            
             tatolCount++;
         });
         // 手动递增索引


### PR DESCRIPTION
### Motivation

`opentenbase_ctl guc show|change|delete` always exits 0, even when the operation fails on every node, so scripts cannot detect the failure.

In the three GUC concurrency executors (`excute_show_guc_concurrency`, `excute_del_guc_concurrency`, `excute_change_guc_concurrency` in `contrib/opentenbase_ctl/src/node/node.cpp`), a failing node's return code is recorded via `results[i] = ret;`, but the very next statement unconditionally runs:

```cpp
// 成功
results[i] = 0;
```

which overwrites the failure code. The post-join check

```cpp
for (int result : results) {
    if (result != 0) { ... return -1; }
}
```

can therefore never fire. Additionally, the success-path `std::cout` line runs even after a failure, printing a bogus result — for `guc show` the ssh error text gets rendered as if it were the GUC value:

```
dn0001 127.0.0.1:40004 Failed to show config item max_connections
dn0001 127.0.0.1:40004 max_connections=ssh: connect to host 127.0.0.1 port 1: Connection refused

Total: 2,Success: 0
$ echo $?
0
```

Note: on current master this is masked end-to-end because the ssh exec layer ignores remote exit codes and always returns 0, so the per-node GUC helpers never observe a failure. It becomes fully observable once the exit-status propagation of #290 lands; the repro below builds on top of that change to expose it.

### Modification

Move `results[i] = 0;` and the success print into an `else` branch in all three executors, mirroring the existing structure of `excute_cmd_concurrency`:

```cpp
if (ret != 0) {
    ...
    results[i] = ret;
    failedCount++;
} else {
    // 成功
    results[i] = 0;
    std::cout << ... << '\n';
}
tatolCount++;
```

For `excute_change_guc_concurrency` (which implements change as delete-then-add), additionally chain `add_guc()` behind `delete_guc()` success:

* previously both calls ran unconditionally, so a failed `sed` delete was still followed by `echo ... >>` append, leaving a duplicate config entry;
* a fully failing node incremented `failedCount` twice while `tatolCount` only counted once, printing `Success: -2`;
* the add-failure log/message said "delete" (copy-paste); corrected to "add".

### Verification

Compiled the full tool (g++ 11.4, `-std=c++17`), no warnings introduced. Repro used a sandbox config whose ssh-port is unreachable (port 1), so every node operation fails with ssh exit 255 and no real cluster is touched. Built with #290's exec-layer change applied on both sides to make per-node failures observable (it is not needed for the compile or the code change itself):

Before (master `node.cpp`):

```
$ ./opentenbase_ctl guc -c demo-config.ini -o show -k max_connections -n dn-master
dn0001 ... Failed to show config item max_connections
dn0001 ... max_connections=ssh: connect to host 127.0.0.1 port 1: Connection refused
Total: 2,Success: 0
$ echo $?
0

$ ./opentenbase_ctl guc -c demo-config.ini -o change -k max_connections -v 200 -n dn-master
dn0001 ... Failed to delete config item max_connections
dn0001 ... Failed to add config item max_connections
dn0001 ... max_connections Change to 200
Total: 2,Success: -2
$ echo $?
0
```

After this patch (same build):

```
$ ./opentenbase_ctl guc -c demo-config.ini -o show -k max_connections -n dn-master
dn0001 ... Failed to show config item max_connections
dn0001 ... Failed to show config item max_connections
$ echo $?
255

$ ./opentenbase_ctl guc -c demo-config.ini -o change -k max_connections -v 200 -n dn-master
dn0001 ... Failed to delete config item max_connections
$ echo $?
255
```

`guc delete` behaves the same way (exit 255 instead of 0). No more bogus success lines, no more negative success counts, and the exit status now reflects per-node failures, consistent with `shell`/`sql` commands.