### PR TITLE
opentenbase_ctl: fix division by zero when master IP list is empty

### DIFF
--- a/contrib/opentenbase_ctl/src/types/types.cpp
+++ b/contrib/opentenbase_ctl/src/types/types.cpp
@@ -366,6 +366,10 @@ build_cn_node_config(const ConfigFile& cfg_file, OpentenbaseConfig& config) {
     // 获得IP列表
     std::vector<std::string> master_ips = parse_ip_list(cfg_file.coordinators.master);
     std::vector<std::string> slave_ips = parse_ip_list(cfg_file.coordinators.slave);
+    if (master_ips.empty()) {
+        LOG_ERROR_FMT("The master IP list of coordinators in the Config file is empty. Please correct your configuration.");
+        return -1;
+    }
     if (slave_ips.size() % master_ips.size() != 0) {
         LOG_ERROR_FMT("The number of IPs contained in master should be exactly several times that of the number of IPs in slave. Please correct your configuration..");
         return -1;
@@ -417,6 +421,10 @@ build_dn_node_config(const ConfigFile& cfg_file, OpentenbaseConfig& config) {
     // 获得IP列表
     std::vector<std::string> master_ips = parse_ip_list(cfg_file.datanodes.master);
     std::vector<std::string> slave_ips = parse_ip_list(cfg_file.datanodes.slave);
+    if (master_ips.empty()) {
+        LOG_ERROR_FMT("The master IP list of datanodes in the Config file is empty. Please correct your configuration.");
+        return -1;
+    }
     if (slave_ips.size() % master_ips.size() != 0) {
         LOG_ERROR_FMT("The number of IPs contained in master should be exactly several times that of the number of IPs in slave. Please correct your configuration..");
         return -1;


### PR DESCRIPTION
## Motivation

If the `master` item is missing from the `[coordinators]` or `[datanodes]` section of the config file, `parse_ip_list` returns an empty vector and the node builders divide by `master_ips.size() == 0`, which is undefined behavior.

## Problem

`build_cn_node_config` / `build_dn_node_config` compute `slave_ips.size() % master_ips.size()` before checking that the master IP list is not empty:

* on **x86-64** the process dies with SIGFPE (`Floating point exception`, exit 136) before any diagnostic is printed;
* on **aarch64** the division silently evaluates to 0 (no trap), and the code falls through to the misleading error `The number of IPs contained in master should be exactly several times that of the number of IPs in slave...`, which blames the slave IP count although the real problem is the missing master list.

Reproduce: remove `master = ...` from `[coordinators]` (or `[datanodes]`) in an otherwise valid ini and run e.g. `opentenbase_ctl status -c bad.ini -n dn-master`.

## Modification

Add an explicit empty check for the master IP list in both `build_cn_node_config` and `build_dn_node_config`, returning `-1` with an accurate message:

```
The master IP list of coordinators/datanodes in the Config file is empty. Please correct your configuration.
```

## Verification

Before (master code):

* x86-64 (emulated linux/amd64 container): `status -c bad.ini -n dn-master` and `status -c bad-dn.ini -n dn-master` both die with `Floating point exception`, exit 136, no diagnostic printed.
* UBSan (`-fsanitize=integer-divide-by-zero`, aarch64): `src/types/types.cpp:369:26: runtime error: division by zero` (same for the datanodes site).

After (this patch):

* x86-64: both variants print the new message (`types.cpp:370` / `types.cpp:425`) and exit 1 — no crash.
* UBSan: 0 runtime errors; exit 1 with the accurate message.
* Regression: a valid distributed config still builds all node configs and proceeds to the normal execution path on both aarch64 and x86-64; full normal build passes with no new warnings.