### PR TITLE
opentenbase_ctl: fix data races in the concurrent executors

### DIFF
--- a/contrib/opentenbase_ctl/src/node/node.cpp
+++ b/contrib/opentenbase_ctl/src/node/node.cpp
@@ -5,6 +5,7 @@
 #include "../file/file.h"
 #include <unistd.h>
 #include <thread>
+#include <atomic>
 #include <iostream>
 #include <string>
 #include <fstream>
@@ -1220,7 +1221,7 @@ int transfer_package_concurrency(OpentenbaseConfig *configInfo,
     std::vector<std::thread> threads;
     std::vector<int> results(server_list.size(), 0);  // 每个 server 对应一个结果
 
-    int failedCount = 0;
+    std::atomic<int> failedCount = 0;
 
     size_t i = 0;  // 手动维护索引
     for (const std::string& server : server_list) {
@@ -1287,18 +1288,19 @@ int excute_cmd_concurrency(OpentenbaseConfig *configInfo, const std::vector<std:
     // 每个 server 对应一个结果
     std::vector<std::thread> threads;
     std::vector<int> results(server_list.size(), 0);
-    int failedCount = 0;
+    std::atomic<int> failedCount = 0;
 
     // 手动维护索引
-    size_t i = 0; 
-    std::string result;
+    size_t i = 0;
     std::string cmd = configInfo->shell.shell_cmd;
     for (const std::string& server : server_list) {
         LOG_INFO_FMT("Start to excute cmd(%s) on %s", cmd, server);
 
         // 捕获当前 server、i、以及其它所需变量
         threads.emplace_back([&, server, i]() {
-            int ret = execute_command( 
+            // 每个线程独享一份输出，避免并发写共享 std::string 的数据竞争
+            std::string result;
+            int ret = execute_command(
                 server,
                 configInfo->server.ssh_port,
                 configInfo->server.ssh_user,
@@ -1358,12 +1360,11 @@ int excute_sql_concurrency(OpentenbaseConfig *configInfo, const std::vector<Node
     // 每个 server 对应一个结果
     std::vector<std::thread> threads;
     std::vector<int> results(node_list.size(), 0);
-    int failedCount = 0;
-    int tatolCount = 0;
+    std::atomic<int> failedCount = 0;
+    std::atomic<int> tatolCount = 0;
 
     // 手动维护索引
-    size_t i = 0; 
-    std::string result;
+    size_t i = 0;
     std::string cmd = configInfo->shell.shell_cmd;
 
     for (const NodeInfo& node : node_list) {
@@ -1373,13 +1374,15 @@ int excute_sql_concurrency(OpentenbaseConfig *configInfo, const std::vector<Node
         {
             continue;
         }
-        
+
         LOG_DEBUG_FMT("Start to excute cmd(%s) on %s", cmd, node);
 
         // 捕获当前 node、i、以及其它所需变量
         threads.emplace_back([&, node, i]() {
 
-            std::string psql_cmd = build_sql_cmd_for_psql(node.install_path, 
+            // 每个线程独享一份输出，避免并发写共享 std::string 的数据竞争
+            std::string result;
+            std::string psql_cmd = build_sql_cmd_for_psql(node.install_path,
                                                           node.ip, 
                                                           node.port, 
                                                           configInfo->sql.user_name, 
@@ -1443,12 +1446,11 @@ int excute_show_guc_concurrency(OpentenbaseConfig *configInfo, const std::vector
     // 每个 server 对应一个结果
     std::vector<std::thread> threads;
     std::vector<int> results(node_list.size(), 0);
-    int failedCount = 0;
-    int tatolCount = 0;
+    std::atomic<int> failedCount = 0;
+    std::atomic<int> tatolCount = 0;
 
     // 手动维护索引
-    size_t i = 0; 
-    std::string output;
+    size_t i = 0;
     for (const NodeInfo& node : node_list) {
 
         // 如果不是操作的节点，继续下一个
@@ -1460,7 +1462,8 @@ int excute_show_guc_concurrency(OpentenbaseConfig *configInfo, const std::vector
         // 捕获当前 node、i、以及其它所需变量
         threads.emplace_back([&, node, i]() {
 
-
+            // 每个线程独享一份输出，避免并发写共享 std::string 的数据竞争
+            std::string output;
             int ret = show_guc(configInfo, node, output);
             if (ret != 0) {
                 LOG_WARN_FMT("Failed to show config item %s on node %s (%s)", 
@@ -1513,8 +1516,8 @@ int excute_del_guc_concurrency(OpentenbaseConfig *configInfo, const std::vector<
     // 每个 server 对应一个结果
     std::vector<std::thread> threads;
     std::vector<int> results(node_list.size(), 0);
-    int failedCount = 0;
-    int tatolCount = 0;
+    std::atomic<int> failedCount = 0;
+    std::atomic<int> tatolCount = 0;
 
     // 手动维护索引
     size_t i = 0; 
@@ -1583,8 +1586,8 @@ int excute_change_guc_concurrency(OpentenbaseConfig *configInfo, const std::vect
     // 每个 server 对应一个结果
     std::vector<std::thread> threads;
     std::vector<int> results(node_list.size(), 0);
-    int failedCount = 0;
-    int tatolCount = 0;
+    std::atomic<int> failedCount = 0;
+    std::atomic<int> tatolCount = 0;
     std::string sql = "";
 
     // 手动维护索引


### PR DESCRIPTION
### Motivation

The concurrency executors in `contrib/opentenbase_ctl/src/node/node.cpp` share **one `std::string` across all worker threads** and let every thread write it:

* `excute_cmd_concurrency` — shared `result`, written by `execute_command()` (`shell` command)
* `excute_sql_concurrency` — shared `result`, written by `execute_sql_by_psql()` (`sql` command)
* `excute_show_guc_concurrency` — shared `output`, written by `show_guc()` (`guc show`)

Every worker's `remote_ssh_exec()` ends with `result = ss.str()` on the *same* object. Concurrent `std::string` assignment is undefined behavior: two threads race on the internal pointer/size fields and on freeing the old heap buffer. On a multi-server cluster the printed `shell`/`sql`/`guc show` output belongs to a random thread (others' output is silently lost), and the process can crash inside `operator delete`.

The same functions also increment plain `int failedCount` / `tatolCount` from worker threads without synchronization — a second data race that the in-code TODO comments already call out (`failedCount++ 应该用原子操作或加锁`).

### Modification

* Declare the output string **inside each lambda** so every thread owns its buffer; remove the outer shared declaration.
* Make `failedCount` / `tatolCount` `std::atomic<int>` in all six executors (`transfer_package_concurrency`, `excute_cmd_concurrency`, `excute_sql_concurrency`, `excute_show/del/change_guc_concurrency`). `operator++` on atomics keeps every call site unchanged, resolving the existing TODOs.

`excute_del_guc_concurrency` / `excute_change_guc_concurrency` declare a shared `output` too, but nothing ever writes it (delete_guc/add_guc return no output), so there is no race there — left untouched.

### Verification

ThreadSanitizer (g++ 11.4, `-fsanitize=thread -g`), sandbox config with three servers over loopback aliases (sshd on 127.0.0.1/127.0.0.2/127.0.0.3, no real cluster touched):

Before (master):

```
$ ./opentenbase_ctl_tsan shell -c demo3.ini --cmd 'echo hello'
WARNING: ThreadSanitizer: data race
  Write of size 8 ... by thread T2:
    #0 operator delete(void*) ...
    #1 remote_ssh_exec(...) src/ssh/remote_ssh.cpp:48
    #2 execute_command(...) src/ssh/remote_ssh.cpp:297
    #3 operator() src/node/node.cpp:1301      # excute_cmd_concurrency lambda
$ echo $?
66        # forced by TSAN_OPTIONS=exitcode=66
```

* `shell`: 3 data-race warnings (shared `result`)
* `sql`: 4 warnings (shared `result` + counter races)
* `guc show`: 4 warnings (shared `output` + counter races)

After this patch — all five code paths run with **zero** ThreadSanitizer warnings and normal exit codes:

```
shell ... exit 0, 0 warnings
sql ... exit 0, 0 warnings
guc show ... exit 0, 0 warnings
guc delete ... exit 0, 0 warnings
guc change ... exit 0, 0 warnings
```

Also compiled the full tool without sanitizers (g++ 11.4 `-std=c++17`, zero errors) and smoke-tested `shell` on the 3-server sandbox: `Total: 3, Success: 3`.

No behavioral change for the single-server case; output content is unchanged, only its ownership.