### PR TITLE
opentenbase_ctl: fix dangling pointer in set_log_level

### DIFF
--- a/contrib/opentenbase_ctl/src/log/log.cpp
+++ b/contrib/opentenbase_ctl/src/log/log.cpp
@@ -13,7 +13,7 @@
 #include <mutex>
 
 // Global log level
-static const char* current_log_level = LOG_LEVEL_INFO;
+static std::string current_log_level = LOG_LEVEL_INFO;
 static std::string current_timestamp;
 
 // Log directory path
@@ -40,7 +40,7 @@ get_timestamp() {
 // Check if should record this level log
 static bool 
 should_log(const char* level) {
-    if (strcmp(level, LOG_LEVEL_DEBUG) == 0 && strcmp(current_log_level, LOG_LEVEL_DEBUG) != 0) {
+    if (strcmp(level, LOG_LEVEL_DEBUG) == 0 && strcmp(current_log_level.c_str(), LOG_LEVEL_DEBUG) != 0) {
         return false;
     }
     return true;
@@ -128,7 +128,7 @@ log_warn(const char* message, const char* file, int line) {
 // Format log function implementation
 void 
 log_debug_fmt(const char* format, const char* file, int line, ...) {
-    if (strcmp(current_log_level, LOG_LEVEL_DEBUG) != 0) {
+    if (strcmp(current_log_level.c_str(), LOG_LEVEL_DEBUG) != 0) {
         return;
     }
     char buffer[4096];


### PR DESCRIPTION
## Motivation

`build_log_config` (types.cpp) passes the `c_str()` of a function-local `std::string` to `set_log_level`, which stores the raw pointer in the file-static `current_log_level` (log.cpp). The pointer dangles the moment `build_log_config` returns, and every subsequent `LOG_*` call reads dead stack memory through `strcmp`.

## Problem

* `log.cpp`: `static const char* current_log_level` keeps only the pointer — no copy is made.
* `types.cpp` `build_log_config` is the only caller that passes a non-literal:
  ```cpp
  std::string level = toUpperCase(cfg_file.log.level);
  if (level == LOG_LEVEL_DEBUG || ...) {
      set_log_level(level.c_str());   // pointer into a stack-local string
  }
  ```
* After `build_log_config` returns, the sibling `build_shell_config` / `build_scp_config` / `build_sql_config` / `build_guc_config` calls (all in `build_config`) reuse its dead stack frame, so `current_log_level` points at overwritten memory.

Effect: with `[log] level=DEBUG` configured, DEBUG logging dies silently part-way through config building. In a real run (built at -O0, `status` against a 3-node demo config) the last DEBUG line logged is `Build shell config begin.` — `Build shell config end.`, all scp/sql/guc config lines and every later runtime DEBUG message are lost for the rest of the process. INFO/ERROR logs are not level-gated, which is why this goes unnoticed.

## Modification

Store the level as `std::string` (the same pattern the adjacent `current_timestamp` already uses in log.cpp), so `set_log_level` keeps its own copy. The public signature `void set_log_level(const char*)` and all callers are unchanged; the two internal `strcmp` reads use `.c_str()`. 3 lines changed.

## Verification

* Before (master build, config with `level=DEBUG`, `status -c demo-debug.ini -n dn-master` over real sshd): 50 DEBUG lines, the last one being `Build shell config begin.`; `Build shell config end.` / `Build scp config` / `Build sql config` / `Build guc config` lines and all later DEBUG messages absent (grep count 0).
* After (this patch, same run): 62 DEBUG lines — the 7 missing config-build lines plus 5 runtime DEBUG lines are restored; command completes identically (`Total: 3, Stopped: 3`, exit 0).
* Regression: `level=ERROR` and an invalid level (falls back to INFO) still suppress DEBUG once the config is applied (48 DEBUG lines, all before the override — `main.cpp` sets DEBUG at startup before reading the config), exit 0 in both cases.
* Full tool builds clean with no new warnings.