### PR TITLE
opentenbase_ctl: make status counters atomic against worker-thread increments

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -518,7 +518,8 @@ int pre_install_command_concurrency(OpentenbaseConfig *config) {
     // Step 2: Transfer and extract package (only for unique IPs)
     std::map<std::string, NodeInfo*> unique_ip_nodes;
     std::vector<int> result(unique_ip_nodes.size(), 0);
-    int failedCount = 0;
+    // 工作线程并发递增，必须原子操作
+    std::atomic<int> failedCount = 0;
     for (auto& node : config->nodes) {
         unique_ip_nodes[node.ip] = &node;
     }
@@ -1362,9 +1363,10 @@ int status_command(OpentenbaseConfig *config) {
 
     std::vector<std::thread> threads;
     std::vector<int> results(opNodes.size(), 0);
-    int runningCount = 0;
-    int stoppedCount = 0;
-    int unkownCount = 0;
+    // 工作线程并发递增，必须原子操作
+    std::atomic<int> runningCount = 0;
+    std::atomic<int> stoppedCount = 0;
+    std::atomic<int> unkownCount = 0;
 
     // instance
     std::cout << "\n ------------- Instance status -----------  " << std::endl;
@@ -1410,8 +1412,8 @@ int status_command(OpentenbaseConfig *config) {
             << ", Running: " << runningCount 
             << ", Stopped: " << stoppedCount
             << ", Unknown: " << unkownCount << "\n" << std::endl;
-    LOG_INFO_FMT("[Result] Total: %zu, Running: %zu, Stopped: %zu, Unknown: %zu", 
-             opNodes.size(), runningCount , stoppedCount, unkownCount);
+    LOG_INFO_FMT("[Result] Total: %zu, Running: %zu, Stopped: %zu, Unknown: %zu",
+             opNodes.size(), runningCount.load(), stoppedCount.load(), unkownCount.load());
 
 
     // connection info
@@ -1602,9 +1604,10 @@ int get_instance_status(OpentenbaseConfig *config) {
 
     std::vector<std::thread> threads;
     std::vector<int> results(config->nodes.size(), 0);
-    int runningCount = 0;
-    int stoppedCount = 0;
-    int unkownCount = 0;
+    // 工作线程并发递增，必须原子操作
+    std::atomic<int> runningCount = 0;
+    std::atomic<int> stoppedCount = 0;
+    std::atomic<int> unkownCount = 0;
 
     // node status
     std::cout << "\n -------------- Node status --------------  " << std::endl;
@@ -1643,8 +1646,8 @@ int get_instance_status(OpentenbaseConfig *config) {
             << ", Running: " << runningCount 
             << ", Stopped: " << stoppedCount
             << ", Unknown: " << unkownCount << "\n" << std::endl;
-    LOG_INFO_FMT("[Result] Total: %zu, Running: %zu, Stopped: %zu, Unknown: %zu", 
-             config->nodes.size(), runningCount , stoppedCount, unkownCount);
+    LOG_INFO_FMT("[Result] Total: %zu, Running: %zu, Stopped: %zu, Unknown: %zu",
+             config->nodes.size(), runningCount.load(), stoppedCount.load(), unkownCount.load());
 
 
     // connection info


### PR DESCRIPTION
### Motivation

`status_command` (and the same-pattern `get_instance_status`) in `contrib/opentenbase_ctl/src/cluster/cluster.cpp` spawn one worker thread per node and increment plain `int` counters inside the lambdas:

```cpp
int runningCount = 0;
int stoppedCount = 0;
int unkownCount = 0;
...
threads.emplace_back([&, i]() {
    results[i] = is_node_running(&opNodes[i], config);
    switch (results[i]) {
        case 0: ... runningCount++; break;
        case 1: ... stoppedCount++; break;
        ...
```

Concurrent `++` on the same non-atomic `int` is a data race (undefined behavior); in practice increments can be lost, so the `[Result] Total: N, Running: X, Stopped: Y, Unknown: Z` summary printed after `join()` can undercount on multi-node clusters — the operator sees `Total: 6, Running: 1, Stopped: 3, Unknown: 0` and cannot tell whether two nodes vanished from the accounting.

`pre_install_command_concurrency` has the identical pattern with `failedCount`, incremented by the package-transfer threads.

This is the same class of race fixed for the node.cpp executors in #293.

### Modification

* `status_command`, `get_instance_status`: `runningCount` / `stoppedCount` / `unkownCount` → `std::atomic<int>` (`operator++` call sites unchanged).
* `pre_install_command_concurrency`: `failedCount` → `std::atomic<int>`.
* The two `LOG_INFO_FMT` summary lines pass the counters through varargs, where `std::atomic` is not copyable; pass `.load()` explicitly.
* `start_command` / `stop_command` compute their counters after `join()` from `results` and are not raced — untouched.

`<atomic>` is already included in cluster.cpp.

### Verification

ThreadSanitizer (g++ 11.4, `-fsanitize=thread -g`), 3-server sandbox config (sshd on 127.0.0.1/.2/.3, no cluster touched):

Before (master):

```
$ ./opentenbase_ctl status -c demo3.ini -n dn-master
WARNING: ThreadSanitizer: data race
  Read of size 4 ... by thread T1:
    #0 operator() src/cluster/cluster.cpp:1391     # stoppedCount++ in status_command lambda
    #1 __invoke_impl<void, status_command(OpentenbaseConfig*)::<lambda()> > ...
$ echo $?
66      # forced by TSAN_OPTIONS=exitcode=66
```

After this patch:

```
$ ./opentenbase_ctl status -c demo3.ini -n dn-master
Node dn0001(127.0.0.1:) is Stopped
Node dn0002(127.0.0.2:) is Stopped
Node dn0003(127.0.0.3:) is Stopped
[Result] Total: 3, Running: 0, Stopped: 3, Unknown: 0
$ echo $?
0       # zero ThreadSanitizer warnings
```

Full tool also compiles clean without sanitizers (g++ 11.4 `-std=c++17`).