### PR TITLE
opentenbase_ctl: pass C strings to the LOG_*_FMT printf-style logging

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -737,14 +737,14 @@ int init_node(NodeInfo* node, OpentenbaseConfig* install) {
     } else if (is_slave_gtm(node->type)) {
 
         if (init_and_start_slave_gtm(node, install) != 0) {
-            LOG_ERROR_FMT("Failed to init slave gtm node %s in %s", node->name, node->ip);
+            LOG_ERROR_FMT("Failed to init slave gtm node %s in %s", node->name.c_str(), node->ip.c_str());
             return -1;
         }
         
     } else if (is_slave_cn(node->type) || is_slave_dn(node->type))
     {
         if (redo_and_start_slave_node(node, install) != 0) {
-            LOG_ERROR_FMT("Failed to init slave node %s in %s", node->name, node->ip);
+            LOG_ERROR_FMT("Failed to init slave node %s in %s", node->name.c_str(), node->ip.c_str());
             return -1;
         }
         
@@ -1564,7 +1564,7 @@ int guc_command(OpentenbaseConfig *config_info) {
         ret = excute_show_guc_concurrency(config_info, config_info->nodes);
         if (ret != 0)
         {
-            LOG_ERROR_FMT("Failed to show config item %s", config_info->guc.guc_name);
+            LOG_ERROR_FMT("Failed to show config item %s", config_info->guc.guc_name.c_str());
             return -1;
         }
     } else if(Constants::GUC_OP_CHANGE == op_name){
@@ -1573,7 +1573,7 @@ int guc_command(OpentenbaseConfig *config_info) {
         ret = excute_change_guc_concurrency(config_info, config_info->nodes);
         if (ret != 0)
         {
-            LOG_ERROR_FMT("Failed to change config item %s", config_info->guc.guc_name);
+            LOG_ERROR_FMT("Failed to change config item %s", config_info->guc.guc_name.c_str());
             return -1;
         }
 
@@ -1584,7 +1584,7 @@ int guc_command(OpentenbaseConfig *config_info) {
         ret = excute_del_guc_concurrency(config_info, config_info->nodes);
         if (ret != 0)
         {
-            LOG_ERROR_FMT("Failed to delete config item %s", config_info->guc.guc_name);
+            LOG_ERROR_FMT("Failed to delete config item %s", config_info->guc.guc_name.c_str());
             return -1;
         }
 
@@ -1615,22 +1615,22 @@ int get_instance_status(OpentenbaseConfig *config) {
             switch (results[i]) {
                 case 0:
                     std::cout << "Node " << config->nodes[i].name << "(" << config->nodes[i].ip << ") is Running " << std::endl;
-                    LOG_INFO_FMT("node(%s:%s) is running", config->nodes[i].name, config->nodes[i].ip);
+                    LOG_INFO_FMT("node(%s:%s) is running", config->nodes[i].name.c_str(), config->nodes[i].ip.c_str());
                     runningCount++;
                     break;
                 case 1:
                     std::cout << "Node " << config->nodes[i].name << "(" << config->nodes[i].ip << ") is Stopped " << std::endl;
-                    LOG_INFO_FMT("node(%s:%s) is Stopped", config->nodes[i].name, config->nodes[i].ip);
+                    LOG_INFO_FMT("node(%s:%s) is Stopped", config->nodes[i].name.c_str(), config->nodes[i].ip.c_str());
                     stoppedCount++;
                     break;
                 case 2:
                     std::cout << "Node " << config->nodes[i].name << "(" << config->nodes[i].ip << ") is Unknown " << std::endl;
-                    LOG_INFO_FMT("node(%s:%s) is Unknown", config->nodes[i].name, config->nodes[i].ip);
+                    LOG_INFO_FMT("node(%s:%s) is Unknown", config->nodes[i].name.c_str(), config->nodes[i].ip.c_str());
                     unkownCount++;
                     break;
                 default:
                     std::cout << "Node " << config->nodes[i].name << "(" << config->nodes[i].ip << ") is Unknown " << std::endl;
-                    LOG_INFO_FMT("node(%s:%s) is Unknown", config->nodes[i].name, config->nodes[i].ip);
+                    LOG_INFO_FMT("node(%s:%s) is Unknown", config->nodes[i].name.c_str(), config->nodes[i].ip.c_str());
                     unkownCount++;
             }
         });
@@ -1677,19 +1677,19 @@ int get_node_status(NodeInfo *node, OpentenbaseConfig *config) {
     switch (result) {
         case 0:
             std::cout << "Node " << node->name << "(" << node->ip << ") is Running " << std::endl;
-            LOG_INFO_FMT("node(%s:%s) is running", node->name, node->ip);
+            LOG_INFO_FMT("node(%s:%s) is running", node->name.c_str(), node->ip.c_str());
             break;
         case 1:
             std::cout << "Node " << node->name << "(" << node->ip << ") is Stopped " << std::endl;
-            LOG_INFO_FMT("node(%s:%s) is Stopped", node->name, node->ip);
+            LOG_INFO_FMT("node(%s:%s) is Stopped", node->name.c_str(), node->ip.c_str());
             break;
         case 2:
             std::cout << "Node " << node->name << "(" << node->ip << ") is Unknown " << std::endl;
-            LOG_INFO_FMT("node(%s:%s) is Unknown", node->name, node->ip);
+            LOG_INFO_FMT("node(%s:%s) is Unknown", node->name.c_str(), node->ip.c_str());
             break;
         default:
             std::cout << "Node " << node->name << "(" << node->ip << ") is Unknown " << std::endl;
-            LOG_INFO_FMT("node(%s:%s) is Unknown", node->name, node->ip);
+            LOG_INFO_FMT("node(%s:%s) is Unknown", node->name.c_str(), node->ip.c_str());
     }
 
     // connection info

--- a/contrib/opentenbase_ctl/src/node/node.cpp
+++ b/contrib/opentenbase_ctl/src/node/node.cpp
@@ -1294,7 +1294,7 @@ int excute_cmd_concurrency(OpentenbaseConfig *configInfo, const std::vector<std:
     std::string result;
     std::string cmd = configInfo->shell.shell_cmd;
     for (const std::string& server : server_list) {
-        LOG_INFO_FMT("Start to excute cmd(%s) on %s", cmd, server);
+        LOG_INFO_FMT("Start to excute cmd(%s) on %s", cmd.c_str(), server.c_str());
 
         // 捕获当前 server、i、以及其它所需变量
         threads.emplace_back([&, server, i]() {
@@ -1308,7 +1308,7 @@ int excute_cmd_concurrency(OpentenbaseConfig *configInfo, const std::vector<std:
             );
 
             if (ret != 0) {
-                LOG_ERROR_FMT("Failed to excute cmd(%s) on %s", cmd, server);
+                LOG_ERROR_FMT("Failed to excute cmd(%s) on %s", cmd.c_str(), server.c_str());
                 std::cout << "[ " << server << " ] Failed to excute cmd as user: " << configInfo->server.ssh_user << std::to_string(configInfo->server.ssh_port) << '\n';
                 results[i] = ret;
                 failedCount++;
@@ -1374,7 +1374,7 @@ int excute_sql_concurrency(OpentenbaseConfig *configInfo, const std::vector<Node
             continue;
         }
         
-        LOG_DEBUG_FMT("Start to excute cmd(%s) on %s", cmd, node);
+        LOG_DEBUG_FMT("Start to excute cmd(%s) on %s", cmd.c_str(), node.name.c_str());
 
         // 捕获当前 node、i、以及其它所需变量
         threads.emplace_back([&, node, i]() {
@@ -1394,7 +1394,7 @@ int excute_sql_concurrency(OpentenbaseConfig *configInfo, const std::vector<Node
                                           psql_cmd,
                                           result);
             if (ret != 0) {
-                LOG_WARN_FMT("Failed to excute sql(%s) on %s", cmd, node);
+                LOG_WARN_FMT("Failed to excute sql(%s) on %s", cmd.c_str(), node.name.c_str());
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to excute sql in database " << configInfo->sql.database_name << " as user " << configInfo->sql.user_name << '\n';
                 results[i] = ret;
                 failedCount++;
@@ -1464,7 +1464,7 @@ int excute_show_guc_concurrency(OpentenbaseConfig *configInfo, const std::vector
             int ret = show_guc(configInfo, node, output);
             if (ret != 0) {
                 LOG_WARN_FMT("Failed to show config item %s on node %s (%s)", 
-                        configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str());
+                        configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str());
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to show config item " << configInfo->guc.guc_name  << '\n';
                 results[i] = ret;
                 failedCount++;
@@ -1533,7 +1533,7 @@ int excute_del_guc_concurrency(OpentenbaseConfig *configInfo, const std::vector<
             int ret = delete_guc(configInfo, node);
             if (ret != 0) {
                 LOG_WARN_FMT("Failed to delete config item %s on node %s (%s)", 
-                        configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str());
+                        configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str());
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
                 results[i] = ret;
                 failedCount++;
@@ -1598,7 +1598,7 @@ int excute_change_guc_concurrency(OpentenbaseConfig *configInfo, const std::vect
             continue;
         }
         
-        LOG_INFO_FMT("Start to excute sql(%s) on %s", sql, node);
+        LOG_INFO_FMT("Start to excute sql(%s) on %s", sql.c_str(), node.name.c_str());
 
         // 捕获当前 node、i、以及其它所需变量
         threads.emplace_back([&, node, i]() {
@@ -1606,7 +1606,7 @@ int excute_change_guc_concurrency(OpentenbaseConfig *configInfo, const std::vect
             int ret = delete_guc(configInfo, node);
             if (ret != 0) {
                 LOG_WARN_FMT("Failed to delete config item %s on node %s (%s)", 
-                        configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str());
+                        configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str());
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
                 results[i] = ret;
                 failedCount++;
@@ -1616,7 +1616,7 @@ int excute_change_guc_concurrency(OpentenbaseConfig *configInfo, const std::vect
             ret = add_guc(configInfo, node);
             if (ret != 0) {
                 LOG_WARN_FMT("Failed to delete config item %s on node %s (%s)", 
-                        configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str());
+                        configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str());
                 std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
                 results[i] = ret;
                 failedCount++;
@@ -1678,7 +1678,7 @@ int delete_guc(const OpentenbaseConfig *configInfo, const NodeInfo& node) {
             result);
         if (ret != 0) {
             LOG_WARN_FMT("Failed to delete config item %s on node %s (%s): %s", 
-                    configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str(), result.c_str());
+                    configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str(), result.c_str());
             std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
         } 
         
@@ -1694,7 +1694,7 @@ int delete_guc(const OpentenbaseConfig *configInfo, const NodeInfo& node) {
             result);
         if (ret != 0) {
             LOG_WARN_FMT("Failed to delete config item %s on node %s (%s): %s", 
-                    configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str(), result.c_str());
+                    configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str(), result.c_str());
             std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
         } 
 
@@ -1708,7 +1708,7 @@ int delete_guc(const OpentenbaseConfig *configInfo, const NodeInfo& node) {
             result);
         if (ret != 0) {
             LOG_WARN_FMT("Failed to delete config item %s on node %s (%s): %s", 
-                    configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str(), result.c_str());
+                    configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str(), result.c_str());
             std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
         }
     }
@@ -1751,7 +1751,7 @@ int add_guc(const OpentenbaseConfig *configInfo, const NodeInfo& node) {
                         result);
     if (ret != 0) {
         LOG_WARN_FMT("Failed to add config item %s on node %s (%s): %s", 
-                configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str(), result.c_str());
+                configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str(), result.c_str());
         std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to add config item " << configInfo->guc.guc_name  << '\n';
     }
 
@@ -1780,7 +1780,7 @@ int show_guc(const OpentenbaseConfig *configInfo, const NodeInfo& node, std::str
             result);
         if (ret != 0) {
             LOG_WARN_FMT("Failed to show config item %s on node %s (%s): %s", 
-                    configInfo->guc.guc_name, node.name.c_str(), node.ip.c_str(), result.c_str());
+                    configInfo->guc.guc_name.c_str(), node.name.c_str(), node.ip.c_str(), result.c_str());
             std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to delete config item " << configInfo->guc.guc_name  << '\n';
         } 
 
@@ -1802,7 +1802,7 @@ int show_guc(const OpentenbaseConfig *configInfo, const NodeInfo& node, std::str
                                 psql_cmd,
                                 result);
         if (ret != 0) {
-            LOG_WARN_FMT("Failed to excute sql(%s) on %s", psql_cmd, node);
+            LOG_WARN_FMT("Failed to excute sql(%s) on %s", psql_cmd.c_str(), node.name.c_str());
             std::cout << node.name << " " << node.ip << ":" << std::to_string(node.port) << " Failed to excute sql in database " << configInfo->sql.database_name << " as user " << configInfo->sql.user_name << '\n';
         }
     }

--- a/contrib/opentenbase_ctl/src/ssh/remote_ssh.cpp
+++ b/contrib/opentenbase_ctl/src/ssh/remote_ssh.cpp
@@ -130,7 +130,7 @@ excute_cp_file(const std::string& ip, int port, const std::string& username,
         // Remote execution
         int ret = remote_scp_file(ip, port, username, password, local_path, remote_path);
         if (ret != 0) {
-            LOG_ERROR_FMT("Failed to transfer package %s to %s (%s)", local_path, ip, remote_path);
+            LOG_ERROR_FMT("Failed to transfer package %s to %s (%s)", local_path.c_str(), ip.c_str(), remote_path.c_str());
             return -1;
         }
     }

--- a/contrib/opentenbase_ctl/src/types/types.cpp
+++ b/contrib/opentenbase_ctl/src/types/types.cpp
@@ -866,7 +866,7 @@ bool parse_command_line(int argc, char** argv, CommandLineArgs& args, Opentenbas
             // 设置环境变量
             if (setEnvironmentVariableInBashrc(Constants::ENV_CLUSTER_CONFIG_FILE, abolute_path) == 0) {
                 // 成功写入环境变量
-                LOG_INFO_FMT("Environment variable %s successfully set, value:%s\n", Constants::ENV_CLUSTER_CONFIG_FILE, args.config_file);
+                LOG_INFO_FMT("Environment variable %s successfully set, value:%s\n", Constants::ENV_CLUSTER_CONFIG_FILE, args.config_file.c_str());
             }
         }
         
@@ -1100,7 +1100,7 @@ int set_config_file_for_args(CommandLineArgs& args) {
         // 设置环境变量
         if (setEnvironmentVariableInBashrc(Constants::ENV_CLUSTER_CONFIG_FILE, abolute_path) == 0) {
             // 成功写入环境变量
-            LOG_INFO_FMT("Environment variable %s successfully set, value:%s\n", Constants::ENV_CLUSTER_CONFIG_FILE, args.config_file);
+            LOG_INFO_FMT("Environment variable %s successfully set, value:%s\n", Constants::ENV_CLUSTER_CONFIG_FILE, args.config_file.c_str());
         }
 
     }


### PR DESCRIPTION
## Motivation

The `LOG_*_FMT` macros forward their arguments to the `vsnprintf`-based `log_*_fmt` helpers, so every argument is consumed by a printf-style format string. Passing `std::string` or `NodeInfo` objects directly through the varargs ellipsis is undefined behaviour ([expr.call]/12: passing a potentially-throwing non-trivially-copyable type through `...` is conditionally-supported at best). On the Itanium C++ ABI each such argument is passed as a **pointer to a copy of the object**, so `%s` ends up printing the raw bytes of the object — starting with the `std::string` internal data pointer — instead of its text.

This is observable today, not theoretical. On current master:

```
$ opentenbase_ctl shell -c demo.ini --cmd "echo hello-prh"
...
[INFO] [src/node/node.cpp:1297] Start to excute cmd(\x08\xea\xc9\xff\xff\xff) on (\xea\xc9\xff\xff\xff)

$ opentenbase_ctl guc -c demo.ini -k max_connections -v 2000 -o change
...
[INFO] [src/node/node.cpp:1601] Start to excute sql(\xc0\x89\xf9\xd3\xff\xff) on \xc0\x89\xf9\xd3\xff\xff
```

The bytes printed are the little-endian encoding of the `std::string` data pointer living inside the (copied) object; `%s` walks that memory until it happens to hit a NUL. The log line is unreadable garbage, and beyond the garbled output the callee may also read past the end of the copy — undefined behaviour with no guaranteed bound.

## Change

Mechanical fix: pass `.c_str()` at every call site that hands a `std::string` or `NodeInfo` to a `%s` conversion. `NodeInfo` arguments now print `node.name`, the node identifier that every sibling log call in the same functions already uses. 32 call sites in 4 files:

* `src/node/node.cpp` (15): `excute_cmd_concurrency`, `excute_sql_concurrency`, `excute_show/del/change_guc_concurrency`, `delete_guc`, `add_guc`, `show_guc`
* `src/cluster/cluster.cpp` (14): `init_node`, `guc_command`, `get_instance_status`, `get_node_status`
* `src/ssh/remote_ssh.cpp` (1): `excute_cp_file` transfer-failure log (all 3 arguments)
* `src/types/types.cpp` (2): `parse_command_line` / `set_config_file_for_args` environment-variable logs

The full list was produced by the compiler rather than by eye: annotating the four `log_*_fmt` declarations with `__attribute__((format(printf, 1, 4)))` and compiling with `-Wformat` reports every mismatched argument. The remaining `int`-vs-`%zu` mismatches the same annotation reports are deliberately left out of this PR — they do not pass objects through the ellipsis and do not corrupt the output.

## Verification

* **Compiler**: with the `format(printf)` annotation, before the fix GCC reports 49 argument mismatches where `std::string`/`NodeInfo`/`size_type` values are passed to `%s`/`%d`; after this PR, zero non-trivial-type mismatches remain (only the out-of-scope `int`/`%zu` class).
* **Fail-before / pass-after** (demo config with 3 dn + cn + gtm nodes, default INFO level):
  * `shell --cmd "echo hello-prh"` — master: `Start to excute cmd(\x08\xea\xc9\xff\xff\xff) on (\xea\xc9\xff\xff\xff)`; patched: `Start to excute cmd(echo hello-prh) on 127.0.0.3`
  * `guc -k max_connections -v 2000 -o change` — master: `Start to excute sql(\xc0\x89\xf9\xd3\xff\xff) on \xc0\x89\xf9\xd3\xff\xff`; patched: `Start to excute sql() on gtm0001` / `cn0001` / `dn0001`–`dn0003`
* **No regression**: `shell`, `sql`, `guc show`, `status` all run against the same demo cluster on both master and patched builds with identical results (exit 0, same node output; line order varies between runs on master already because the concurrent executors print from worker threads). Builds cleanly with g++ (C++17) on aarch64.

Note: the guc-executor hunks in `src/node/node.cpp` may show a small textual conflict with #292/#293 (same functions, different lines); resolution is mechanical — keep their restructuring and the `.c_str()` additions. Merges cleanly with #294.