### PR TITLE
docs: add libpqxx manual build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ or
 apt install -y git sudo gcc make libreadline-dev zlib1g-dev libssl-dev libossp-uuid-dev bison flex cmake libssh2-1-dev sshpass libxml2-dev language-pack-zh-hans
 ```
 
+### Building libpqxx manually (C++ client library)
+
+C++ client programs that connect to OpenTenBase are usually built against [libpqxx](https://github.com/jtv/libpqxx), the official C++ API of libpq. If the system does not provide a suitable libpqxx package, the compilation fails with errors such as `libpqxx/pqxx: No such file or directory`. In that case, build and install libpqxx manually (version 6.4.8 is verified to work):
+
+```bash
+wget https://github.com/jtv/libpqxx/archive/refs/tags/6.4.8.zip
+unzip libpqxx-6.4.8.zip && cd libpqxx-6.4.8
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+If linking fails with `cannot find -lpqxx`, or the program cannot load `libpqxx-6.4.so` at runtime, make sure `/usr/local/lib` is in the library search path:
+
+```bash
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+```
+
 
 ### Create User 'opentenbase'
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -41,6 +41,26 @@ yum -y install git sudo gcc make readline-devel zlib-devel openssl-devel uuid-de
 apt install -y git sudo gcc make libreadline-dev zlib1g-dev libssl-dev libossp-uuid-dev bison flex cmake libssh2-1-dev sshpass libxml2-dev language-pack-zh-hans
 ```
 
+### 手动编译 libpqxx（C++ 客户端库）
+
+连接 OpenTenBase 的 C++ 客户端程序通常基于 [libpqxx](https://github.com/jtv/libpqxx)（libpq 的官方 C++ 接口）编译。若系统未提供合适的 libpqxx 包，编译时会报 `libpqxx/pqxx: No such file or directory` 等错误，此时可手动编译安装（已验证 6.4.8 版本可用）：
+
+```bash
+wget https://github.com/jtv/libpqxx/archive/refs/tags/6.4.8.zip
+unzip libpqxx-6.4.8.zip && cd libpqxx-6.4.8
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local
+make -j$(nproc)
+sudo make install
+sudo ldconfig
+```
+
+若链接时报 `cannot find -lpqxx`，或运行时找不到 `libpqxx-6.4.so`，请确保 `/usr/local/lib` 在库搜索路径中：
+
+```bash
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+```
+
 ### 创建用户 'opentenbase'
 
 ```bash


### PR DESCRIPTION
## 问题背景

连接 OpenTenBase 的 C++ 客户端程序通常基于 [libpqxx](https://github.com/jtv/libpqxx)（libpq 的官方 C++ 接口）编译。当系统未提供合适的 libpqxx 包时，编译会报 `libpqxx/pqxx: No such file or directory` 等错误；手动安装后还可能遇到 `cannot find -lpqxx` 链接失败，或运行时找不到 `libpqxx-6.4.so` 的问题。

## 修改内容

在 `README.md` 与 `README_ZH.md` 中各新增 20 行，补充「手动编译 libpqxx（C++ 客户端库）」小节：

- 手动编译安装 libpqxx 6.4.8（issue #183 报告人验证可用的版本）的完整步骤：下载、解压、cmake、make、`sudo make install`、`sudo ldconfig`
- 链接失败（`cannot find -lpqxx`）或运行时无法加载 `libpqxx-6.4.so` 时，将 `/usr/local/lib` 加入库搜索路径的处理方法（`LD_LIBRARY_PATH`）

纯文档改动，不涉及任何代码变更。

Fixes #183