### PR TITLE
opentenbase_ctl: make start/stop commands fail when any node fails

### DIFF
--- a/contrib/opentenbase_ctl/src/cluster/cluster.cpp
+++ b/contrib/opentenbase_ctl/src/cluster/cluster.cpp
@@ -1281,9 +1281,9 @@ int start_command(OpentenbaseConfig *config) {
             << ", Failed: " << failedCount << "\n" << std::endl;
 
 
-    LOG_INFO_FMT("[Result] Total: %zu, Success: %zu, Failed: %zu", 
+    LOG_INFO_FMT("[Result] Total: %zu, Success: %zu, Failed: %zu",
              op_node_count, successCount, failedCount);
-    return 0;
+    return failedCount > 0 ? -1 : 0;
 }
 
 // Stop single node
@@ -1348,9 +1348,9 @@ int stop_command(OpentenbaseConfig *config) {
             << ", Failed: " << failedCount << "\n" << std::endl;
 
 
-    LOG_INFO_FMT("[Result] Total: %zu, Success: %zu, Failed: %zu", 
+    LOG_INFO_FMT("[Result] Total: %zu, Success: %zu, Failed: %zu",
              op_nodes.size(), successCount, failedCount);
-    return 0;
+    return failedCount > 0 ? -1 : 0;
 }
 
 // status command


### PR DESCRIPTION
## Motivation

`start_command` and `stop_command` already detect per-node failures: after joining the worker threads they iterate `results`, log `Start/Stop failed for one or more nodes`, count them in `failedCount`, and print `[Result] Total: N, Success: X, Failed: Y`. But both functions then `return 0;` unconditionally, and `main()` forwards that value as the process exit code — so a cluster where **every** node failed to start or stop still exits 0 and looks successful to scripts and automation.

The sibling commands already propagate: `delete_command` returns -1 on failure (#286), and the shell/sql/guc executors return -1 (with #290 making the exec layer report real exit codes). `start`/`stop` are the odd ones out.

## Change

Return `failedCount > 0 ? -1 : 0` at the end of `start_command` and `stop_command` (2 functional lines in `src/cluster/cluster.cpp`).

## Verification

Fail-before/pass-after against a demo cluster. Since current master's exec layer reports success for every command (the bug fixed by #290), the verification builds pair #290's `remote_ssh.cpp` with master's `cluster.cpp` (before) and with this patch (after), so node failures are actually visible to the command layer.

| scenario | before | after |
|---|---|---|
| `start`, SSH unreachable — all nodes fail (`Total: 2, Success: 0, Failed: 2`) | **exit 0** | exit 255 |
| `stop`, nodes running, `pg_ctl` missing — all 5 fail (`Total: 5, Success: 0, Failed: 5`) | **exit 0** | exit 255 |
| `stop`, partial failure 1 of 5 (`Total: 5, Success: 4, Failed: 1`) | **exit 0** | exit 255 |
| `start`/`stop`, all nodes succeed (`Total: 5, Success: 5, Failed: 0`) | exit 0 | exit 0 |
| `status` (untouched command) | exit 0 | exit 0 |

The all-success and status rows confirm the fix only changes the failure path; per-node output lines are identical before/after. Builds cleanly with g++ -std=c++17; merges cleanly with #294 and #297 (same file, disjoint functions).